### PR TITLE
Add password strength indicator and fix reset encoding

### DIFF
--- a/src/composables/usePasswordStrength.ts
+++ b/src/composables/usePasswordStrength.ts
@@ -1,0 +1,95 @@
+import { computed, type Ref } from 'vue'
+
+export type PasswordStrengthLevel = 'weak' | 'fair' | 'strong'
+
+export interface PasswordStrength {
+  level: PasswordStrengthLevel
+  label: string
+  feedback: string
+}
+
+/**
+ * Common passwords + Filipino-specific patterns.
+ * This list is advisory/UX-only — it drives the strength indicator.
+ * The backend is the authoritative gate; a password can pass this list
+ * and still be rejected server-side.
+ */
+const BLOCKLIST = new Set([
+  // Universal commons
+  'password', 'password1', 'password123', '123456789', '1234567890',
+  'qwerty123', 'qwertyuiop', 'iloveyou', 'sunshine', 'princess',
+  'welcome1', 'monkey123', 'dragon123', 'master123', 'superman',
+  'batman123', 'letmein1', 'passw0rd', 'p@ssword', 'p@ssw0rd',
+  'admin1234', 'admin123!', 'trustno1', 'abc123456', 'football',
+  'baseball', 'soccer123', 'hockey123', 'shadow123', 'michael1',
+  'jessica1', 'charlie1', 'donald123', 'andrew123', 'thomas12',
+  'ranger123', 'daniel12', 'harley123', 'hunter123', 'joshua12',
+  'robert123', 'george123', 'jordan123', 'jennifer1', 'buster123',
+  'pepper123', 'cookie123', 'butter123', 'cheese123', 'banana12',
+  // Filipino first names
+  'mariajose', 'juandelacruz', 'josemaria', 'mariaclara',
+  'babaybading', 'pinoyako', 'pilipino1', 'pilipinas',
+  // Filipino surnames
+  'delacruz1', 'delos reyes', 'delossantos', 'reyes1234',
+  'santos123', 'garcia123', 'cruz12345', 'ramos1234', 'flores123',
+  'gomez1234', 'mendoza12', 'castro123', 'torres123', 'ramirez12',
+  'aquino123', 'marcos123', 'duterte12', 'arroyo123', 'estrada12',
+  // App-specific patterns
+  'mediflow1', 'mediflow!', 'clinic123', 'clinic1234', 'doctor123',
+  'nurse1234', 'patient12', 'hospital1', 'health123', 'medical12',
+  'filipinodoc', 'doctorph1', 'nurseph12',
+])
+
+function isBlocklisted(password: string): boolean {
+  return BLOCKLIST.has(password.toLowerCase())
+}
+
+function scorePassword(password: string): number {
+  if (password.length < 10) return 0
+
+  let score = 0
+
+  // Length scoring
+  if (password.length >= 14) score += 2
+  else if (password.length >= 12) score += 1
+
+  // Character variety
+  if (/[a-z]/.test(password)) score += 1
+  if (/[A-Z]/.test(password)) score += 1
+  if (/[0-9]/.test(password)) score += 1
+  if (/[^a-zA-Z0-9]/.test(password)) score += 2
+
+  return score
+}
+
+export function usePasswordStrength(password: Ref<string>) {
+  const strength = computed((): PasswordStrength => {
+    const val = password.value ?? ''
+
+    if (!val) {
+      return { level: 'weak', label: 'Weak', feedback: '' }
+    }
+
+    if (val.length < 10) {
+      return { level: 'weak', label: 'Weak', feedback: 'Too short — use at least 10 characters' }
+    }
+
+    if (isBlocklisted(val)) {
+      return { level: 'weak', label: 'Weak', feedback: 'Too common — choose a less predictable password' }
+    }
+
+    const score = scorePassword(val)
+
+    if (score >= 5) {
+      return { level: 'strong', label: 'Strong', feedback: '' }
+    }
+
+    if (score >= 2) {
+      return { level: 'fair', label: 'Fair', feedback: 'Decent — mix in symbols or uppercase to strengthen' }
+    }
+
+    return { level: 'weak', label: 'Weak', feedback: 'Weak — try adding variety (uppercase, numbers, symbols)' }
+  })
+
+  return { strength }
+}

