### PR TITLE
Fix dead-end signup verification flow

### DIFF
--- a/src/domains/auth/views/LoginView.vue
+++ b/src/domains/auth/views/LoginView.vue
@@ -36,6 +36,7 @@ const { value: password, errorMessage: passwordError } = useField<string>('passw
 
 const isLoading = ref(false)
 const generalError = ref<string | null>(null)
+const showResendLink = ref(false)
 const rememberMe = ref(true)
 
 const ready = ref(false)
@@ -47,6 +48,7 @@ onMounted(() => {
 
 const onSubmit = handleSubmit(async (values) => {
   generalError.value = null
+  showResendLink.value = false
   isLoading.value = true
 
   try {
@@ -66,7 +68,13 @@ const onSubmit = handleSubmit(async (values) => {
       } else if (err.status === 401) {
         generalError.value = 'Invalid email or password.'
       } else if (err.status === 403) {
-        generalError.value = 'Please verify your email address before signing in.'
+        const body = err.data as { message?: string; error_code?: string }
+        if (body.error_code === 'email_not_verified') {
+          generalError.value = 'Please verify your email address before signing in.'
+          showResendLink.value = true
+        } else {
+          generalError.value = body.message || 'Access denied.'
+        }
       } else {
         generalError.value = 'An unexpected error occurred. Please try again.'
       }
@@ -112,6 +120,13 @@ const onSubmit = handleSubmit(async (values) => {
                 class="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2.5 text-sm text-destructive"
               >
                 {{ generalError }}
+                <RouterLink
+                  v-if="showResendLink"
+                  :to="{ name: RouteNames.VERIFY_EMAIL_NOTICE, query: { email: email } }"
+                  class="mt-1 block font-medium underline underline-offset-4 hover:text-destructive/80"
+                >
+                  Resend verification email
+                </RouterLink>
               </div>
 
               <div

--- a/src/domains/auth/views/VerifyEmailView.vue
+++ b/src/domains/auth/views/VerifyEmailView.vue
@@ -11,7 +11,7 @@ import {
 } from '@/components/ui/card'
 import { authApi } from '../api/authApi'
 import { RouteNames } from '@/router/routeNames'
-import { CircleCheck, CircleX, LoaderCircle, ArrowRight, UserPlus, ArrowLeft } from 'lucide-vue-next'
+import { CircleCheck, CircleX, LoaderCircle, ArrowRight, ArrowLeft, RefreshCw } from 'lucide-vue-next'
 import AppLogo from '@/components/AppLogo.vue'
 import { useNeuralNetwork } from '@/composables/useNeuralNetwork'
 
@@ -20,6 +20,7 @@ const { canvasRef } = useNeuralNetwork()
 
 const status = ref<'verifying' | 'success' | 'error'>('verifying')
 const errorMessage = ref<string | null>(null)
+const userEmail = ref<string | null>(null)
 
 const ready = ref(false)
 onMounted(() => {
@@ -31,7 +32,16 @@ onMounted(() => {
 onMounted(async () => {
   const token = typeof route.query.token === 'string' ? route.query.token : null
   const encodedEmail = typeof route.query.email === 'string' ? route.query.email : null
-  const email = encodedEmail ? atob(encodedEmail) : null
+
+  let email: string | null = null
+  try {
+    email = encodedEmail ? atob(encodedEmail) : null
+  } catch {
+    status.value = 'error'
+    errorMessage.value = 'Invalid verification link. Please check your email and try again.'
+    return
+  }
+  userEmail.value = email
 
   if (!token || !email) {
     status.value = 'error'
@@ -109,10 +119,10 @@ onMounted(async () => {
               <CardDescription>{{ errorMessage }}</CardDescription>
             </CardHeader>
             <CardContent class="flex flex-col gap-3">
-              <RouterLink :to="{ name: RouteNames.SIGNUP }">
-                <Button variant="outline" class="w-full">
-                  <UserPlus class="size-4" />
-                  Sign up again
+              <RouterLink v-if="userEmail" :to="{ name: RouteNames.VERIFY_EMAIL_NOTICE, query: { email: userEmail } }">
+                <Button class="w-full">
+                  <RefreshCw class="size-4" />
+                  Resend verification email
                 </Button>
               </RouterLink>
               <RouterLink :to="{ name: RouteNames.LOGIN }">


### PR DESCRIPTION
## Summary
- Fix the dead-end when a verification link expires — users can now resend from the error page
- Fix login 403 for unverified users — shows a "Resend verification email" link
- Frontend now checks `error_code` field instead of message strings (pairs with backend error codes PR)

## What was broken
| Entry point | Before | After |
|---|---|---|
| Expired link click | "Sign up again" (422 email taken) or "Back to sign in" (403 dead end) | "Resend verification email" → new email sent |
| Login with unverified email | "Please verify your email" with no action | Same message + "Resend verification email" link |

## Files changed
- `VerifyEmailView.vue` — replaced "Sign up again" with "Resend verification email", added atob() error handling
- `LoginView.vue` — show resend link only when `error_code === 'email_not_verified'` (not on other 403s)

## Test plan
- [ ] Sign up → don't verify → click expired link → "Resend verification email" button appears and works
- [ ] Sign up → don't verify → try to login → error banner shows resend link
- [ ] Resend link pre-fills email on the verification notice page
- [ ] Malformed verification URL shows error state gracefully (no crash)
- [ ] Other 403 errors (permission denied, etc.) do NOT show resend link

🤖 Generated with [Claude Code](https://claude.com/claude-code)