### PR TITLE
fix: frontend security hardening from white-box penetration test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2722,9 +2722,9 @@
       }
     },
     "node_modules/cosmiconfig/node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
       "license": "ISC",
       "engines": {
         "node": ">= 6"
@@ -3234,9 +3234,9 @@
       }
     },
     "node_modules/defu": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
-      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
       "license": "MIT"
     },
     "node_modules/delaunator": {
@@ -3960,9 +3960,9 @@
       }
     },
     "node_modules/lodash-es": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "license": "MIT"
     },
     "node_modules/long": {
@@ -4207,9 +4207,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -4751,9 +4751,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.27.0",
@@ -5015,9 +5015,9 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/src/composables/useCentrifugo.ts
+++ b/src/composables/useCentrifugo.ts
@@ -29,12 +29,12 @@ export function useCentrifugo() {
     })
 
     client.on('disconnected', (ctx) => {
-      console.warn('[Centrifugo] disconnected:', ctx)
+      if (import.meta.env.DEV) console.warn('[Centrifugo] disconnected:', ctx)
       isConnected.value = false
     })
 
     client.on('error', (ctx) => {
-      console.error('[Centrifugo] client error:', ctx)
+      if (import.meta.env.DEV) console.error('[Centrifugo] client error:', ctx)
     })
 
     client.connect()
@@ -63,7 +63,7 @@ export function useCentrifugo() {
 
     sub.on('publication', onPublication)
     sub.on('error', (ctx) => {
-      console.warn(`[Centrifugo] subscription error on ${channel}:`, ctx)
+      if (import.meta.env.DEV) console.warn(`[Centrifugo] subscription error on ${channel}:`, ctx)
     })
     sub.subscribe()
     subscriptions.set(channel, sub)

--- a/src/domains/auth/api/authApi.ts
+++ b/src/domains/auth/api/authApi.ts
@@ -1,4 +1,4 @@
-import { http } from '@/lib/http'
+import { http, getAuthToken } from '@/lib/http'
 import type { LoginCredentials, LoginResponse, MeResponse, MessageResponse, RefreshResponse, SelectClinicResponse, SignupCredentials, SignupResponse, VerifyEmailPayload } from '../types/auth.types'
 
 export const authApi = {
@@ -65,7 +65,7 @@ export const authApi = {
 
   async logout(): Promise<void> {
     const BASE_URL = import.meta.env.VITE_API_URL as string
-    const token = localStorage.getItem('auth_token')
+    const token = getAuthToken()
     const headers: Record<string, string> = { Accept: 'application/json' }
     if (token) {
       headers['Authorization'] = `Bearer ${token}`

--- a/src/domains/auth/stores/authStore.ts
+++ b/src/domains/auth/stores/authStore.ts
@@ -113,6 +113,14 @@ export const useAuthStore = defineStore('auth', () => {
     } catch {
       // BroadcastChannel not supported — fine
     }
+    // Clear PHI draft keys from localStorage
+    localStorage.removeItem('create-patient')
+    // Wipe offline IndexedDB to prevent PHI leaking between sessions
+    try {
+      indexedDB.deleteDatabase('clinicapp-offline')
+    } catch {
+      // Not supported or already absent — fine
+    }
     token.value = null
     user.value = null
     memberships.value = []

--- a/src/domains/message/components/MessageInput.vue
+++ b/src/domains/message/components/MessageInput.vue
@@ -218,7 +218,7 @@ function handleSend() {
   emit('send', text)
 
   if (editorRef.value) {
-    editorRef.value.innerHTML = ''
+    editorRef.value.textContent = ''
   }
   isEditorEmpty.value = true
 }

--- a/src/domains/queue/views/QueueDisplayView.vue
+++ b/src/domains/queue/views/QueueDisplayView.vue
@@ -215,7 +215,7 @@ function initCentrifuge(
   })
 
   sub.on('error', (ctx) => {
-    console.warn('[QueueDisplay] subscription error:', ctx)
+    if (import.meta.env.DEV) console.warn('[QueueDisplay] subscription error:', ctx)
   })
 
   sub.subscribe()
@@ -255,7 +255,7 @@ async function bootstrap(): Promise<void> {
     )
   } catch (err) {
     isLoading.value = false
-    console.error('[QueueDisplay] bootstrap error:', err)
+    if (import.meta.env.DEV) console.error('[QueueDisplay] bootstrap error:', err)
     const message = err instanceof Error ? err.message : ''
     displayError.value = message === 'INVALID_TOKEN' ? 'INVALID_TOKEN' : 'NETWORK_ERROR'
   }

--- a/src/domains/subscription/stores/subscriptionStore.ts
+++ b/src/domains/subscription/stores/subscriptionStore.ts
@@ -39,7 +39,11 @@ export const useSubscriptionStore = defineStore('subscription', () => {
     checkoutLoading.value = true
     try {
       const response = await subscriptionApi.createCheckout()
-      window.location.href = response.data.checkout_url
+      const checkoutUrl = response.data.checkout_url
+      if (!checkoutUrl.startsWith('https://')) {
+        throw new Error('Invalid checkout URL returned from server')
+      }
+      window.location.href = checkoutUrl
     } finally {
       checkoutLoading.value = false
     }


### PR DESCRIPTION
## Summary
Fixes 4 frontend security vulnerabilities discovered during white-box penetration test.

### Fixed
- **Logout token (#23)**: Replace `localStorage.getItem('auth_token')` with `getAuthToken()` — JWT lives in memory, old call always returned null
- **PHI persistence (#22)**: Clear `localStorage['create-patient']` and delete IndexedDB `clinicapp-offline` on logout
- **Checkout redirect (#25)**: Validate `checkout_url` starts with `https://` before navigation
- **Console logs (#25)**: Gate Centrifugo/QueueDisplay console output behind `import.meta.env.DEV`
- **MessageInput (#25)**: Use `textContent` instead of `innerHTML` to clear editor
- **NPM deps (#24)**: `npm audit fix` — 0 vulnerabilities remaining

### Not fixed (separate PR)
- **v-html XSS (#21)**: Needs architectural change to replace `v-html` with structured rendering

## Test plan
- [ ] Logout properly clears all client state
- [ ] No console output in production build
- [ ] Subscription checkout flow still works