### PR TITLE
Update template defaults and gate watermark for Free accounts

### DIFF
--- a/src/domains/template/types/template.types.ts
+++ b/src/domains/template/types/template.types.ts
@@ -39,7 +39,7 @@ const defaultPageSetup: PageSetup = {
 
 const defaultHeader: TemplateHeader = {
   showLogo: true,
-  logoSize: 40,
+  logoSize: 70,
   logoUrl: null,
   showClinicName: true,
   showClinicAddress: true,

--- a/src/domains/template/views/ConsultationSummaryTemplateEditor.vue
+++ b/src/domains/template/views/ConsultationSummaryTemplateEditor.vue
@@ -25,6 +25,7 @@ import { templateApi } from '@/domains/template/api/templateApi'
 const route = useRoute()
 const router = useRouter()
 const authStore = useAuthStore()
+const canHideWatermark = computed(() => authStore.hasFeature('remove_watermark'))
 
 const category = computed(() => route.params.category as string)
 const variation = computed(() => route.params.variation as string)
@@ -151,7 +152,7 @@ async function save() {
                 <Label>Font Size (px)</Label>
                 <span class="text-xs tabular-nums text-muted-foreground">{{ template.fontSize }}</span>
               </div>
-              <Slider :model-value="[template.fontSize]" :min="8" :max="24" :step="1" @update:model-value="template.fontSize = $event[0]" />
+              <Slider :model-value="[template.fontSize]" :min="8" :max="16" :step="1" @update:model-value="template.fontSize = $event[0]" />
             </div>
             <div class="col-span-full flex flex-col gap-3">
               <Label>Margins (mm)</Label>
@@ -316,8 +317,8 @@ async function save() {
                 <Label for="cs-page" class="font-normal">Show page number</Label>
               </div>
               <div class="flex items-center gap-2">
-                <Checkbox id="cs-watermark" :model-value="template.footer.showWatermark" @update:model-value="template.footer.showWatermark = !!$event" />
-                <Label for="cs-watermark" class="font-normal text-muted-foreground">Show watermark <span class="text-xs">(Pro accounts can hide this)</span></Label>
+                <Checkbox id="cs-watermark" :model-value="canHideWatermark ? template.footer.showWatermark : true" :disabled="!canHideWatermark" @update:model-value="template.footer.showWatermark = canHideWatermark ? !!$event : true" />
+                <Label for="cs-watermark" class="font-normal text-muted-foreground">Show watermark <span class="text-xs">({{ canHideWatermark ? 'Pro feature' : 'Upgrade to Pro to hide' }})</span></Label>
               </div>
             </div>
             <div class="flex flex-col gap-2">

--- a/src/domains/template/views/InvoiceTemplateEditor.vue
+++ b/src/domains/template/views/InvoiceTemplateEditor.vue
@@ -25,6 +25,7 @@ import { templateApi } from '@/domains/template/api/templateApi'
 const route = useRoute()
 const router = useRouter()
 const authStore = useAuthStore()
+const canHideWatermark = computed(() => authStore.hasFeature('remove_watermark'))
 
 const category = computed(() => route.params.category as string)
 const variation = computed(() => route.params.variation as string)
@@ -145,7 +146,7 @@ async function save() {
                 <Label>Font Size (px)</Label>
                 <span class="text-xs tabular-nums text-muted-foreground">{{ template.fontSize }}</span>
               </div>
-              <Slider :model-value="[template.fontSize]" :min="8" :max="24" :step="1" @update:model-value="template.fontSize = $event[0]" />
+              <Slider :model-value="[template.fontSize]" :min="8" :max="16" :step="1" @update:model-value="template.fontSize = $event[0]" />
             </div>
 
             <div class="col-span-full flex flex-col gap-3">
@@ -298,8 +299,8 @@ async function save() {
                 <Label for="inv-show-page-number" class="font-normal">Show page number</Label>
               </div>
               <div class="flex items-center gap-2">
-                <Checkbox id="inv-show-watermark" :model-value="template.footer.showWatermark" @update:model-value="template.footer.showWatermark = !!$event" />
-                <Label for="inv-show-watermark" class="font-normal text-muted-foreground">Show watermark <span class="text-xs">(Pro accounts can hide this)</span></Label>
+                <Checkbox id="inv-show-watermark" :model-value="canHideWatermark ? template.footer.showWatermark : true" :disabled="!canHideWatermark" @update:model-value="template.footer.showWatermark = canHideWatermark ? !!$event : true" />
+                <Label for="inv-show-watermark" class="font-normal text-muted-foreground">Show watermark <span class="text-xs">({{ canHideWatermark ? 'Pro feature' : 'Upgrade to Pro to hide' }})</span></Label>
               </div>
             </div>
             <div class="flex flex-col gap-2">

--- a/src/domains/template/views/LabRequestTemplateEditor.vue
+++ b/src/domains/template/views/LabRequestTemplateEditor.vue
@@ -25,6 +25,7 @@ import { templateApi } from '@/domains/template/api/templateApi'
 const route = useRoute()
 const router = useRouter()
 const authStore = useAuthStore()
+const canHideWatermark = computed(() => authStore.hasFeature('remove_watermark'))
 
 const category = computed(() => route.params.category as string)
 const variation = computed(() => route.params.variation as string)
@@ -151,7 +152,7 @@ async function save() {
                 <Label>Font Size (px)</Label>
                 <span class="text-xs tabular-nums text-muted-foreground">{{ template.fontSize }}</span>
               </div>
-              <Slider :model-value="[template.fontSize]" :min="8" :max="24" :step="1" @update:model-value="template.fontSize = $event[0]" />
+              <Slider :model-value="[template.fontSize]" :min="8" :max="16" :step="1" @update:model-value="template.fontSize = $event[0]" />
             </div>
 
             <div class="col-span-full flex flex-col gap-3">
@@ -306,8 +307,8 @@ async function save() {
                 <Label for="lr-show-page-number" class="font-normal">Show page number</Label>
               </div>
               <div class="flex items-center gap-2">
-                <Checkbox id="lr-show-watermark" :model-value="template.footer.showWatermark" @update:model-value="template.footer.showWatermark = !!$event" />
-                <Label for="lr-show-watermark" class="font-normal text-muted-foreground">Show watermark <span class="text-xs">(Pro accounts can hide this)</span></Label>
+                <Checkbox id="lr-show-watermark" :model-value="canHideWatermark ? template.footer.showWatermark : true" :disabled="!canHideWatermark" @update:model-value="template.footer.showWatermark = canHideWatermark ? !!$event : true" />
+                <Label for="lr-show-watermark" class="font-normal text-muted-foreground">Show watermark <span class="text-xs">({{ canHideWatermark ? 'Pro feature' : 'Upgrade to Pro to hide' }})</span></Label>
               </div>
             </div>
             <div class="flex flex-col gap-2">

--- a/src/domains/template/views/MedCertTemplateEditor.vue
+++ b/src/domains/template/views/MedCertTemplateEditor.vue
@@ -26,6 +26,7 @@ import { templateApi } from '@/domains/template/api/templateApi'
 const route = useRoute()
 const router = useRouter()
 const authStore = useAuthStore()
+const canHideWatermark = computed(() => authStore.hasFeature('remove_watermark'))
 
 const category = computed(() => route.params.category as string)
 const variation = computed(() => route.params.variation as string)
@@ -152,7 +153,7 @@ async function save() {
                 <Label>Font Size (px)</Label>
                 <span class="text-xs tabular-nums text-muted-foreground">{{ template.fontSize }}</span>
               </div>
-              <Slider :model-value="[template.fontSize]" :min="8" :max="24" :step="1" @update:model-value="template.fontSize = $event[0]" />
+              <Slider :model-value="[template.fontSize]" :min="8" :max="16" :step="1" @update:model-value="template.fontSize = $event[0]" />
             </div>
 
             <div class="col-span-full flex flex-col gap-3">
@@ -319,8 +320,8 @@ async function save() {
                 <Label for="mc-show-page-number" class="font-normal">Show page number</Label>
               </div>
               <div class="flex items-center gap-2">
-                <Checkbox id="mc-show-watermark" :model-value="template.footer.showWatermark" @update:model-value="template.footer.showWatermark = !!$event" />
-                <Label for="mc-show-watermark" class="font-normal text-muted-foreground">Show watermark <span class="text-xs">(Pro accounts can hide this)</span></Label>
+                <Checkbox id="mc-show-watermark" :model-value="canHideWatermark ? template.footer.showWatermark : true" :disabled="!canHideWatermark" @update:model-value="template.footer.showWatermark = canHideWatermark ? !!$event : true" />
+                <Label for="mc-show-watermark" class="font-normal text-muted-foreground">Show watermark <span class="text-xs">({{ canHideWatermark ? 'Pro feature' : 'Upgrade to Pro to hide' }})</span></Label>
               </div>
             </div>
             <div class="flex flex-col gap-2">

--- a/src/domains/template/views/PrescriptionTemplateEditor.vue
+++ b/src/domains/template/views/PrescriptionTemplateEditor.vue
@@ -26,6 +26,7 @@ import { templateApi } from '@/domains/template/api/templateApi'
 const route = useRoute()
 const router = useRouter()
 const authStore = useAuthStore()
+const canHideWatermark = computed(() => authStore.hasFeature('remove_watermark'))
 
 const category = computed(() => route.params.category as string)
 const variation = computed(() => route.params.variation as string)
@@ -161,7 +162,7 @@ async function save() {
                 <Label>Font Size (px)</Label>
                 <span class="text-xs tabular-nums text-muted-foreground">{{ template.fontSize }}</span>
               </div>
-              <Slider :model-value="[template.fontSize]" :min="8" :max="24" :step="1" @update:model-value="template.fontSize = $event[0]" />
+              <Slider :model-value="[template.fontSize]" :min="8" :max="16" :step="1" @update:model-value="template.fontSize = $event[0]" />
             </div>
 
             <div class="col-span-full flex flex-col gap-3">
@@ -309,8 +310,8 @@ async function save() {
                 <Label for="show-page-number" class="font-normal">Show page number</Label>
               </div>
               <div class="flex items-center gap-2">
-                <Checkbox id="show-watermark" :model-value="template.footer.showWatermark" @update:model-value="template.footer.showWatermark = !!$event" />
-                <Label for="show-watermark" class="font-normal text-muted-foreground">Show watermark <span class="text-xs">(Pro accounts can hide this)</span></Label>
+                <Checkbox id="show-watermark" :model-value="canHideWatermark ? template.footer.showWatermark : true" :disabled="!canHideWatermark" @update:model-value="template.footer.showWatermark = canHideWatermark ? !!$event : true" />
+                <Label for="show-watermark" class="font-normal text-muted-foreground">Show watermark <span class="text-xs">({{ canHideWatermark ? 'Pro feature' : 'Upgrade to Pro to hide' }})</span></Label>
               </div>
             </div>
 


### PR DESCRIPTION
## What Changed
- Default logo size 40 → 70
- Font size slider max 24 → 16 in all 5 editors
- Watermark toggle disabled for Free accounts with upgrade hint
- Pro accounts can toggle watermark freely

## Why We Change
- Font size max was too large, causing layout issues
- Logo default was too small for most clinic logos
- Watermark removal needs Pro-only gating

## Business Impact
- Better template defaults out of the box
- Pro feature differentiation drives subscription conversion

Fixes jomaf1010/clinic-fe#6