--- a/src/domains/auth/api/authApi.ts
+++ b/src/domains/auth/api/authApi.ts
@@ -86,7 +86,11 @@ export const authApi = {
   },
 
   async resetPassword(data: { email: string; token: string; password: string; password_confirmation: string }): Promise<MessageResponse> {
-    return http.post<MessageResponse>('/auth/reset-password', data)
+    return http.post<MessageResponse>('/auth/reset-password', {
+      ...data,
+      password: btoa(data.password),
+      password_confirmation: btoa(data.password_confirmation),
+    })
   },
 
   async heartbeat(): Promise<void> {

--- a/src/domains/auth/components/PasswordForm.vue
+++ b/src/domains/auth/components/PasswordForm.vue
@@ -12,6 +12,7 @@ import { Lock, KeyRound, LoaderCircle } from 'lucide-vue-next'
 import { authApi } from '../api/authApi'
 import { changePasswordSchema } from '@/lib/validationRules'
 import type { ValidationError } from '../types/auth.types'
+import PasswordStrengthBar from './PasswordStrengthBar.vue'
 
 const { handleSubmit, setFieldError, resetForm } = useForm({
   validationSchema: changePasswordSchema,
@@ -88,8 +89,9 @@ const onSubmit = handleSubmit(async (values) => {
               <KeyRound class="size-3.5 text-muted-foreground" />
               New password
             </Label>
-            <PasswordInput id="new-password" v-model="newPassword" placeholder="Minimum 8 characters" autocomplete="new-password" :disabled="isLoading" :aria-invalid="!!newPasswordError" />
+            <PasswordInput id="new-password" v-model="newPassword" placeholder="Minimum 10 characters" autocomplete="new-password" :disabled="isLoading" :aria-invalid="!!newPasswordError" />
             <p v-if="newPasswordError" class="text-xs text-destructive">{{ newPasswordError }}</p>
+            <PasswordStrengthBar :password="newPassword ?? ''" />
           </div>
 
           <div class="flex flex-col gap-2">

--- a/src/domains/auth/components/PasswordStrengthBar.vue
+++ b/src/domains/auth/components/PasswordStrengthBar.vue
@@ -1,0 +1,52 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { usePasswordStrength } from '@/composables/usePasswordStrength'
+
+const props = defineProps<{
+  password: string
+}>()
+
+const passwordRef = computed(() => props.password)
+const { strength } = usePasswordStrength(passwordRef)
+
+const barClass = computed(() => {
+  switch (strength.value.level) {
+    case 'strong': return 'bg-green-500'
+    case 'fair':   return 'bg-amber-500'
+    default:       return 'bg-destructive'
+  }
+})
+
+const labelClass = computed(() => {
+  switch (strength.value.level) {
+    case 'strong': return 'text-green-600 dark:text-green-400'
+    case 'fair':   return 'text-amber-600 dark:text-amber-400'
+    default:       return 'text-destructive'
+  }
+})
+
+const barWidth = computed(() => {
+  switch (strength.value.level) {
+    case 'strong': return 'w-full'
+    case 'fair':   return 'w-2/3'
+    default:       return 'w-1/3'
+  }
+})
+</script>
+
+<template>
+  <div v-if="password" class="flex flex-col gap-1.5">
+    <div class="h-1.5 w-full overflow-hidden rounded-full bg-muted">
+      <div
+        class="h-full rounded-full transition-all duration-300 ease-out"
+        :class="[barClass, barWidth]"
+      />
+    </div>
+    <div class="flex items-center justify-between gap-2">
+      <p class="text-xs" :class="labelClass">{{ strength.label }}</p>
+      <p v-if="strength.feedback" class="text-xs text-muted-foreground">
+        {{ strength.feedback }}
+      </p>
+    </div>
+  </div>
+</template>

--- a/src/domains/auth/views/ResetPasswordView.vue
+++ b/src/domains/auth/views/ResetPasswordView.vue
@@ -20,6 +20,7 @@ import { RouteNames } from '@/router/routeNames'
 import { useNeuralNetwork } from '@/composables/useNeuralNetwork'
 import { authApi } from '../api/authApi'
 import type { ValidationError } from '../types/auth.types'
+import PasswordStrengthBar from '../components/PasswordStrengthBar.vue'
 
 const route = useRoute()
 const { canvasRef } = useNeuralNetwork()
@@ -187,6 +188,7 @@ const onSubmit = handleSubmit(async (values) => {
                 <p v-if="passwordError" class="text-xs text-destructive">
                   {{ passwordError }}
                 </p>
+                <PasswordStrengthBar :password="password ?? ''" />
               </div>
 
               <div

--- a/src/domains/auth/views/SignupView.vue
+++ b/src/domains/auth/views/SignupView.vue
@@ -21,6 +21,7 @@ import { RouteNames } from '@/router/routeNames'
 import { useRecaptcha } from '@/composables/useRecaptcha'
 import { useNeuralNetwork } from '@/composables/useNeuralNetwork'
 import type { ValidationError } from '../types/auth.types'
+import PasswordStrengthBar from '../components/PasswordStrengthBar.vue'
 
 const router = useRouter()
 const route = useRoute()
@@ -209,6 +210,7 @@ const onSubmit = handleSubmit(async (values) => {
                 <p v-if="passwordError" class="text-xs text-destructive">
                   {{ passwordError }}
                 </p>
+                <PasswordStrengthBar :password="password ?? ''" />
               </div>
 
               <div

--- a/src/lib/validationRules.ts
+++ b/src/lib/validationRules.ts
@@ -123,7 +123,7 @@ export const loginSchema = {
  */
 export const signupSchema = {
   email: [required('Email'), email('Email')],
-  password: [required('Password'), minLength('Password', 8)],
+  password: [required('Password'), minLength('Password', 10)],
   first_name: [maxLength('First name', 255)],
   last_name: [maxLength('Last name', 255)],
 }
@@ -181,7 +181,7 @@ export const credentialsSchema = {
  */
 export const changePasswordSchema = {
   current_password: [required('Current password')],
-  new_password: [required('New password'), minLength('New password', 8)],
+  new_password: [required('New password'), minLength('New password', 10)],
   new_password_confirmation: [required('Password confirmation')],
 }
 
@@ -198,6 +198,6 @@ export const forgotPasswordSchema = {
  * Pass directly to `useForm({ validationSchema: resetPasswordSchema })`.
  */
 export const resetPasswordSchema = {
-  password: [required('New password'), minLength('New password', 8)],
+  password: [required('New password'), minLength('New password', 10)],
   password_confirmation: [required('Confirm password')],
 }


### PR DESCRIPTION
## What Changed
- New `usePasswordStrength` composable — real-time strength scoring (weak/fair/strong) with client-side blocklist
- New `PasswordStrengthBar` component — visual 3-segment bar with plain-language feedback
- Wired into all 3 auth views: signup, reset password, change password
- Fixed `resetPassword` API call missing `btoa()` encoding (would corrupt stored passwords)
- Minimum password length increased from 8 to 10 across all validation schemas

## Why We Change
- No visual feedback on password quality — users had zero guidance during signup
- Reset password was silently sending plaintext while backend expected base64, corrupting passwords
- RA 10173 compliance requires reasonable security measures for medical data

## Business Impact
- Better signup UX — doctors/secretaries get real-time feedback without confusing complexity rules
- Prevents account lockout bug on password reset (base64 fix)
- Strength bar is informational, not a gate — reduces signup abandonment while encouraging stronger passwords