### PR TITLE
Handle stale chunk loading errors after deployments

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -217,6 +217,16 @@ const router = createRouter({
   ],
 })
 
+router.onError((error) => {
+  if (
+    error instanceof Error &&
+    (error.message.includes('Failed to fetch dynamically imported module') ||
+      error.message.includes('Importing a module script failed'))
+  ) {
+    window.location.assign(window.location.href)
+  }
+})
+
 router.beforeEach(async (to) => {
   const authStore = useAuthStore()
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,12 @@ import tailwindcss from '@tailwindcss/vite'
 import vue from '@vitejs/plugin-vue'
 import { defineConfig } from 'vite'
 
-const commitHash = execSync('git rev-parse --short HEAD').toString().trim()
+let commitHash = 'dev'
+try {
+  commitHash = execSync('git rev-parse --short HEAD').toString().trim()
+} catch {
+  // git not available in container
+}
 
 export default defineConfig({
   plugins: [


### PR DESCRIPTION
## Summary
- Add `router.onError` handler that catches chunk import failures and force-reloads the page
- Fix `vite.config.ts` crash when `git` is not available in the Docker container

## Problem
After a deployment, the browser may have a cached `index.html` referencing old JS chunk filenames that no longer exist on the CDN. When navigating to a lazy-loaded route (e.g. after signup → verify email notice), the chunk import silently fails and the page appears stuck.

## Fix
`router.onError` detects dynamic import failures and calls `window.location.assign()` to force a fresh page load with the latest assets.

## Test plan
- [ ] Deploy to staging, then navigate without hard-refreshing — lazy routes should load
- [ ] Vite dev server starts in Docker container without git installed