### PR TITLE
Auto-save custom lab tests and fix Enter key submission

### DIFF
--- a/src/domains/consultation/components/LabOrderSection.vue
+++ b/src/domains/consultation/components/LabOrderSection.vue
@@ -262,6 +262,13 @@ async function handleCreate() {
     showCreateForm.value = false
     createFormItems.value = [{ description: '', instruction: '' }]
     emit('lab-updated')
+
+    // Auto-save lab tests to clinic lab services (fire-and-forget, idempotent)
+    for (const item of validItems) {
+      labServiceApi.findOrCreate({ name: item.description }).catch(() => {
+        // silent — clinic lab service creation is best-effort
+      })
+    }
   } finally {
     isCreating.value = false
   }
@@ -317,6 +324,11 @@ async function handleAddItem() {
     await cacheCurrentLabOrder()
     cancelAddForm()
     emit('lab-updated')
+
+    // Auto-save lab test to clinic lab services (fire-and-forget, idempotent)
+    labServiceApi.findOrCreate({ name: desc }).catch(() => {
+      // silent — clinic lab service creation is best-effort
+    })
   } finally {
     isAddingItem.value = false
   }

--- a/src/domains/consultation/components/LabOrderSection.vue
+++ b/src/domains/consultation/components/LabOrderSection.vue
@@ -303,10 +303,12 @@ function onCreateRowKeydown(e: KeyboardEvent) {
       return
     }
   }
-  // Otherwise Enter adds a new row
+  // Enter submits the form if any row has content
   if (e.key === 'Enter') {
     e.preventDefault()
-    addCreateFormRow()
+    if (createFormItems.value.some((r) => r.description.trim())) {
+      handleCreate()
+    }
   }
 }
 


### PR DESCRIPTION
## What Changed
- Auto-save custom lab tests to clinic lab services via `findOrCreate` on lab order create and add item
- Enter key now submits the lab order form instead of adding an empty row

## Why We Change
- Custom lab tests typed during consultation were not saved to clinic's lab service list
- Enter key was adding empty rows instead of submitting — broke expected flow

## Business Impact
- Clinic lab catalog builds organically from usage — less admin work
- Faster lab order creation — type and Enter, done

Relates to jomaf1010/clinic-fe#2