### PR TITLE
Auto-save custom lab tests to clinic lab services

### DIFF
--- a/src/domains/consultation/components/LabOrderSection.vue
+++ b/src/domains/consultation/components/LabOrderSection.vue
@@ -262,6 +262,13 @@ async function handleCreate() {
     showCreateForm.value = false
     createFormItems.value = [{ description: '', instruction: '' }]
     emit('lab-updated')
+
+    // Auto-save lab tests to clinic lab services (fire-and-forget, idempotent)
+    for (const item of validItems) {
+      labServiceApi.findOrCreate({ name: item.description }).catch(() => {
+        // silent — clinic lab service creation is best-effort
+      })
+    }
   } finally {
     isCreating.value = false
   }
@@ -317,6 +324,11 @@ async function handleAddItem() {
     await cacheCurrentLabOrder()
     cancelAddForm()
     emit('lab-updated')
+
+    // Auto-save lab test to clinic lab services (fire-and-forget, idempotent)
+    labServiceApi.findOrCreate({ name: desc }).catch(() => {
+      // silent — clinic lab service creation is best-effort
+    })
   } finally {
     isAddingItem.value = false
   }


### PR DESCRIPTION
## What Changed
- `LabOrderSection.vue`: calls `labServiceApi.findOrCreate()` for all lab test items when creating a lab order or adding an item
- Matches existing pattern used for system item selections (line 186)
- Fire-and-forget, best-effort — doesn't block lab order creation

## Why We Change
- Custom lab tests typed during consultation were not saved to the clinic's lab services list
- Doctors had to manually add them separately in clinic settings
- Now the clinic's lab catalog builds organically from usage

## Business Impact
- Less admin work for doctors and secretaries
- Clinic lab service list becomes more comprehensive over time
- Better autocomplete suggestions in future consultations

Relates to jomaf1010/clinic-fe#2