### PR TITLE
Agent harness UI, Appointment Board, Schedule Studio, Patient rebuild

### DIFF
--- a/e2e/appointments-board.spec.ts
+++ b/e2e/appointments-board.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from './fixtures'
+import { waitForDataLoad } from './helpers'
+
+test.describe('Appointments board', () => {
+  test('renders board controls and quick book on desktop', async ({ page }) => {
+    await page.goto('/appointments?page=1')
+    await waitForDataLoad(page)
+
+    await expect(page.getByRole('heading', { name: 'Appointments' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Today Board' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Calendar' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'List' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'All doctors' })).toBeVisible()
+    await expect(page.getByRole('combobox')).toHaveCount(2)
+    await expect(page.getByRole('heading', { name: "Today's flow" })).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'Week at a glance' })).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'Doctor lanes' })).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'Quick book' })).toBeVisible()
+    await expect(page.getByText('Today', { exact: true }).first()).toBeVisible()
+    await expect(page.getByLabel('Reason')).toBeVisible()
+    await expect(page.getByPlaceholder('Reason for visit...')).toBeVisible()
+  })
+
+  test('keeps board usable on a narrow viewport', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 })
+    await page.goto('/appointments?page=1')
+    await waitForDataLoad(page)
+
+    await expect(page.getByRole('heading', { name: 'Appointments' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Today Board' })).toBeVisible()
+    await expect(page.getByRole('heading', { name: "Today's flow" })).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'Quick book' })).toBeVisible()
+    await expect(page.getByLabel('Patient')).toBeVisible()
+    await expect(page.getByLabel('Doctor')).toBeVisible()
+    await expect(page.getByLabel('Reason')).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Book appointment' }).last()).toBeVisible()
+  })
+})

--- a/src/domains/appointment/components/AppointmentBoard.vue
+++ b/src/domains/appointment/components/AppointmentBoard.vue
@@ -1,0 +1,891 @@
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
+import {
+  Ban,
+  CalendarDays,
+  CalendarPlus,
+  ChevronRight,
+  CheckCircle2,
+  Clock,
+  Coffee,
+  LoaderCircle,
+  LogIn,
+  MoreVertical,
+  UserRound,
+  UserX,
+  X,
+} from 'lucide-vue-next'
+import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { appointmentApi } from '../api/appointmentApi'
+import { scheduleApi } from '@/domains/schedule/api/scheduleApi'
+import type { AppointmentResponse, AppointmentStatus, ClinicDoctor } from '../types/appointment.types'
+import type { BlockType, CalendarBlock, Slot } from '@/domains/schedule/types/schedule.types'
+
+const props = defineProps<{
+  doctorFilter: string
+  statusFilter: string
+  canManage: boolean
+}>()
+
+const emit = defineEmits<{
+  'appointment-click': [id: string]
+  'slot-select': [dateTime: string | null, options?: { doctorId?: string | null, doctorName?: string | null, patientId?: string | null, patientName?: string | null }]
+  reschedule: [appointment: AppointmentResponse]
+  'check-in': [id: string]
+  cancel: [id: string]
+  'no-show': [id: string]
+  'summary-change': [total: number]
+}>()
+
+interface DoctorLane {
+  doctor: ClinicDoctor
+  appointments: AppointmentResponse[]
+  openSlots: number
+  nextAvailableAt: string | null
+  utilization: number
+}
+
+type TimelineItem =
+  | {
+    type: 'section'
+    key: string
+    label: 'Morning' | 'Afternoon' | 'Evening'
+  }
+  | {
+    type: 'now'
+    key: 'current-time'
+    sortMinutes: number
+  }
+  | {
+    type: 'appointment'
+    key: string
+    sortMinutes: number
+    appointment: AppointmentResponse
+  }
+  | {
+    type: 'block'
+    key: string
+    sortMinutes: number
+    block: CalendarBlock
+  }
+
+type TimelineMarker = Exclude<TimelineItem, { type: 'section' }>
+
+const selectedDate = ref(toLocalDate(new Date()))
+const appointments = ref<AppointmentResponse[]>([])
+const weekAppointments = ref<AppointmentResponse[]>([])
+const doctors = ref<ClinicDoctor[]>([])
+const availabilityByDoctor = ref<Record<string, Slot[]>>({})
+const calendarBlocks = ref<CalendarBlock[]>([])
+const isLoading = ref(false)
+const error = ref<string | null>(null)
+const hasAutoSelectedNextAppointmentDate = ref(false)
+const currentTime = ref(new Date())
+let currentTimeTimer: ReturnType<typeof setInterval> | null = null
+let latestFetchKey = ''
+let inFlightFetchKey = ''
+
+function toLocalDate(date: Date): string {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+function parseLocalDate(value: string): Date {
+  return new Date(`${value}T00:00:00`)
+}
+
+function addDays(value: string, amount: number): string {
+  const date = parseLocalDate(value)
+  date.setDate(date.getDate() + amount)
+  return toLocalDate(date)
+}
+
+function startOfWeek(value: string): string {
+  const date = parseLocalDate(value)
+  date.setDate(date.getDate() - date.getDay())
+  return toLocalDate(date)
+}
+
+function endOfWeek(value: string): string {
+  return addDays(startOfWeek(value), 6)
+}
+
+function formatDay(value: string): string {
+  return parseLocalDate(value).toLocaleDateString('en-US', { weekday: 'short' })
+}
+
+function formatTime(value: string): string {
+  return new Date(value).toLocaleTimeString('en-US', {
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+  })
+}
+
+function formatShortDate(value: string): string {
+  return parseLocalDate(value).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+}
+
+function formatNumericDate(value: string): string {
+  return parseLocalDate(value).toLocaleDateString('en-US', { month: 'numeric', day: 'numeric' })
+}
+
+function isTerminal(status: AppointmentStatus): boolean {
+  return ['completed', 'cancelled', 'no_show'].includes(status)
+}
+
+function doctorInitials(name: string): string {
+  return name.split(' ').map((part) => part[0]?.toUpperCase()).filter(Boolean).slice(0, 2).join('')
+}
+
+function patientInitials(name: string | null): string {
+  if (!name) return 'PT'
+  const parts = name.split(' ').filter(Boolean)
+  const first = parts[0]?.[0]
+  const last = parts[parts.length - 1]?.[0]
+  return [first, last].filter(Boolean).join('').toUpperCase()
+}
+
+function patientAvatar(appointment: AppointmentResponse): string | null {
+  return appointment.patient_avatar_url ?? null
+}
+
+function periodForTime(value: string): 'Morning' | 'Afternoon' | 'Evening' {
+  const hour = new Date(value).getHours()
+  if (hour < 12) return 'Morning'
+  if (hour < 17) return 'Afternoon'
+  return 'Evening'
+}
+
+function isSameDay(iso: string, date: string): boolean {
+  return toLocalDate(new Date(iso)) === date
+}
+
+function minutesForIso(value: string): number {
+  const date = new Date(value)
+  return date.getHours() * 60 + date.getMinutes()
+}
+
+const weekDays = computed(() => Array.from({ length: 7 }, (_, index) => addDays(startOfWeek(selectedDate.value), index)))
+const todayDate = computed(() => toLocalDate(currentTime.value))
+
+const weekCounts = computed(() => {
+  const counts: Record<string, number> = {}
+  for (const day of weekDays.value) counts[day] = 0
+  for (const appointment of weekAppointments.value) {
+    const key = toLocalDate(new Date(appointment.scheduled_at))
+    if (key in counts) counts[key] = (counts[key] ?? 0) + 1
+  }
+  return counts
+})
+
+const weekStartLabel = computed(() => {
+  const firstDay = weekDays.value[0]
+  return firstDay ? formatShortDate(firstDay) : ''
+})
+
+const weekEndLabel = computed(() => {
+  const lastDay = weekDays.value[6]
+  return lastDay ? formatShortDate(lastDay) : ''
+})
+
+function getWeekCount(day: string): number {
+  return weekCounts.value[day] ?? 0
+}
+
+function weekHeatBars(day: string): number[] {
+  const count = getWeekCount(day)
+  const intensity = count > 0 ? Math.min(0.95, 0.42 + count * 0.12) : 0.18
+  return Array.from({ length: 4 }, (_, index) => Math.max(0.18, intensity - (3 - index) * 0.08))
+}
+
+const totalOpenSlots = computed(() => Object.values(availabilityByDoctor.value)
+  .flat()
+  .filter((slot) => slot.available).length)
+
+const nextAppointment = computed(() => {
+  const now = Date.now()
+  return appointments.value
+    .filter((appointment) => !isTerminal(appointment.status) && new Date(appointment.scheduled_at).getTime() >= now)
+    .sort((a, b) => new Date(a.scheduled_at).getTime() - new Date(b.scheduled_at).getTime())[0] ?? null
+})
+
+function getNextVisibleAppointment(items: AppointmentResponse[]): AppointmentResponse | null {
+  const now = Date.now()
+
+  return items
+    .filter((appointment) => !isTerminal(appointment.status) && new Date(appointment.scheduled_at).getTime() >= now)
+    .sort((a, b) => new Date(a.scheduled_at).getTime() - new Date(b.scheduled_at).getTime())[0] ?? null
+}
+
+const stats = computed(() => ({
+  total: appointments.value.length,
+  checkedIn: appointments.value.filter((appointment) => appointment.status === 'checked_in').length,
+  scheduled: appointments.value.filter((appointment) => appointment.status === 'scheduled').length,
+  openSlots: totalOpenSlots.value,
+}))
+
+watch(stats, (value) => {
+  emit('summary-change', value.total)
+}, { immediate: true })
+
+const currentTimeLabel = computed(() => formatTime(currentTime.value.toISOString()))
+
+const selectedDayBlocks = computed(() => calendarBlocks.value
+  .filter((block) => isSameDay(block.start, selectedDate.value) || isSameDay(block.end, selectedDate.value))
+  .slice()
+  .sort((a, b) => new Date(a.start).getTime() - new Date(b.start).getTime()))
+
+const timelineAppointments = computed(() => appointments.value
+  .slice()
+  .sort((a, b) => new Date(a.scheduled_at).getTime() - new Date(b.scheduled_at).getTime()))
+
+const timelineItems = computed<TimelineItem[]>(() => {
+  const now = currentTime.value
+  const markers: TimelineMarker[] = [{
+    type: 'now',
+    key: 'current-time',
+    sortMinutes: now.getHours() * 60 + now.getMinutes(),
+  }]
+
+  for (const appointment of timelineAppointments.value) {
+    const scheduledAt = new Date(appointment.scheduled_at)
+    markers.push({
+      type: 'appointment',
+      key: appointment.id,
+      sortMinutes: scheduledAt.getHours() * 60 + scheduledAt.getMinutes(),
+      appointment,
+    })
+  }
+
+  for (const block of selectedDayBlocks.value) {
+    markers.push({
+      type: 'block',
+      key: `block-${block.id}`,
+      sortMinutes: block.all_day ? 0 : minutesForIso(block.start),
+      block,
+    })
+  }
+
+  const sortedMarkers = markers.sort((a, b) => a.sortMinutes - b.sortMinutes)
+  const items: TimelineItem[] = []
+  const renderedPeriods = new Set<string>()
+
+  for (const marker of sortedMarkers) {
+    if (marker.type === 'appointment') {
+      const period = periodForTime(marker.appointment.scheduled_at)
+      if (!renderedPeriods.has(period)) {
+        renderedPeriods.add(period)
+        items.push({
+          type: 'section',
+          key: `section-${period}`,
+          label: period,
+        })
+      }
+    }
+
+    if (marker.type === 'block') {
+      const period = marker.block.all_day ? 'Morning' : periodForTime(marker.block.start)
+      if (!renderedPeriods.has(period)) {
+        renderedPeriods.add(period)
+        items.push({
+          type: 'section',
+          key: `section-${period}`,
+          label: period,
+        })
+      }
+    }
+
+    items.push(marker)
+  }
+
+  return items
+})
+
+const visibleDoctors = computed(() => {
+  if (props.doctorFilter === 'all') return doctors.value
+  return doctors.value.filter((doctor) => doctor.id === props.doctorFilter)
+})
+
+const doctorLanes = computed<DoctorLane[]>(() => visibleDoctors.value.map((doctor) => {
+  const doctorAppointments = appointments.value.filter((appointment) => appointment.doctor_id === doctor.id)
+  const availableSlots = availabilityByDoctor.value[doctor.id]?.filter((slot) => slot.available) ?? []
+  const utilization = Math.min(100, Math.round((doctorAppointments.length / Math.max(1, doctorAppointments.length + availableSlots.length)) * 100))
+
+  return {
+    doctor,
+    appointments: doctorAppointments,
+    openSlots: availableSlots.length,
+    nextAvailableAt: availableSlots[0]?.start ?? null,
+    utilization,
+  }
+}))
+
+function appointmentCardClasses(status: AppointmentStatus): string {
+  if (status === 'checked_in') return 'border-emerald-200 bg-white shadow-sm shadow-emerald-950/5 dark:border-emerald-900 dark:bg-background'
+  if (status === 'cancelled' || status === 'no_show') return 'border-muted bg-muted/40 text-muted-foreground opacity-75'
+  return 'border-border bg-white shadow-sm dark:bg-background'
+}
+
+function formatStatus(status: AppointmentStatus): string {
+  if (status === 'no_show') return 'No show'
+  return status.replace('_', ' ').replace(/\b\w/g, (letter) => letter.toUpperCase())
+}
+
+function doctorAvatar(lane: DoctorLane): string | null {
+  return lane.doctor.avatar_url ?? lane.appointments.find((appointment) => appointment.doctor_avatar_url)?.doctor_avatar_url ?? null
+}
+
+function blockTypeLabel(type: BlockType): string {
+  if (type === 'leave') return 'Leave'
+  if (type === 'meeting') return 'Meeting'
+  if (type === 'holiday') return 'Holiday'
+  if (type === 'personal') return 'Personal'
+  return 'Unavailable'
+}
+
+function blockTypeClass(type: BlockType): string {
+  if (type === 'leave') return 'border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-900 dark:bg-amber-950/30 dark:text-amber-200'
+  if (type === 'meeting') return 'border-blue-200 bg-blue-50 text-blue-700 dark:border-blue-900 dark:bg-blue-950/30 dark:text-blue-200'
+  if (type === 'holiday') return 'border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-900 dark:bg-emerald-950/30 dark:text-emerald-200'
+  if (type === 'personal') return 'border-violet-200 bg-violet-50 text-violet-700 dark:border-violet-900 dark:bg-violet-950/30 dark:text-violet-200'
+  return 'border-red-200 bg-red-50 text-red-700 dark:border-red-900 dark:bg-red-950/30 dark:text-red-200'
+}
+
+function blockDotClass(type: BlockType): string {
+  if (type === 'leave') return 'bg-amber-500 ring-amber-100'
+  if (type === 'meeting') return 'bg-blue-500 ring-blue-100'
+  if (type === 'holiday') return 'bg-emerald-500 ring-emerald-100'
+  if (type === 'personal') return 'bg-violet-500 ring-violet-100'
+  return 'bg-red-500 ring-red-100'
+}
+
+function blockIcon(type: BlockType) {
+  if (type === 'leave' || type === 'personal') return Coffee
+  if (type === 'meeting') return UserRound
+  if (type === 'holiday') return CalendarDays
+  return Ban
+}
+
+function blockDurationLabel(block: CalendarBlock): string {
+  if (block.all_day) return 'All day'
+  const minutes = Math.max(0, Math.round((new Date(block.end).getTime() - new Date(block.start).getTime()) / 60000))
+  if (minutes >= 60 && minutes % 60 === 0) return `${minutes / 60} hr`
+  if (minutes >= 60) return `${Math.floor(minutes / 60)}h ${minutes % 60}m`
+  return `${minutes} min`
+}
+
+function blockTimeRange(block: CalendarBlock): string {
+  if (block.all_day) return 'All day'
+  return `${formatTime(block.start)} - ${formatTime(block.end)}`
+}
+
+async function fetchBoard(): Promise<void> {
+  const doctorId = props.doctorFilter !== 'all' ? props.doctorFilter : undefined
+  const status = props.statusFilter !== 'all' ? props.statusFilter as AppointmentStatus : undefined
+  const start = startOfWeek(selectedDate.value)
+  const end = endOfWeek(selectedDate.value)
+  const fetchKey = `${selectedDate.value}:${start}:${end}:${doctorId ?? 'all'}:${status ?? 'all'}`
+  if (inFlightFetchKey === fetchKey) return
+  latestFetchKey = fetchKey
+  inFlightFetchKey = fetchKey
+  isLoading.value = true
+  error.value = null
+
+  try {
+    const [weekResult, doctorsResult] = await Promise.all([
+      appointmentApi.list(1, 500, { start_date: start, end_date: end, ...(doctorId ? { doctor_id: doctorId } : {}), ...(status ? { status } : {}) }),
+      doctors.value.length > 0 ? Promise.resolve(null) : appointmentApi.getDoctors(),
+    ])
+    if (latestFetchKey !== fetchKey) return
+
+    const dayAppointments = weekResult.data.filter((appointment) => isSameDay(appointment.scheduled_at, selectedDate.value))
+    appointments.value = dayAppointments
+    weekAppointments.value = weekResult.data
+    if (doctorsResult) {
+      doctors.value = doctorsResult.data
+    }
+
+    const nextVisibleAppointment = getNextVisibleAppointment(weekResult.data)
+    if (
+      !hasAutoSelectedNextAppointmentDate.value
+      && dayAppointments.length === 0
+      && selectedDate.value === toLocalDate(new Date())
+      && nextVisibleAppointment
+    ) {
+      hasAutoSelectedNextAppointmentDate.value = true
+      selectedDate.value = toLocalDate(new Date(nextVisibleAppointment.scheduled_at))
+      return
+    }
+
+    const availabilityEntries = await Promise.all(visibleDoctors.value.map(async (doctor) => {
+      try {
+        const response = await scheduleApi.getAvailability(doctor.id, selectedDate.value)
+        return [doctor.id, response.data.slots, response.data.blocks] as const
+      } catch {
+        return [doctor.id, [] as Slot[], [] as CalendarBlock[]] as const
+      }
+    }))
+
+    if (latestFetchKey !== fetchKey) return
+    availabilityByDoctor.value = Object.fromEntries(availabilityEntries.map(([doctorId, slots]) => [doctorId, slots]))
+    calendarBlocks.value = Array.from(new Map(availabilityEntries
+      .flatMap(([, , blocks]) => blocks)
+      .map((block) => [block.id, block])).values())
+  } catch {
+    if (latestFetchKey !== fetchKey) return
+    error.value = 'Failed to load appointment board.'
+  } finally {
+    if (inFlightFetchKey === fetchKey) {
+      inFlightFetchKey = ''
+    }
+    if (latestFetchKey === fetchKey) {
+      isLoading.value = false
+    }
+  }
+}
+
+function selectDate(date: string): void {
+  selectedDate.value = date
+}
+
+function bookAt(slotStart: string | null, doctorId: string | null = null, doctorName: string | null = null): void {
+  emit('slot-select', slotStart, {
+    doctorId,
+    doctorName,
+    patientId: null,
+    patientName: null,
+  })
+}
+
+watch(() => props.statusFilter, () => {
+  void fetchBoard()
+})
+
+watch(() => props.doctorFilter, () => {
+  void fetchBoard()
+})
+
+watch(selectedDate, () => {
+  void fetchBoard()
+})
+
+onMounted(() => {
+  currentTimeTimer = setInterval(() => {
+    currentTime.value = new Date()
+  }, 1000)
+  void fetchBoard()
+})
+
+onUnmounted(() => {
+  if (currentTimeTimer) clearInterval(currentTimeTimer)
+})
+
+defineExpose({ refetch: fetchBoard })
+</script>
+
+<template>
+  <div class="space-y-4">
+    <div class="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+      <div class="rounded-lg border bg-background p-4 shadow-sm">
+        <div class="grid grid-cols-[44px_minmax(0,1fr)_auto] items-center gap-3">
+          <span class="flex size-10 items-center justify-center rounded-xl bg-gradient-to-br from-blue-500 to-blue-600 text-white shadow-sm">
+            <CalendarDays class="size-6" />
+          </span>
+          <div>
+            <span class="text-sm text-muted-foreground">Today</span>
+            <p class="text-2xl font-semibold leading-tight">{{ stats.total }}</p>
+          </div>
+          <ChevronRight class="size-4 text-muted-foreground" />
+        </div>
+        <p class="mt-3 text-sm text-muted-foreground">{{ stats.scheduled }} appointments</p>
+      </div>
+      <div class="rounded-lg border bg-background p-4 shadow-sm">
+        <div class="grid grid-cols-[44px_minmax(0,1fr)_auto] items-center gap-3">
+          <span class="flex size-10 items-center justify-center rounded-xl bg-gradient-to-br from-emerald-500 to-emerald-600 text-white shadow-sm">
+            <CheckCircle2 class="size-6" />
+          </span>
+          <div>
+            <span class="text-sm text-muted-foreground">Checked in</span>
+            <p class="text-2xl font-semibold leading-tight">{{ stats.checkedIn }}</p>
+          </div>
+          <ChevronRight class="size-4 text-muted-foreground" />
+        </div>
+        <p class="mt-3 text-sm text-muted-foreground">0 waiting</p>
+      </div>
+      <div class="rounded-lg border bg-background p-4 shadow-sm">
+        <div class="grid grid-cols-[44px_minmax(0,1fr)_auto] items-center gap-3">
+          <span class="flex size-10 items-center justify-center rounded-xl bg-gradient-to-br from-amber-500 to-amber-600 text-white shadow-sm">
+            <Clock class="size-6" />
+          </span>
+          <div class="min-w-0">
+            <span class="text-sm text-muted-foreground">Next</span>
+            <p class="truncate text-2xl font-semibold leading-tight">
+              {{ nextAppointment ? formatTime(nextAppointment.scheduled_at) : 'None' }}
+            </p>
+          </div>
+          <ChevronRight class="size-4 text-muted-foreground" />
+        </div>
+        <p class="mt-3 truncate text-sm text-muted-foreground">
+          {{ nextAppointment?.patient_name ?? 'No more scheduled visits' }}
+        </p>
+      </div>
+      <div class="rounded-lg border bg-background p-4 shadow-sm">
+        <div class="grid grid-cols-[44px_minmax(0,1fr)_auto] items-center gap-3">
+          <span class="flex size-10 items-center justify-center rounded-xl bg-gradient-to-br from-violet-500 to-violet-600 text-white shadow-sm">
+            <CalendarPlus class="size-6" />
+          </span>
+          <div>
+            <span class="text-sm text-muted-foreground">Open slots</span>
+            <p class="text-2xl font-semibold leading-tight">{{ stats.openSlots }}</p>
+          </div>
+          <ChevronRight class="size-4 text-muted-foreground" />
+        </div>
+        <p class="mt-3 text-sm text-muted-foreground">View availability</p>
+      </div>
+    </div>
+
+    <div v-if="error" role="alert" class="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2.5 text-sm text-destructive">
+      {{ error }}
+      <Button variant="outline" size="sm" class="mt-2" @click="fetchBoard">Try again</Button>
+    </div>
+
+    <div class="grid gap-3 xl:grid-cols-[minmax(0,1fr)_minmax(430px,0.86fr)]">
+      <section class="overflow-hidden rounded-lg border bg-background shadow-sm">
+        <div class="flex items-center justify-between border-b px-4 py-3">
+          <h2 class="text-base font-semibold">Today's flow</h2>
+        </div>
+
+        <div v-if="isLoading" class="m-5 flex items-center justify-center rounded-lg border py-16">
+          <LoaderCircle class="size-6 animate-spin text-muted-foreground" />
+        </div>
+
+        <div v-else-if="appointments.length === 0 && selectedDayBlocks.length === 0" class="m-5 flex flex-col items-center justify-center rounded-lg border py-16 text-center">
+          <div class="mb-3 flex size-12 items-center justify-center rounded-full bg-primary/10">
+            <CalendarDays class="size-6 text-primary" />
+          </div>
+          <p class="text-sm font-medium">No appointments for this day</p>
+          <p class="mt-1 text-xs text-muted-foreground">Use an open slot or create a walk-in from the queue.</p>
+          <Button size="sm" class="mt-4" @click="bookAt(null)">
+            <CalendarPlus class="size-3.5" />
+            Book appointment
+          </Button>
+        </div>
+
+        <div v-else class="relative px-4 py-5">
+          <div class="absolute bottom-9 left-[102px] top-14 w-px bg-border" />
+
+          <div class="space-y-4">
+            <div
+              v-for="item in timelineItems"
+              :key="item.key"
+              :class="[
+                item.type === 'section'
+                  ? 'grid grid-cols-[64px_20px_minmax(0,1fr)] gap-3'
+                  : item.type === 'now'
+                    ? 'grid grid-cols-[64px_20px_minmax(0,1fr)] gap-3'
+                    : 'grid grid-cols-[64px_20px_minmax(0,1fr)] gap-3',
+              ]"
+            >
+              <template v-if="item.type === 'section'">
+                <div />
+                <div />
+                <div class="pb-0.5 pt-0.5 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                  {{ item.label }}
+                </div>
+              </template>
+
+              <template v-else-if="item.type === 'now'">
+                <div class="flex justify-end">
+                  <span class="whitespace-nowrap rounded-md border border-teal-300 bg-teal-50 px-2 py-0.5 text-xs font-semibold text-teal-700">
+                    {{ currentTimeLabel }}
+                  </span>
+                </div>
+
+                <div class="relative flex justify-center pt-2">
+                  <span class="relative z-10 size-3 rounded-full bg-teal-500" />
+                </div>
+
+                <div class="pt-3">
+                  <div class="border-t border-dashed border-teal-500" />
+                </div>
+              </template>
+
+              <template v-else-if="item.type === 'appointment'">
+                <div class="pt-8 text-right">
+                  <p class="text-sm font-semibold leading-tight text-foreground">{{ formatTime(item.appointment.scheduled_at) }}</p>
+                  <p class="mt-1 text-xs text-muted-foreground">{{ item.appointment.duration }} min</p>
+                </div>
+
+                <div class="relative flex justify-center pt-10">
+                  <span class="relative z-10 size-3.5 rounded-full border-2 border-background bg-teal-500 shadow-sm" />
+                </div>
+
+                <div
+                  role="button"
+                  tabindex="0"
+                  :class="['relative min-h-24 rounded-lg border p-3 text-left transition hover:-translate-y-0.5 hover:shadow-md', appointmentCardClasses(item.appointment.status)]"
+                  @click="emit('appointment-click', item.appointment.id)"
+                  @keydown.enter.space.prevent="emit('appointment-click', item.appointment.id)"
+                >
+                  <div class="grid gap-3 pr-24 sm:grid-cols-[52px_minmax(0,1fr)]">
+                    <img
+                      v-if="patientAvatar(item.appointment)"
+                      :src="patientAvatar(item.appointment) ?? undefined"
+                      alt=""
+                      class="size-12 rounded-full object-cover"
+                    >
+                    <div v-else class="flex size-12 items-center justify-center rounded-full bg-violet-100 text-sm font-semibold text-violet-700 dark:bg-violet-950/40 dark:text-violet-200">
+                      {{ patientInitials(item.appointment.patient_name) }}
+                    </div>
+
+                    <div class="min-w-0 pt-1">
+                      <p class="truncate text-sm font-semibold text-foreground">{{ item.appointment.patient_name ?? 'Unknown Patient' }}</p>
+                      <div class="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1.5 text-xs text-muted-foreground">
+                        <span v-if="item.appointment.doctor_name" class="flex items-center gap-1.5">
+                          <UserRound class="size-3.5" />
+                          Dr. {{ item.appointment.doctor_name }}
+                        </span>
+                        <span v-if="item.appointment.reason">{{ item.appointment.reason }}</span>
+                        <span v-if="item.appointment.notes" class="max-w-72 truncate">{{ item.appointment.notes }}</span>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div class="absolute right-3 top-3">
+                    <span
+                      :class="[
+                        'rounded-full px-2.5 py-0.5 text-[11px] font-semibold',
+                        item.appointment.status === 'scheduled'
+                          ? 'bg-blue-100 text-blue-700 dark:bg-blue-950/40 dark:text-blue-200'
+                          : 'bg-muted text-muted-foreground',
+                      ]"
+                    >
+                      {{ formatStatus(item.appointment.status) }}
+                    </span>
+                  </div>
+
+                  <div v-if="canManage && item.appointment.status === 'scheduled'" class="mt-3 flex flex-wrap items-center justify-end gap-1.5" @click.stop>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      class="h-8 gap-1.5 px-2.5 text-xs"
+                      @click="emit('check-in', item.appointment.id)"
+                    >
+                      <LogIn class="size-3.5" />
+                      Check In
+                    </Button>
+
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      class="h-8 gap-1.5 px-2.5 text-xs"
+                      @click="emit('reschedule', item.appointment)"
+                    >
+                      <CalendarDays class="size-3.5" />
+                      Reschedule
+                    </Button>
+
+                    <DropdownMenu>
+                      <DropdownMenuTrigger as-child>
+                        <Button variant="outline" size="icon" class="size-8">
+                          <MoreVertical class="size-3.5" />
+                          <span class="sr-only">Appointment actions</span>
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end">
+                        <DropdownMenuItem @click="emit('check-in', item.appointment.id)">
+                          <LogIn class="mr-2 size-4" />
+                          Check in
+                        </DropdownMenuItem>
+                        <DropdownMenuItem @click="emit('no-show', item.appointment.id)">
+                          <UserX class="mr-2 size-4" />
+                          Mark no-show
+                        </DropdownMenuItem>
+                        <DropdownMenuSeparator />
+                        <DropdownMenuItem
+                          class="text-destructive focus:text-destructive"
+                          @click="emit('cancel', item.appointment.id)"
+                        >
+                          <X class="mr-2 size-4" />
+                          Cancel
+                        </DropdownMenuItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </div>
+                </div>
+              </template>
+
+              <template v-else>
+                <div class="pt-5 text-right">
+                  <p class="text-sm font-semibold leading-tight text-foreground">
+                    {{ item.block.all_day ? 'All day' : formatTime(item.block.start) }}
+                  </p>
+                  <p class="mt-1 text-xs text-muted-foreground">{{ blockDurationLabel(item.block) }}</p>
+                </div>
+
+                <div class="relative flex justify-center pt-7">
+                  <span :class="['relative z-10 size-3.5 rounded-full border-2 border-background shadow-sm ring-4', blockDotClass(item.block.type)]" />
+                </div>
+
+                <div
+                  :class="[
+                    'relative rounded-lg border p-3 text-left',
+                    item.block.type === 'leave' || item.block.type === 'unavailable'
+                      ? 'border-dashed bg-muted/30'
+                      : 'bg-background',
+                  ]"
+                >
+                  <div class="grid gap-3 sm:grid-cols-[40px_minmax(0,1fr)_auto] sm:items-center">
+                    <div :class="['flex size-10 items-center justify-center rounded-xl border', blockTypeClass(item.block.type)]">
+                      <component :is="blockIcon(item.block.type)" class="size-5" />
+                    </div>
+
+                    <div class="min-w-0">
+                      <div class="flex flex-wrap items-center gap-2">
+                        <p class="truncate text-sm font-semibold text-foreground">{{ item.block.title }}</p>
+                        <span :class="['rounded-full border px-2 py-0.5 text-[11px] font-semibold', blockTypeClass(item.block.type)]">
+                          {{ blockTypeLabel(item.block.type) }}
+                        </span>
+                      </div>
+                      <div class="mt-1.5 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
+                        <span>{{ blockTimeRange(item.block) }}</span>
+                        <span v-if="item.block.user_name" class="flex items-center gap-1.5">
+                          <UserRound class="size-3.5" />
+                          Dr. {{ item.block.user_name }}
+                        </span>
+                        <span v-if="item.block.notes" class="max-w-72 truncate">{{ item.block.notes }}</span>
+                      </div>
+                    </div>
+
+                    <span class="hidden text-xs font-medium text-muted-foreground sm:block">
+                      Block
+                    </span>
+                  </div>
+                </div>
+              </template>
+            </div>
+
+            <div v-if="appointments.length > timelineAppointments.length" class="grid grid-cols-[64px_20px_minmax(0,1fr)] gap-3 pt-1">
+              <div />
+              <div />
+              <div class="flex justify-center">
+                <Button variant="outline" size="sm" class="h-9 min-w-32 text-xs">
+                  Load more
+                </Button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <aside class="space-y-3">
+        <section class="rounded-lg border bg-background p-4 shadow-sm">
+          <div class="mb-3 flex items-center justify-between">
+            <div>
+              <h2 class="text-base font-semibold">Week at a glance</h2>
+              <p class="text-xs text-muted-foreground">{{ weekStartLabel }} - {{ weekEndLabel }}</p>
+            </div>
+          </div>
+
+          <div class="grid grid-cols-7 gap-2">
+            <button
+              v-for="day in weekDays"
+              :key="day"
+              :class="[
+                'rounded-lg border p-2 text-center transition-colors',
+                day === todayDate
+                  ? 'border-teal-300 bg-teal-50 text-teal-950 shadow-sm shadow-teal-950/10 ring-1 ring-teal-300 dark:border-teal-700 dark:bg-teal-950/30 dark:text-teal-100'
+                  : day === selectedDate
+                    ? 'border-transparent bg-blue-50 text-foreground dark:bg-blue-950/30'
+                    : 'border-transparent hover:bg-muted/60',
+              ]"
+              @click="selectDate(day)"
+            >
+              <span class="block text-[10px] font-medium">{{ formatDay(day) }}</span>
+              <span class="mt-0.5 block text-xs">{{ formatNumericDate(day) }}</span>
+              <span
+                v-if="day === todayDate"
+                class="mt-1 inline-flex rounded-full bg-teal-500 px-1.5 py-0.5 text-[9px] font-semibold leading-none text-white"
+              >
+                Today
+              </span>
+              <span class="mt-3 block space-y-1">
+                <span
+                  v-for="(opacity, index) in weekHeatBars(day)"
+                  :key="index"
+                  class="mx-auto block h-1 w-8 rounded-full bg-teal-500"
+                  :style="{ opacity }"
+                />
+              </span>
+            </button>
+          </div>
+          <div class="mt-3 flex items-center justify-between text-[10px] text-muted-foreground">
+            <div class="flex items-center gap-1.5">
+              <span>Low</span>
+              <span class="size-2 rounded-sm bg-teal-100" />
+              <span class="size-2 rounded-sm bg-teal-200" />
+              <span class="size-2 rounded-sm bg-teal-400" />
+              <span class="size-2 rounded-sm bg-teal-600" />
+              <span class="size-2 rounded-sm bg-teal-800" />
+              <span>High</span>
+            </div>
+            <span>More appointments = darker</span>
+          </div>
+        </section>
+
+        <section class="rounded-lg border bg-background p-4 shadow-sm">
+          <div class="mb-3 flex items-center justify-between">
+            <h2 class="text-base font-semibold">Doctor lanes</h2>
+            <Button variant="link" size="sm" class="h-auto p-0 text-xs">View all</Button>
+          </div>
+          <div class="divide-y">
+            <div v-for="lane in doctorLanes.slice(0, 3)" :key="lane.doctor.id" class="py-3 first:pt-0 last:pb-0">
+              <div class="grid grid-cols-[44px_minmax(0,1fr)_92px_120px] items-center gap-3">
+                <img
+                  v-if="doctorAvatar(lane)"
+                  :src="doctorAvatar(lane) ?? undefined"
+                  alt=""
+                  class="size-10 rounded-full object-cover"
+                >
+                <div v-else class="flex size-10 items-center justify-center rounded-full bg-primary/10 text-sm font-semibold text-primary">
+                  {{ doctorInitials(lane.doctor.name) }}
+                </div>
+                <div class="min-w-0">
+                  <p class="truncate text-sm font-semibold">Dr. {{ lane.doctor.name }}</p>
+                  <p class="text-xs text-muted-foreground">{{ lane.appointments.length }} visits · {{ lane.openSlots }} open</p>
+                </div>
+                <div>
+                  <p class="text-[10px] text-muted-foreground">Next</p>
+                  <p class="text-sm font-semibold leading-tight">{{ lane.nextAvailableAt ? formatTime(lane.nextAvailableAt) : 'No slot' }}</p>
+                </div>
+                <div>
+                  <div class="mb-1 flex items-center justify-between text-[10px] text-muted-foreground">
+                    <span>Utilization</span>
+                    <span>{{ lane.utilization }}%</span>
+                  </div>
+                  <div class="h-1.5 overflow-hidden rounded-full bg-muted">
+                    <div
+                      class="h-full rounded-full bg-teal-500"
+                      :style="{ width: `${lane.utilization}%` }"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+      </aside>
+    </div>
+  </div>
+</template>

--- a/src/domains/appointment/components/AppointmentBookingWizard.vue
+++ b/src/domains/appointment/components/AppointmentBookingWizard.vue
@@ -30,9 +30,13 @@ import type { ClinicDoctor } from '../types/appointment.types'
 
 const props = defineProps<{
   open: boolean
+  mode?: 'create' | 'reschedule'
+  appointmentId?: string | null
   prefillDateTime?: string | null // ISO datetime from calendar click
   prefillDoctorId?: string | null // pre-select doctor (skip step 1)
   prefillDoctorName?: string | null
+  prefillPatientId?: string | null
+  prefillPatientName?: string | null
 }>()
 
 const emit = defineEmits<{
@@ -43,7 +47,11 @@ const emit = defineEmits<{
 const appointmentStore = useAppointmentStore()
 
 const step = ref(1)
-const totalSteps = computed(() => hasPrefillDoctor.value ? 3 : 4)
+const isReschedule = computed(() => props.mode === 'reschedule')
+const totalSteps = computed(() => {
+  if (isReschedule.value) return 1
+  return hasPrefillDoctor.value ? 3 : 4
+})
 
 // Step 1: Doctor
 const doctorId = ref<string | null>(null)
@@ -64,6 +72,7 @@ const reason = ref('')
 const notes = ref('')
 
 const generalError = ref<string | null>(null)
+const isRescheduling = ref(false)
 
 // Prefill helpers — extract date and ISO from prefillDateTime
 const prefillDate = computed(() => {
@@ -97,6 +106,8 @@ function handlePatientSelect(patient: PatientSearchResult) {
 }
 
 const canNext = computed(() => {
+  if (isReschedule.value) return !!selectedSlot.value
+
   switch (step.value) {
     case 1:
       return !!doctorId.value
@@ -121,6 +132,31 @@ function prev() {
 }
 
 async function submit() {
+  if (isReschedule.value) {
+    if (!props.appointmentId || !selectedSlot.value) return
+    generalError.value = null
+    isRescheduling.value = true
+
+    try {
+      await appointmentApi.reschedule(props.appointmentId, selectedSlot.value)
+      toast.success('Appointment rescheduled')
+      emit('created')
+      emit('update:open', false)
+      reset()
+    } catch (err) {
+      if (err instanceof HttpError && err.status === 422) {
+        const body = err.data as { message?: string; errors?: Record<string, string[]> }
+        generalError.value = body.message ?? 'Validation failed.'
+      } else {
+        generalError.value = 'Failed to reschedule appointment. Please try again.'
+      }
+    } finally {
+      isRescheduling.value = false
+    }
+
+    return
+  }
+
   if (!doctorId.value || !selectedSlot.value || !patientId.value) return
   generalError.value = null
 
@@ -148,10 +184,17 @@ async function submit() {
 }
 
 const hasPrefillDoctor = computed(() => !!props.prefillDoctorId)
-const displayStep = computed(() => hasPrefillDoctor.value ? step.value - 1 : step.value)
+const displayStep = computed(() => {
+  if (isReschedule.value) return 1
+  return hasPrefillDoctor.value ? step.value - 1 : step.value
+})
 
 function reset() {
-  if (props.prefillDoctorId) {
+  if (isReschedule.value) {
+    step.value = 2
+    doctorId.value = props.prefillDoctorId ?? null
+    doctorName.value = props.prefillDoctorName ?? ''
+  } else if (props.prefillDoctorId) {
     // Skip doctor step — start at date/slot
     step.value = 2
     doctorId.value = props.prefillDoctorId
@@ -163,8 +206,8 @@ function reset() {
   }
   selectedSlot.value = null
   selectedDuration.value = null
-  patientId.value = null
-  patientName.value = ''
+  patientId.value = props.prefillPatientId ?? null
+  patientName.value = props.prefillPatientName ?? ''
   reason.value = ''
   notes.value = ''
   generalError.value = null
@@ -181,6 +224,8 @@ watch(
 )
 
 const stepTitle = computed(() => {
+  if (isReschedule.value) return 'Choose New Date & Time'
+
   switch (step.value) {
     case 1:
       return 'Select Doctor'
@@ -215,7 +260,7 @@ function formatSlotTime(iso: string | null): string {
       <DialogHeader>
         <DialogTitle class="flex items-center gap-2">
           <CalendarCheck class="size-5 text-primary" />
-          Book Appointment
+          {{ isReschedule ? 'Reschedule Appointment' : 'Book Appointment' }}
         </DialogTitle>
         <div class="flex items-center gap-2 pt-2">
           <div
@@ -276,12 +321,13 @@ function formatSlotTime(iso: string | null): string {
           v-model:duration="selectedDuration"
           :doctor-id="doctorId"
           :initial-date="prefillDate"
-          :auto-select-time="prefillDateTime ?? undefined"
+          :auto-select-time="isReschedule ? undefined : prefillDateTime ?? undefined"
+          :allow-duration-selection="!isReschedule"
         />
       </div>
 
       <!-- Step 3: Patient -->
-      <div v-if="step === 3" class="flex flex-col gap-3">
+      <div v-if="!isReschedule && step === 3" class="flex flex-col gap-3">
         <Label class="flex items-center gap-1.5">
           <User class="size-3.5 text-muted-foreground" />
           Patient
@@ -290,7 +336,7 @@ function formatSlotTime(iso: string | null): string {
       </div>
 
       <!-- Step 4: Confirm -->
-      <div v-if="step === 4" class="flex flex-col gap-4">
+      <div v-if="!isReschedule && step === 4" class="flex flex-col gap-4">
         <div class="rounded-lg border p-4">
           <div class="grid gap-2 text-sm">
             <div class="flex justify-between">
@@ -324,18 +370,18 @@ function formatSlotTime(iso: string | null): string {
       </div>
 
       <DialogFooter class="flex-row gap-2">
-        <Button v-if="step > (hasPrefillDoctor ? 2 : 1)" variant="outline" @click="prev">
+        <Button v-if="!isReschedule && step > (hasPrefillDoctor ? 2 : 1)" variant="outline" @click="prev">
           <ChevronLeft class="size-4" />
           Back
         </Button>
         <div class="flex-1" />
-        <Button v-if="step < totalSteps" :disabled="!canNext" @click="next">
+        <Button v-if="!isReschedule && step < totalSteps" :disabled="!canNext" @click="next">
           Next
           <ChevronRight class="size-4" />
         </Button>
-        <Button v-if="step === totalSteps" :disabled="appointmentStore.isCreating" @click="submit">
-          <LoaderCircle v-if="appointmentStore.isCreating" class="size-3.5 animate-spin" />
-          Book Appointment
+        <Button v-if="isReschedule || step === totalSteps" :disabled="isReschedule ? isRescheduling || !canNext : appointmentStore.isCreating" @click="submit">
+          <LoaderCircle v-if="isReschedule ? isRescheduling : appointmentStore.isCreating" class="size-3.5 animate-spin" />
+          {{ isReschedule ? 'Reschedule' : 'Book Appointment' }}
         </Button>
       </DialogFooter>
     </DialogContent>

--- a/src/domains/appointment/components/AppointmentCalendar.vue
+++ b/src/domains/appointment/components/AppointmentCalendar.vue
@@ -42,6 +42,7 @@ const BLOCK_TYPE_LABELS: Record<string, string> = {
 }
 
 const props = defineProps<{
+  doctorFilter?: string
   statusFilter?: string
 }>()
 
@@ -119,6 +120,9 @@ async function eventSourceFn(
     const start = info.startStr.slice(0, 10)
     const end = info.endStr.slice(0, 10)
     const filters: AppointmentListFilters = { start_date: start, end_date: end }
+    if (props.doctorFilter && props.doctorFilter !== 'all') {
+      filters.doctor_id = props.doctorFilter
+    }
     if (props.statusFilter && props.statusFilter !== 'all') {
       filters.status = props.statusFilter as AppointmentListFilters['status']
     }
@@ -169,6 +173,10 @@ async function eventSourceFn(
 
     // Calendar block events
     for (const block of blocksRes.data) {
+      if (props.doctorFilter && props.doctorFilter !== 'all' && block.user_id !== props.doctorFilter) {
+        continue
+      }
+
       const colors = BLOCK_TYPE_COLORS[block.type] ?? BLOCK_TYPE_COLORS.unavailable
       const typeLabel = BLOCK_TYPE_LABELS[block.type] ?? block.type
       const doctorLabel = block.user_name ? `Dr. ${block.user_name}` : ''
@@ -199,8 +207,8 @@ async function eventSourceFn(
   }
 }
 
-// Refetch when status filter changes
-watch(() => props.statusFilter, () => {
+// Refetch when filters change
+watch(() => [props.doctorFilter, props.statusFilter], () => {
   calendarRef.value?.getApi()?.refetchEvents()
 })
 

--- a/src/domains/appointment/components/DateSlotPicker.vue
+++ b/src/domains/appointment/components/DateSlotPicker.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, watch, computed } from 'vue'
+import { computed, ref, shallowRef, watch } from 'vue'
 import { CalendarIcon, Clock, LoaderCircle } from 'lucide-vue-next'
 import { CalendarDate, getLocalTimeZone, today } from '@internationalized/date'
 import type { DateValue } from '@internationalized/date'
@@ -15,6 +15,7 @@ const props = defineProps<{
   duration?: number | null // total minutes
   initialDate?: string // ISO date "2026-03-27"
   autoSelectTime?: string // ISO datetime — auto-select matching slot after load
+  allowDurationSelection?: boolean
 }>()
 
 const emit = defineEmits<{
@@ -22,16 +23,19 @@ const emit = defineEmits<{
   'update:duration': [value: number]
 }>()
 
-function parseInitialDate() {
+function parseInitialDate(): CalendarDate {
+  const minDate = today(getLocalTimeZone())
   if (props.initialDate) {
     const [y, m, d] = props.initialDate.split('-').map(Number)
-    if (y && m && d) return new CalendarDate(y, m, d)
+    if (y && m && d) {
+      const initial = new CalendarDate(y, m, d)
+      return initial.compare(minDate) < 0 ? minDate : initial
+    }
   }
-  return today(getLocalTimeZone())
+  return minDate
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const dateValue = ref<any>(parseInitialDate())
+const dateValue = shallowRef<DateValue>(parseInitialDate())
 const slots = ref<Slot[]>([])
 const isLoading = ref(false)
 const error = ref<string | null>(null)
@@ -43,7 +47,7 @@ const selectedIndices = ref<Set<number>>(new Set())
 const dateLabel = computed(() => {
   const d = dateValue.value
   const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
-  return `${months[d.month - 1]} ${d.day}, ${d.year}`
+  return `${months[d.month - 1] ?? ''} ${d.day}, ${d.year}`
 })
 
 const selectionSummary = computed(() => {
@@ -51,8 +55,11 @@ const selectionSummary = computed(() => {
   if (count === 0) return null
   const totalMin = count * slotDuration.value
   const sorted = [...selectedIndices.value].sort((a, b) => a - b)
-  const first = slots.value[sorted[0]]
-  const last = slots.value[sorted[sorted.length - 1]]
+  const firstIndex = sorted[0]
+  const lastIndex = sorted[sorted.length - 1]
+  if (firstIndex === undefined || lastIndex === undefined) return null
+  const first = slots.value[firstIndex]
+  const last = slots.value[lastIndex]
   if (!first || !last) return null
   return {
     count,
@@ -68,10 +75,14 @@ const selectionSummary = computed(() => {
 // Which indices can be added (adjacent to current selection and available)
 const extendableIndices = computed(() => {
   const ext = new Set<number>()
+  if (props.allowDurationSelection === false) return ext
   if (selectedIndices.value.size === 0) return ext
   const sorted = [...selectedIndices.value].sort((a, b) => a - b)
-  const before = sorted[0] - 1
-  const after = sorted[sorted.length - 1] + 1
+  const first = sorted[0]
+  const last = sorted[sorted.length - 1]
+  if (first === undefined || last === undefined) return ext
+  const before = first - 1
+  const after = last + 1
   if (before >= 0 && slots.value[before]?.available) ext.add(before)
   if (after < slots.value.length && slots.value[after]?.available) ext.add(after)
   return ext
@@ -109,6 +120,7 @@ async function loadAvailability() {
 
 function onDateChange(date: DateValue | undefined) {
   if (!date) return
+  if (date.compare(today(getLocalTimeZone())) < 0) return
   dateValue.value = date
   clearSelection()
   loadAvailability()
@@ -117,6 +129,12 @@ function onDateChange(date: DateValue | undefined) {
 function selectSlot(index: number) {
   const slot = slots.value[index]
   if (!slot?.available) return
+
+  if (props.allowDurationSelection === false) {
+    selectedIndices.value = new Set([index])
+    emitSelection()
+    return
+  }
 
   const selected = selectedIndices.value
 
@@ -128,6 +146,7 @@ function selectSlot(index: number) {
     const sorted = [...selected].sort((a, b) => a - b)
     const min = sorted[0]
     const max = sorted[sorted.length - 1]
+    if (min === undefined || max === undefined) return
     if (index === min || index === max) {
       const next = new Set(selected)
       next.delete(index)
@@ -137,6 +156,7 @@ function selectSlot(index: number) {
     const sorted = [...selected].sort((a, b) => a - b)
     const min = sorted[0]
     const max = sorted[sorted.length - 1]
+    if (min === undefined || max === undefined) return
 
     if (index === min - 1) {
       // Extend backward
@@ -162,7 +182,18 @@ function emitSelection() {
   }
 
   const sorted = [...selected].sort((a, b) => a - b)
-  const firstSlot = slots.value[sorted[0]]
+  const firstIndex = sorted[0]
+  if (firstIndex === undefined) {
+    emit('update:modelValue', null)
+    emit('update:duration', slotDuration.value)
+    return
+  }
+  const firstSlot = slots.value[firstIndex]
+  if (!firstSlot) {
+    emit('update:modelValue', null)
+    emit('update:duration', slotDuration.value)
+    return
+  }
   const totalMin = selected.size * slotDuration.value
 
   emit('update:modelValue', firstSlot.start)
@@ -189,7 +220,7 @@ function slotClass(index: number): string {
   if (isSelected) return 'border-primary bg-primary text-primary-foreground'
   if (!slot.available) return 'cursor-not-allowed bg-muted text-muted-foreground opacity-50'
   if (isExtendable) return 'cursor-pointer border-primary/40 bg-primary/10 hover:bg-primary/20'
-  if (selectedIndices.value.size > 0) return 'cursor-pointer opacity-60 hover:bg-accent'
+  if (selectedIndices.value.size > 0 && props.allowDurationSelection !== false) return 'cursor-pointer opacity-60 hover:bg-accent'
   return 'cursor-pointer hover:border-primary/50 hover:bg-accent'
 }
 
@@ -216,7 +247,11 @@ watch(
           </Button>
         </PopoverTrigger>
         <PopoverContent class="w-auto p-0" align="start">
-          <Calendar v-model="dateValue" @update:model-value="onDateChange" />
+          <Calendar
+            v-model="dateValue"
+            :min-value="today(getLocalTimeZone())"
+            @update:model-value="onDateChange"
+          />
         </PopoverContent>
       </Popover>
     </div>
@@ -260,7 +295,7 @@ watch(
     <!-- Slot grid -->
     <div v-else>
       <p class="mb-2 text-xs text-muted-foreground">
-        Click a slot to select, click adjacent slots to extend the duration.
+        {{ allowDurationSelection === false ? 'Click a slot to select the new appointment time.' : 'Click a slot to select, click adjacent slots to extend the duration.' }}
       </p>
       <div class="grid grid-cols-3 gap-2 sm:grid-cols-4 md:grid-cols-5">
         <button

--- a/src/domains/appointment/components/PatientSelector.vue
+++ b/src/domains/appointment/components/PatientSelector.vue
@@ -77,13 +77,14 @@ watch(
       <Input
         :model-value="query"
         placeholder="Search patients..."
-        class="pl-8"
+        class="truncate pl-8 pr-14"
         @update:model-value="onInput"
         @focus="showResults = results.length > 0"
       />
       <button
         v-if="selectedName"
-        class="absolute right-2 top-1/2 -translate-y-1/2 text-xs text-muted-foreground hover:text-foreground"
+        type="button"
+        class="absolute right-2 top-1/2 -translate-y-1/2 bg-background pl-1 text-xs text-muted-foreground hover:text-foreground"
         @click="clear"
       >
         Clear

--- a/src/domains/appointment/types/appointment.types.ts
+++ b/src/domains/appointment/types/appointment.types.ts
@@ -5,6 +5,7 @@ export interface AppointmentResponse {
   clinic_id: string
   patient_id: string
   patient_name: string | null
+  patient_avatar_url: string | null
   doctor_id: string
   doctor_name: string | null
   doctor_avatar_url: string | null

--- a/src/domains/appointment/views/AppointmentListView.vue
+++ b/src/domains/appointment/views/AppointmentListView.vue
@@ -3,8 +3,8 @@ import { onMounted, onUnmounted, ref, computed, watch, nextTick } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import FeatureGate from '@/components/shared/FeatureGate.vue'
 import { toast } from 'vue-sonner'
-import { CalendarDate, getLocalTimeZone, today } from '@internationalized/date'
-import { AlertTriangle, CalendarCheck, CalendarIcon, ClipboardPlus, List, LoaderCircle, Plus, X } from 'lucide-vue-next'
+import { CalendarDate, getLocalTimeZone, today, type DateValue } from '@internationalized/date'
+import { AlertTriangle, CalendarCheck, CalendarIcon, ClipboardPlus, LayoutDashboard, List, LoaderCircle, Plus, UserRound, X } from 'lucide-vue-next'
 import { RouteNames } from '@/router/routeNames'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -38,10 +38,11 @@ import { useCentrifugo } from '@/composables/useCentrifugo'
 import { appointmentApi } from '../api/appointmentApi'
 import { useAppointmentStore } from '../stores/appointmentStore'
 import AppointmentBookingWizard from '../components/AppointmentBookingWizard.vue'
+import AppointmentBoard from '../components/AppointmentBoard.vue'
 import AppointmentCalendar from '../components/AppointmentCalendar.vue'
 import AppointmentCard from '../components/AppointmentCard.vue'
 import AppointmentDetailSheet from '../components/AppointmentDetailSheet.vue'
-import type { AppointmentResponse } from '../types/appointment.types'
+import type { AppointmentListFilters, AppointmentResponse, ClinicDoctor } from '../types/appointment.types'
 
 const router = useRouter()
 const route = useRoute()
@@ -49,22 +50,70 @@ const authStore = useAuthStore()
 const store = useAppointmentStore()
 const { connect, subscribe, getSubscription } = useCentrifugo()
 
-const viewMode = ref<'list' | 'calendar'>('calendar')
+const viewMode = ref<'board' | 'list' | 'calendar'>('board')
 const showBookingWizard = ref(false)
+const bookingMode = ref<'create' | 'reschedule'>('create')
+const rescheduleAppointmentId = ref<string | null>(null)
 const prefillDateTime = ref<string | null>(null)
+const prefillDoctorId = ref<string | null>(null)
+const prefillDoctorName = ref<string | null>(null)
+const prefillPatientId = ref<string | null>(null)
+const prefillPatientName = ref<string | null>(null)
 const showDetailSheet = ref(false)
 const selectedAppointment = ref<AppointmentResponse | null>(null)
 const currentPage = ref(Number(route.query.page) || 1)
 const error = ref<string | null>(null)
+const boardTotal = ref(0)
+const doctors = ref<ClinicDoctor[]>([])
+const isLoadingDoctors = ref(false)
 
 const calendarRef = ref<InstanceType<typeof AppointmentCalendar> | null>(null)
+const boardRef = ref<InstanceType<typeof AppointmentBoard> | null>(null)
 
 let savedScrollY = 0
 
 function onCalendarSlotSelect(dateTime: string) {
   savedScrollY = window.scrollY
-  prefillDateTime.value = dateTime
+  openBookingWizard({ dateTime })
+}
+
+function openBookingWizard(options?: {
+  dateTime?: string | null
+  doctorId?: string | null
+  doctorName?: string | null
+  patientId?: string | null
+  patientName?: string | null
+}) {
+  bookingMode.value = 'create'
+  rescheduleAppointmentId.value = null
+  prefillDateTime.value = options?.dateTime ?? null
+  prefillDoctorId.value = options?.doctorId ?? null
+  prefillDoctorName.value = options?.doctorName ?? null
+  prefillPatientId.value = options?.patientId ?? null
+  prefillPatientName.value = options?.patientName ?? null
   showBookingWizard.value = true
+}
+
+function openRescheduleWizard(appointment: AppointmentResponse) {
+  savedScrollY = window.scrollY
+  bookingMode.value = 'reschedule'
+  rescheduleAppointmentId.value = appointment.id
+  prefillDateTime.value = appointment.scheduled_at
+  prefillDoctorId.value = appointment.doctor_id
+  prefillDoctorName.value = appointment.doctor_name ?? null
+  prefillPatientId.value = appointment.patient_id
+  prefillPatientName.value = appointment.patient_name ?? null
+  showBookingWizard.value = true
+}
+
+function clearBookingPrefill() {
+  bookingMode.value = 'create'
+  rescheduleAppointmentId.value = null
+  prefillDateTime.value = null
+  prefillDoctorId.value = null
+  prefillDoctorName.value = null
+  prefillPatientId.value = null
+  prefillPatientName.value = null
 }
 
 async function onCalendarAppointmentClick(id: string) {
@@ -84,12 +133,18 @@ async function onCalendarAppointmentClick(id: string) {
 }
 
 // Filters
-const statusFilter = ref<string>((route.query.status as string) || 'all')
-const rangeFilter = ref<string>((route.query.range as string) || 'upcoming')
-const dateFilter = ref<string>((route.query.date as string) || '')
+function queryString(value: unknown): string {
+  return typeof value === 'string' ? value : ''
+}
+
+const doctorFilter = ref<string>(queryString(route.query.doctor_id) || 'all')
+const statusFilter = ref<string>(queryString(route.query.status) || 'all')
+const rangeFilter = ref<string>(queryString(route.query.range) || 'upcoming')
+const dateFilter = ref<string>(queryString(route.query.date))
 
 // When a specific date is picked, override range to 'date'
 const activeRange = computed(() => dateFilter.value ? 'date' : rangeFilter.value)
+const appointmentTotal = computed(() => viewMode.value === 'board' ? boardTotal.value : store.pagination.total)
 
 function todayIso(): string {
   const t = today(getLocalTimeZone())
@@ -125,7 +180,8 @@ const dateDisplay = computed(() => {
   })
 })
 
-function onDateSelect(date: CalendarDate) {
+function onDateSelect(date: DateValue | undefined) {
+  if (!date) return
   dateFilter.value = `${date.year}-${String(date.month).padStart(2, '0')}-${String(date.day).padStart(2, '0')}`
   rangeFilter.value = 'date'
   onFilterChange()
@@ -145,6 +201,7 @@ function onRangeChange(value: string) {
 
 function buildFilters(): AppointmentListFilters {
   const f: AppointmentListFilters = {}
+  if (doctorFilter.value && doctorFilter.value !== 'all') f.doctor_id = doctorFilter.value
   if (statusFilter.value && statusFilter.value !== 'all') f.status = statusFilter.value as AppointmentListFilters['status']
 
   if (dateFilter.value) {
@@ -185,6 +242,20 @@ async function fetchData() {
   }
 }
 
+async function loadDoctors() {
+  if (doctors.value.length > 0 || isLoadingDoctors.value) return
+
+  isLoadingDoctors.value = true
+  try {
+    const response = await appointmentApi.getDoctors()
+    doctors.value = response.data
+  } catch {
+    toast.error('Failed to load doctors')
+  } finally {
+    isLoadingDoctors.value = false
+  }
+}
+
 function goToPage(page: number) {
   if (page < 1 || page > store.pagination.last_page) return
   currentPage.value = page
@@ -193,6 +264,7 @@ function goToPage(page: number) {
 
 function syncQuery() {
   const q: Record<string, string> = { page: String(currentPage.value) }
+  if (doctorFilter.value && doctorFilter.value !== 'all') q.doctor_id = doctorFilter.value
   if (statusFilter.value && statusFilter.value !== 'all') q.status = statusFilter.value
   if (dateFilter.value) q.date = dateFilter.value
   if (rangeFilter.value !== 'upcoming') q.range = rangeFilter.value
@@ -202,12 +274,39 @@ function syncQuery() {
 function onFilterChange() {
   currentPage.value = 1
   syncQuery()
-  fetchData()
+  if (viewMode.value === 'list') fetchData()
 }
 
-function openDetail(id: string) {
-  selectedAppointment.value = store.appointments.find((a) => a.id === id) ?? null
-  showDetailSheet.value = true
+async function openDetail(id: string) {
+  savedScrollY = window.scrollY
+  const cached = store.appointments.find((a) => a.id === id)
+  if (cached) {
+    selectedAppointment.value = cached
+    showDetailSheet.value = true
+    return
+  }
+
+  try {
+    const res = await appointmentApi.get(id)
+    selectedAppointment.value = res.data
+    showDetailSheet.value = true
+  } catch {
+    toast.error('Failed to load appointment')
+  }
+}
+
+function refreshVisibleView() {
+  if (viewMode.value === 'board') {
+    boardRef.value?.refetch()
+    return
+  }
+
+  if (viewMode.value === 'calendar') {
+    calendarRef.value?.refetch()
+    return
+  }
+
+  fetchData()
 }
 
 // Triage prompt after check-in
@@ -220,7 +319,7 @@ async function handleCheckIn(id: string) {
     await store.checkInAppointment(id)
     toast.success('Patient checked in')
     showDetailSheet.value = false
-    fetchData()
+    refreshVisibleView()
 
     // Find the appointment to get patient info for triage prompt
     const appointment = store.appointments.find((a) => a.id === id)
@@ -261,7 +360,7 @@ async function confirmCancel() {
     toast.success('Appointment cancelled')
     showCancelDialog.value = false
     showDetailSheet.value = false
-    fetchData()
+    refreshVisibleView()
   } catch {
     toast.error('Failed to cancel appointment')
   } finally {
@@ -287,7 +386,7 @@ async function confirmNoShow() {
     toast.success('Marked as no-show')
     showNoShowDialog.value = false
     showDetailSheet.value = false
-    fetchData()
+    refreshVisibleView()
   } catch {
     toast.error('Failed to mark no-show')
   } finally {
@@ -297,10 +396,16 @@ async function confirmNoShow() {
 
 function onCreated() {
   currentPage.value = 1
-  fetchData()
+  refreshVisibleView()
 }
 
-watch(currentPage, () => fetchData())
+watch(currentPage, () => {
+  if (viewMode.value === 'list') fetchData()
+})
+
+watch(viewMode, (mode) => {
+  if (mode === 'list') fetchData()
+})
 
 // Restore scroll position after dialogs close
 watch(showBookingWizard, (open) => {
@@ -316,13 +421,12 @@ const appointmentChannel = computed(() => {
 })
 
 function onAppointmentEvent() {
-  // Refresh both list and calendar
-  fetchData()
-  calendarRef.value?.refetch()
+  refreshVisibleView()
 }
 
 onMounted(() => {
-  fetchData()
+  void loadDoctors()
+  if (viewMode.value === 'list') fetchData()
   if (appointmentChannel.value) {
     connect()
     subscribe(appointmentChannel.value, onAppointmentEvent)
@@ -341,15 +445,85 @@ onUnmounted(() => {
   <FeatureGate feature="appointments" label="Appointments">
   <div class="flex flex-1 flex-col gap-4 pt-4">
     <!-- Header -->
-    <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+    <div class="flex flex-col gap-3">
       <div class="flex items-center gap-3">
-        <h1 class="text-lg font-semibold">Appointments</h1>
-        <Badge variant="secondary" class="text-xs">{{ store.pagination.total }}</Badge>
+        <div class="flex min-w-0 flex-1 items-center gap-3">
+          <h1 class="text-2xl font-semibold">Appointments</h1>
+          <Badge variant="secondary" class="rounded-full text-xs">{{ appointmentTotal }}</Badge>
+        </div>
+
+        <Button class="h-10 gap-2 px-4" @click="openBookingWizard()">
+          <Plus class="size-4" />
+          <span>Book appointment</span>
+        </Button>
       </div>
 
-      <div class="flex flex-wrap items-center gap-2">
+      <div class="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+        <!-- View toggle -->
+        <div class="flex h-10 w-fit items-center rounded-md border bg-background">
+          <button
+            :class="['flex h-full items-center gap-2 rounded-l-md px-4 text-sm font-medium transition-colors', viewMode === 'board' ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:text-foreground']"
+            @click="viewMode = 'board'"
+          >
+            <LayoutDashboard class="size-4" />
+            Today Board
+          </button>
+          <button
+            :class="['flex h-full items-center gap-2 border-l px-4 text-sm font-medium transition-colors', viewMode === 'calendar' ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:text-foreground']"
+            @click="viewMode = 'calendar'"
+          >
+            <CalendarCheck class="size-4" />
+            Calendar
+          </button>
+          <button
+            :class="['flex h-full items-center gap-2 rounded-r-md border-l px-4 text-sm font-medium transition-colors', viewMode === 'list' ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:text-foreground']"
+            @click="viewMode = 'list'"
+          >
+            <List class="size-4" />
+            List
+          </button>
+        </div>
+
+        <div class="flex flex-wrap items-center gap-2 lg:justify-end">
+          <Select v-model="doctorFilter" @update:model-value="onFilterChange">
+            <SelectTrigger class="h-10 w-[170px]">
+              <span class="flex min-w-0 items-center gap-2">
+                <UserRound class="size-4 shrink-0" />
+                <SelectValue placeholder="All doctors" />
+              </span>
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All doctors</SelectItem>
+              <SelectItem
+                v-for="doctor in doctors"
+                :key="doctor.id"
+                :value="doctor.id"
+              >
+                Dr. {{ doctor.name }}
+              </SelectItem>
+            </SelectContent>
+          </Select>
+
+          <!-- Status filter -->
+          <Select v-model="statusFilter" @update:model-value="onFilterChange">
+            <SelectTrigger class="h-10 w-[170px]">
+              <SelectValue placeholder="All statuses" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All statuses</SelectItem>
+              <SelectItem value="scheduled">Scheduled</SelectItem>
+              <SelectItem value="checked_in">Checked In</SelectItem>
+              <SelectItem value="completed">Completed</SelectItem>
+              <SelectItem value="cancelled">Cancelled</SelectItem>
+              <SelectItem value="no_show">No Show</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      <div v-if="viewMode === 'list'" class="flex flex-wrap items-center gap-2">
         <!-- Range quick filters (list view only) -->
-        <div v-if="viewMode === 'list'" class="flex h-8 items-center rounded-md border text-xs">
+        <div class="flex h-8 items-center rounded-md border text-xs">
           <button
             v-for="opt in [
               { value: 'today', label: 'Today' },
@@ -373,7 +547,7 @@ onUnmounted(() => {
         </div>
 
         <!-- Date picker (list view only) -->
-        <div v-if="viewMode === 'list'" class="flex items-center gap-1">
+        <div class="flex items-center gap-1">
           <Popover>
             <PopoverTrigger as-child>
               <Button
@@ -404,50 +578,31 @@ onUnmounted(() => {
           </Button>
         </div>
 
-        <!-- Status filter -->
-        <Select v-model="statusFilter" @update:model-value="onFilterChange">
-          <SelectTrigger class="h-8 w-[140px]">
-            <SelectValue placeholder="All statuses" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="all">All statuses</SelectItem>
-            <SelectItem value="scheduled">Scheduled</SelectItem>
-            <SelectItem value="checked_in">Checked In</SelectItem>
-            <SelectItem value="completed">Completed</SelectItem>
-            <SelectItem value="cancelled">Cancelled</SelectItem>
-            <SelectItem value="no_show">No Show</SelectItem>
-          </SelectContent>
-        </Select>
-
-        <!-- View toggle -->
-        <div class="flex h-8 items-center rounded-md border">
-          <button
-            :class="['flex h-full items-center gap-1 rounded-l-md px-2.5 text-xs font-medium transition-colors', viewMode === 'list' ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:text-foreground']"
-            @click="viewMode = 'list'"
-          >
-            <List class="size-3.5" />
-            List
-          </button>
-          <button
-            :class="['flex h-full items-center gap-1 rounded-r-md px-2.5 text-xs font-medium transition-colors', viewMode === 'calendar' ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:text-foreground']"
-            @click="viewMode = 'calendar'"
-          >
-            <CalendarCheck class="size-3.5" />
-            Calendar
-          </button>
-        </div>
-
-        <Button size="sm" class="h-8" @click="prefillDateTime = null; showBookingWizard = true">
-          <Plus class="size-3.5" />
-          <span class="hidden sm:inline">Book</span>
-        </Button>
       </div>
     </div>
 
+    <!-- Board View -->
+    <template v-if="viewMode === 'board'">
+      <AppointmentBoard
+        ref="boardRef"
+        :doctor-filter="doctorFilter"
+        :status-filter="statusFilter"
+        :can-manage="authStore.hasPermission('appointments.manage')"
+        @appointment-click="openDetail"
+        @slot-select="(dateTime, options) => openBookingWizard({ dateTime, ...options })"
+        @reschedule="openRescheduleWizard"
+        @check-in="handleCheckIn"
+        @cancel="handleCancel"
+        @no-show="handleNoShow"
+        @summary-change="boardTotal = $event"
+      />
+    </template>
+
     <!-- Calendar View -->
-    <template v-if="viewMode === 'calendar'">
+    <template v-else-if="viewMode === 'calendar'">
       <AppointmentCalendar
         ref="calendarRef"
+        :doctor-filter="doctorFilter"
         :status-filter="statusFilter"
         @appointment-click="onCalendarAppointmentClick"
         @slot-select="onCalendarSlotSelect"
@@ -485,7 +640,7 @@ onUnmounted(() => {
         <p class="mt-1 text-xs text-muted-foreground">
           {{ activeRange === 'upcoming' ? 'No upcoming appointments' : 'No appointments match your filters' }}
         </p>
-        <Button size="sm" class="mt-4" @click="prefillDateTime = null; showBookingWizard = true">
+        <Button size="sm" class="mt-4" @click="openBookingWizard()">
           <Plus class="size-3.5" />
           Book Appointment
         </Button>
@@ -547,8 +702,14 @@ onUnmounted(() => {
     <!-- Booking wizard -->
     <AppointmentBookingWizard
       :open="showBookingWizard"
+      :mode="bookingMode"
+      :appointment-id="rescheduleAppointmentId"
       :prefill-date-time="prefillDateTime"
-      @update:open="(val) => { showBookingWizard = val; if (!val) prefillDateTime = null }"
+      :prefill-doctor-id="prefillDoctorId"
+      :prefill-doctor-name="prefillDoctorName"
+      :prefill-patient-id="prefillPatientId"
+      :prefill-patient-name="prefillPatientName"
+      @update:open="(val) => { showBookingWizard = val; if (!val) clearBookingPrefill() }"
       @created="onCreated"
     />
 

--- a/src/domains/billing/components/InvoiceTable.vue
+++ b/src/domains/billing/components/InvoiceTable.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, watch } from 'vue'
 import { toast } from 'vue-sonner'
 import { Download, FileText, LoaderCircle } from 'lucide-vue-next'
 import {
@@ -20,7 +20,7 @@ import { billingApi } from '../api/billingApi'
 import type { GeneratedDocumentResponse } from '@/domains/consultation/api/documentApi'
 import type { InvoiceResponse } from '../types/billing.types'
 
-defineProps<{
+const props = defineProps<{
   invoices: InvoiceResponse[]
   loading: boolean
 }>()
@@ -33,24 +33,33 @@ const emit = defineEmits<{
 const invoiceDocs = ref<Record<string, GeneratedDocumentResponse | null>>({})
 const generatingIds = ref<Set<string>>(new Set())
 
-async function loadInvoiceDoc(invoice: InvoiceResponse) {
-  if (invoice.status === 'void' || invoiceDocs.value[invoice.id] !== undefined) return
-  try {
-    const res = await billingApi.getPdf(invoice.id)
-    invoiceDocs.value[invoice.id] = res.data
-  } catch {
-    // ignore
-  }
-}
+watch(
+  () => props.invoices,
+  (invoices) => {
+    for (const invoice of invoices) {
+      if (invoice.status === 'void') continue
+      if (!Object.prototype.hasOwnProperty.call(invoiceDocs.value, invoice.id)) {
+        invoiceDocs.value[invoice.id] = invoice.invoice_pdf_document
+      }
+      if (getDoc(invoice)?.status === 'pending' && !generatingIds.value.has(invoice.id)) {
+        generatingIds.value.add(invoice.id)
+        pollForCompletion(invoice)
+      }
+    }
+  },
+  { immediate: true },
+)
 
-function getDoc(invoiceId: string): GeneratedDocumentResponse | null | undefined {
-  return invoiceDocs.value[invoiceId]
+function getDoc(invoice: InvoiceResponse): GeneratedDocumentResponse | null | undefined {
+  return Object.prototype.hasOwnProperty.call(invoiceDocs.value, invoice.id)
+    ? invoiceDocs.value[invoice.id]
+    : invoice.invoice_pdf_document
 }
 
 async function handlePdfClick(e: Event, invoice: InvoiceResponse) {
   e.stopPropagation()
 
-  const doc = getDoc(invoice.id)
+  const doc = getDoc(invoice)
 
   // If ready, download
   if (doc?.status === 'completed' && doc.id) {
@@ -62,6 +71,12 @@ async function handlePdfClick(e: Event, invoice: InvoiceResponse) {
       tab.close()
       toast.error('Failed to download invoice PDF')
     }
+    return
+  }
+
+  if (doc?.status === 'pending') {
+    generatingIds.value.add(invoice.id)
+    pollForCompletion(invoice)
     return
   }
 
@@ -155,7 +170,6 @@ function formatDate(iso: string): string {
             :key="invoice.id"
             class="cursor-pointer hover:bg-muted/50"
             @click="emit('select', invoice)"
-            @vue:mounted="loadInvoiceDoc(invoice)"
           >
             <TableCell class="font-medium">{{ invoice.invoice_number }}</TableCell>
             <TableCell>{{ invoice.patient_name ?? '—' }}</TableCell>
@@ -179,13 +193,13 @@ function formatDate(iso: string): string {
                     @click="handlePdfClick($event, invoice)"
                   >
                     <LoaderCircle v-if="generatingIds.has(invoice.id)" class="size-3.5 animate-spin text-muted-foreground" />
-                    <Download v-else-if="getDoc(invoice.id)?.status === 'completed'" class="size-3.5" />
+                    <Download v-else-if="getDoc(invoice)?.status === 'completed'" class="size-3.5" />
                     <FileText v-else class="size-3.5 text-muted-foreground" />
                   </Button>
                 </TooltipTrigger>
                 <TooltipContent>
                   <span v-if="generatingIds.has(invoice.id)">Generating...</span>
-                  <span v-else-if="getDoc(invoice.id)?.status === 'completed'">Download Invoice PDF</span>
+                  <span v-else-if="getDoc(invoice)?.status === 'completed'">Download Invoice PDF</span>
                   <span v-else>Generate Invoice PDF</span>
                 </TooltipContent>
               </Tooltip>

--- a/src/domains/billing/types/billing.types.ts
+++ b/src/domains/billing/types/billing.types.ts
@@ -28,6 +28,16 @@ export interface InvoicePayment {
   paid_at: string
 }
 
+export interface InvoicePdfDocument {
+  id: string
+  type: string
+  status: 'pending' | 'generating' | 'completed' | 'failed'
+  download_url: string | null
+  error_message: string | null
+  created_at: string
+  updated_at: string
+}
+
 export interface InvoiceResponse {
   id: string
   clinic_id: string
@@ -56,6 +66,7 @@ export interface InvoiceResponse {
   medcert_requested_by: string | null
   medcert_requested_at: string | null
   medcert_document_id: string | null
+  invoice_pdf_document: InvoicePdfDocument | null
   created_at: string
   updated_at: string
 }

--- a/src/domains/consultation/components/FinalizeModal.vue
+++ b/src/domains/consultation/components/FinalizeModal.vue
@@ -65,7 +65,11 @@ const hrInd = computed(() => vitalIndicator(classifyHr(vitals.value?.hr, vitalsC
 const rrInd = computed(() => vitalIndicator(classifyRr(vitals.value?.rr, vitalsConfig.config)))
 const tempInd = computed(() => vitalIndicator(classifyTemp(vitals.value?.temp, vitalsConfig.config)))
 const spo2Ind = computed(() => vitalIndicator(classifySpo2(vitals.value?.spo2, vitalsConfig.config)))
-const bsInd = computed(() => vitalIndicator(classifyBloodSugar(vitals.value?.blood_sugar, vitalsConfig.config)))
+const bsInd = computed(() => vitalIndicator(classifyBloodSugar(
+  vitals.value?.blood_sugar,
+  vitalsConfig.config,
+  vitals.value?.blood_glucose_timing,
+)))
 const painInd = computed(() => vitalIndicator(classifyPain(vitals.value?.pain_score as number | null, vitalsConfig.config)))
 
 const bmi = computed(() => {

--- a/src/domains/consultation/components/VitalsSummary.vue
+++ b/src/domains/consultation/components/VitalsSummary.vue
@@ -239,7 +239,11 @@ const rrStatus = computed(() => {
 })
 
 const bsStatus = computed(() => {
-  const s = classifyBloodSugar(props.triage.vitals?.blood_sugar, vitalsConfig.config)
+  const s = classifyBloodSugar(
+    props.triage.vitals?.blood_sugar,
+    vitalsConfig.config,
+    props.triage.vitals?.blood_glucose_timing,
+  )
   if (!s) return null
   return { ...s, icon: s.severity === 'normal' ? CheckCircle2 : AlertTriangle }
 })
@@ -329,9 +333,12 @@ const vitalBadges = computed(() => {
   }
 
   if (bsStatus.value) {
+    const timing = typeof vitals.blood_glucose_timing === 'string'
+      ? vitals.blood_glucose_timing.replaceAll('_', ' ')
+      : null
     badges.push({
       label: 'Sugar',
-      value: `${vitals.blood_sugar} mg/dL`,
+      value: `${vitals.blood_sugar} mg/dL${timing ? ` · ${timing}` : ''}`,
       status: bsStatus.value.label,
       badgeClass: severityToBadge(bsStatus.value.severity),
     })

--- a/src/domains/consultation/components/specialties/family-medicine/FamilyMedicineTriageSection.vue
+++ b/src/domains/consultation/components/specialties/family-medicine/FamilyMedicineTriageSection.vue
@@ -3,8 +3,16 @@ import { reactive, ref, computed, watch } from 'vue'
 import { useAuthStore } from '@/domains/auth/stores/authStore'
 import { useSpecialtyConfigStore } from '@/stores/specialtyConfigStore'
 import { MessageSquare } from 'lucide-vue-next'
+import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import { Label } from '@/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
 import VitalFieldRenderer from '../../VitalFieldRenderer.vue'
 import LabOrderSection from '../../LabOrderSection.vue'
 import type { ConsultationTriage } from '../../../types/consultation.types'
@@ -28,6 +36,16 @@ const specialtyConfigStore = useSpecialtyConfigStore()
 const hasLabOrders = computed(() => authStore.hasFeature('lab_orders'))
 
 const vitalFields = computed(() => specialtyConfigStore.config?.vitals ?? [])
+const renderedVitalFields = computed(() => vitalFields.value.filter((field) => field.key !== 'blood_sugar'))
+const BLOOD_GLUCOSE_TIMING_OPTIONS = [
+  { value: 'fasting', label: 'Fasting' },
+  { value: 'random', label: 'Random' },
+  { value: 'postprandial', label: 'Post-prandial' },
+  { value: 'pre_meal', label: 'Pre-meal' },
+  { value: 'post_meal', label: 'Post-meal' },
+  { value: 'bedtime', label: 'Bedtime' },
+] as const
+type BloodGlucoseTiming = typeof BLOOD_GLUCOSE_TIMING_OPTIONS[number]['value']
 
 // ── Local state ───────────────────────────────────────────────────────────
 const allVitals = reactive<Record<string, string | number | null>>({
@@ -78,6 +96,19 @@ function onBlur(): void {
   emitSave()
 }
 
+function onBloodSugarUpdate(val: string | number) {
+  const num = Number(val)
+  allVitals['blood_sugar'] = isNaN(num) || String(val) === '' ? null : num
+  if (allVitals['blood_sugar'] !== null && !allVitals['blood_glucose_timing']) {
+    allVitals['blood_glucose_timing'] = 'random'
+  }
+}
+
+function onBloodGlucoseTimingUpdate(val: BloodGlucoseTiming) {
+  allVitals['blood_glucose_timing'] = val
+  onBlur()
+}
+
 function emitSave() {
   emit('save', {
     triage: {
@@ -111,7 +142,7 @@ function emitSave() {
       <h3 class="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Vitals</h3>
       <div class="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
         <VitalFieldRenderer
-          v-for="field in vitalFields"
+          v-for="field in renderedVitalFields"
           :key="field.key"
           :field-config="field"
           :model-value="allVitals[field.key] ?? null"
@@ -122,6 +153,47 @@ function emitSave() {
           @update:paired="(updates) => Object.assign(allVitals, updates)"
           @blur="onBlur"
         />
+
+        <div class="flex flex-col gap-2">
+          <div class="flex h-6 items-center">
+            <Label for="blood_sugar">Blood Sugar (mg/dL)</Label>
+          </div>
+          <div class="grid grid-cols-[minmax(0,1fr)_minmax(8.5rem,0.85fr)] gap-1.5">
+            <Input
+              id="blood_sugar"
+              :model-value="(allVitals['blood_sugar'] as number | null) ?? undefined"
+              type="number"
+              min="20"
+              max="600"
+              step="1"
+              placeholder="70-200"
+              :disabled="disabled"
+              :aria-invalid="!!errors.blood_sugar"
+              :class="errors.blood_sugar ? 'border-destructive focus-visible:ring-destructive' : ''"
+              @update:model-value="onBloodSugarUpdate"
+              @blur="onBlur"
+            />
+            <Select
+              :model-value="(allVitals['blood_glucose_timing'] as string | null) ?? undefined"
+              :disabled="disabled"
+              @update:model-value="(v) => onBloodGlucoseTimingUpdate(v as BloodGlucoseTiming)"
+            >
+              <SelectTrigger aria-label="Blood glucose timing">
+                <SelectValue placeholder="Timing" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem
+                  v-for="option in BLOOD_GLUCOSE_TIMING_OPTIONS"
+                  :key="option.value"
+                  :value="option.value"
+                >
+                  {{ option.label }}
+                </SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <p v-if="errors.blood_sugar" class="text-xs text-destructive">{{ errors.blood_sugar }}</p>
+        </div>
       </div>
     </div>
 

--- a/src/domains/consultation/components/specialties/general/GeneralTriageSection.vue
+++ b/src/domains/consultation/components/specialties/general/GeneralTriageSection.vue
@@ -6,6 +6,13 @@ import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import { Label } from '@/components/ui/label'
 import { Slider } from '@/components/ui/slider'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
 import VitalFieldRenderer from '../../VitalFieldRenderer.vue'
 import LabOrderSection from '../../LabOrderSection.vue'
 import type { ConsultationTriage } from '../../../types/consultation.types'
@@ -61,6 +68,17 @@ const DEFAULT_VITAL_FIELDS: VitalFieldConfig[] = [
     age_ranges: null, show_if: null, options: null,
   },
 ]
+
+const renderedVitalFields = DEFAULT_VITAL_FIELDS.filter((field) => field.key !== 'blood_sugar')
+const BLOOD_GLUCOSE_TIMING_OPTIONS = [
+  { value: 'fasting', label: 'Fasting' },
+  { value: 'random', label: 'Random' },
+  { value: 'postprandial', label: 'Post-prandial' },
+  { value: 'pre_meal', label: 'Pre-meal' },
+  { value: 'post_meal', label: 'Post-meal' },
+  { value: 'bedtime', label: 'Bedtime' },
+] as const
+type BloodGlucoseTiming = typeof BLOOD_GLUCOSE_TIMING_OPTIONS[number]['value']
 
 // ── Local state ───────────────────────────────────────────────────────────
 const allVitals = reactive<Record<string, string | number | null>>({
@@ -166,6 +184,19 @@ function onPainScoreChange(val: number[]) {
   emitSave()
 }
 
+function onBloodSugarUpdate(val: string | number) {
+  const num = Number(val)
+  allVitals['blood_sugar'] = isNaN(num) || String(val) === '' ? null : num
+  if (allVitals['blood_sugar'] !== null && !allVitals['blood_glucose_timing']) {
+    allVitals['blood_glucose_timing'] = 'random'
+  }
+}
+
+function onBloodGlucoseTimingUpdate(val: BloodGlucoseTiming) {
+  allVitals['blood_glucose_timing'] = val
+  onBlur()
+}
+
 function emitSave() {
   emit('save', {
     triage: {
@@ -198,7 +229,7 @@ function emitSave() {
       <h3 class="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Vitals</h3>
       <div class="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
         <VitalFieldRenderer
-          v-for="field in DEFAULT_VITAL_FIELDS"
+          v-for="field in renderedVitalFields"
           :key="field.key"
           :field-config="field"
           :model-value="allVitals[field.key] ?? null"
@@ -209,6 +240,47 @@ function emitSave() {
           @update:paired="(updates) => Object.assign(allVitals, updates)"
           @blur="onBlur"
         />
+
+        <div class="flex flex-col gap-2">
+          <div class="flex h-6 items-center">
+            <Label for="blood_sugar">Blood Sugar (mg/dL)</Label>
+          </div>
+          <div class="grid grid-cols-[minmax(0,1fr)_minmax(8.5rem,0.85fr)] gap-1.5">
+            <Input
+              id="blood_sugar"
+              :model-value="(allVitals['blood_sugar'] as number | null) ?? undefined"
+              type="number"
+              min="20"
+              max="600"
+              step="1"
+              placeholder="70-200"
+              :disabled="disabled"
+              :aria-invalid="!!errors.blood_sugar"
+              :class="errors.blood_sugar ? 'border-destructive focus-visible:ring-destructive' : ''"
+              @update:model-value="onBloodSugarUpdate"
+              @blur="onBlur"
+            />
+            <Select
+              :model-value="(allVitals['blood_glucose_timing'] as string | null) ?? undefined"
+              :disabled="disabled"
+              @update:model-value="(v) => onBloodGlucoseTimingUpdate(v as BloodGlucoseTiming)"
+            >
+              <SelectTrigger aria-label="Blood glucose timing">
+                <SelectValue placeholder="Timing" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem
+                  v-for="option in BLOOD_GLUCOSE_TIMING_OPTIONS"
+                  :key="option.value"
+                  :value="option.value"
+                >
+                  {{ option.label }}
+                </SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <p v-if="errors.blood_sugar" class="text-xs text-destructive">{{ errors.blood_sugar }}</p>
+        </div>
       </div>
     </div>
 

--- a/src/domains/consultation/types/consultation.types.ts
+++ b/src/domains/consultation/types/consultation.types.ts
@@ -122,6 +122,8 @@ export interface ConsultationResponse {
   medcert_requested_at: string | null
   finalized_at: string | null
   display_line?: string | null
+  auto_display_line?: string | null
+  auto_display_summary?: string | null
   display_summary?: import('@/domains/encounter/types/encounter.types').DisplaySummary | null
   created_at: string
   updated_at: string

--- a/src/domains/consultation/views/ConsultationFormView.vue
+++ b/src/domains/consultation/views/ConsultationFormView.vue
@@ -49,6 +49,7 @@ import TreatmentPlanTab from '../components/tabs/TreatmentPlanTab.vue'
 import PaymentTab from '../components/tabs/PaymentTab.vue'
 import VitalsSummary from '../components/VitalsSummary.vue'
 import FinalizeModal from '../components/FinalizeModal.vue'
+import SoapNoteSection from '@/domains/encounter/components/SoapNoteSection.vue'
 import { documentApi, type GeneratedDocumentResponse } from '../api/documentApi'
 import { openNewTab, printPdf } from '@/lib/utils'
 import type { UpdateEncounterPayload } from '@/domains/encounter/types/encounter.types'
@@ -73,6 +74,7 @@ const canEditTriage = computed(() => authStore.hasPermission('encounters.edit-tr
 const canEditAssessment = computed(() => authStore.hasPermission('encounters.edit-assessment'))
 const canEditTreatmentPlan = computed(() => authStore.hasPermission('encounters.edit-treatment-plan'))
 const canFinalize = computed(() => authStore.hasPermission('encounters.finalize'))
+const canEditSoapNote = computed(() => canEditAssessment.value || canFinalize.value)
 
 const activeTab = ref('triage')
 const showPreviewModal = ref(false)
@@ -314,7 +316,7 @@ const lifestyleSummary = computed(() => {
 
 const recentEncounters = computed(() => {
   return store.patientEncounters
-    .filter((e) => e.status === 'finalized' && e.id !== store.current?.id && e.display_line)
+    .filter((e) => e.status === 'finalized' && e.id !== store.current?.id && (e.auto_display_line ?? e.display_line))
     .slice(0, 3)
 })
 
@@ -383,6 +385,11 @@ const currentVitals = computed(() => {
   const hasAny = Object.values(vitals).some((v) => v != null && v !== '')
   return hasAny ? vitals : null
 })
+
+function formatBloodGlucoseTiming(timing: unknown): string | null {
+  if (typeof timing !== 'string' || timing.trim() === '') return null
+  return timing.replaceAll('_', ' ')
+}
 
 // ── Tabs ────────────────────────────────────────────────────────────────
 const allTabs = ['triage', 'assessment', 'treatment-plan', 'payment'] as const
@@ -723,23 +730,33 @@ function proceedAfterFeeWarning() {
 
           <!-- ── Treatment Plan Tab ───────────────────────────────────── -->
           <TabsContent value="treatment-plan" class="mt-0 px-0 md:px-8">
-            <TreatmentPlanTab
-              :treatment-plan="store.current.consultation?.treatment_plan ?? { advice: null, follow_up: null }"
-              :encounter-id="store.current.id"
-              :patient-id="store.current.patient_id"
-              :doctor-id="store.current.doctor_id"
-              :consumables="store.current.consumables ?? []"
-              :procedures="store.current.procedures ?? []"
-              :disabled="store.isFinalized || !canEditTreatmentPlan"
-              :lab-order-disabled="store.isFinalized || !authStore.hasPermission('lab-orders.create') || !authStore.hasFeature('lab_orders')"
-              :prescription-update="prescriptionUpdate"
-              :lab-order-update="labOrderUpdate"
-              :document-update="documentUpdate"
-              @save="handleSave"
-              @update:consumables="(c) => { if (store.current) store.current.consumables = c }"
-              @procedures-updated="(p) => { if (store.current) store.current.procedures = p }"
-              @lab-updated="store.loadEncounter(store.current!.id)"
-            />
+            <div class="flex flex-col gap-5">
+              <TreatmentPlanTab
+                :treatment-plan="store.current.consultation?.treatment_plan ?? { advice: null, follow_up: null }"
+                :encounter-id="store.current.id"
+                :patient-id="store.current.patient_id"
+                :doctor-id="store.current.doctor_id"
+                :consumables="store.current.consumables ?? []"
+                :procedures="store.current.procedures ?? []"
+                :disabled="store.isFinalized || !canEditTreatmentPlan"
+                :lab-order-disabled="store.isFinalized || !authStore.hasPermission('lab-orders.create') || !authStore.hasFeature('lab_orders')"
+                :prescription-update="prescriptionUpdate"
+                :lab-order-update="labOrderUpdate"
+                :document-update="documentUpdate"
+                @save="handleSave"
+                @update:consumables="(c) => { if (store.current) store.current.consumables = c }"
+                @procedures-updated="(p) => { if (store.current) store.current.procedures = p }"
+                @lab-updated="store.loadEncounter(store.current!.id)"
+              />
+
+              <SoapNoteSection
+                :soap-note="store.current.consultation?.soap_note ?? null"
+                :disabled="store.isFinalized || !canEditSoapNote"
+                :can-generate="store.isDraft && canFinalize"
+                :is-generating="store.isGeneratingSoapDraft"
+                :error="store.soapDraftError"
+              />
+            </div>
             <div class="mt-5 flex items-center justify-between">
               <Button variant="outline" @click="goToTab('prev')">
                 <ChevronLeft class="mr-1 size-4" />
@@ -859,7 +876,7 @@ function proceedAfterFeeWarning() {
                     class="flex flex-col gap-0.5 rounded-md border border-transparent bg-muted/30 px-2 py-1.5 text-left text-xs transition-colors hover:border-border hover:bg-muted"
                     @click="openEncounter(enc.id)"
                   >
-                    <p class="font-medium leading-tight">{{ enc.display_line }}</p>
+                    <p class="font-medium leading-tight">{{ enc.auto_display_line ?? enc.display_line }}</p>
                     <p class="text-[10px] text-muted-foreground">{{ formatEncounterDate(enc.finalized_at) }}</p>
                   </button>
                 </div>
@@ -902,7 +919,12 @@ function proceedAfterFeeWarning() {
                   </div>
                   <div v-if="currentVitals.blood_sugar">
                     <span class="text-muted-foreground">Blood Sugar</span>
-                    <p class="font-medium">{{ currentVitals.blood_sugar }} mg/dL</p>
+                    <p class="font-medium">
+                      {{ currentVitals.blood_sugar }} mg/dL
+                      <span v-if="formatBloodGlucoseTiming(currentVitals.blood_glucose_timing)" class="capitalize text-muted-foreground">
+                        · {{ formatBloodGlucoseTiming(currentVitals.blood_glucose_timing) }}
+                      </span>
+                    </p>
                   </div>
                   <div v-if="currentVitals.height">
                     <span class="text-muted-foreground">Height</span>

--- a/src/domains/dental/components/ToothQuickActions.vue
+++ b/src/domains/dental/components/ToothQuickActions.vue
@@ -100,8 +100,17 @@ watch(() => props.anchor, () => {
   reanchor()
 }, { immediate: true })
 
+// Scroll fires at ~60-120Hz on trackpads; getBoundingClientRect inside
+// reanchor forces layout each call. rAF-throttle so we run at most once
+// per frame.
+let scrollRafId: number | null = null
 function onScrollOrResize() {
-  if (props.anchor) reanchor()
+  if (!props.anchor) return
+  if (scrollRafId !== null) return
+  scrollRafId = requestAnimationFrame(() => {
+    scrollRafId = null
+    if (props.anchor) reanchor()
+  })
 }
 
 function onDocMouseDown(ev: MouseEvent) {
@@ -126,6 +135,10 @@ onBeforeUnmount(() => {
   window.removeEventListener('scroll', onScrollOrResize, true)
   window.removeEventListener('resize', onScrollOrResize)
   document.removeEventListener('mousedown', onDocMouseDown, true)
+  if (scrollRafId !== null) {
+    cancelAnimationFrame(scrollRafId)
+    scrollRafId = null
+  }
 })
 
 // ── Wheel geometry ────────────────────────────────────────────────────

--- a/src/domains/dental/composables/useDentalServices.ts
+++ b/src/domains/dental/composables/useDentalServices.ts
@@ -78,6 +78,14 @@ if (typeof import.meta !== 'undefined' && import.meta.hot) {
       cacheBusterFocusHandler = null
     }
     initialised = false
+    // Reset module-scoped state too. Without this, the next hot-reload
+    // re-initialises with stale `loaded === true` and skips the fetch
+    // that would have rebuilt `services`.
+    services.value = []
+    loaded.value = false
+    loading.value = false
+    error.value = null
+    pendingLoad = null
   })
 }
 

--- a/src/domains/dental/types/dental.types.ts
+++ b/src/domains/dental/types/dental.types.ts
@@ -4,6 +4,8 @@
 // strings to preserve leading zeros if any (none in FDI but matches
 // MongoDB key shape).
 
+import type { SoapNote } from '@/domains/encounter/types/soapNote.types'
+
 // ---- Shared enums ----
 
 export type CariesSeverity = 'early' | 'moderate' | 'severe'
@@ -301,6 +303,7 @@ export interface DentalVisitData {
   triage: DentalVisitTriage | null
   assessment: DentalVisitAssessment | null
   plan: DentalVisitPlan | null
+  soap_note?: SoapNote | null
 }
 
 export interface DentalVisitDetail extends DentalVisitData {
@@ -342,6 +345,7 @@ export interface UpdateDentalVisitPayload {
   triage?: DentalVisitTriage
   assessment?: DentalVisitAssessment
   plan?: DentalVisitPlan
+  soap_note?: SoapNote
 }
 
 // ---- Fee schedule / catalog ----

--- a/src/domains/dental/views/DentalVisitView.vue
+++ b/src/domains/dental/views/DentalVisitView.vue
@@ -252,11 +252,12 @@ const paymentProcedures = computed(() => {
     const name = detailParts.length > 0
       ? `${codePrefix}${p.procedure} — ${detailParts.join(' · ')}`
       : `${codePrefix}${p.procedure}`
-    // Suffix the index when no stable id exists — two auto-coder
-    // procedures with the same CDT code on different teeth would
-    // otherwise collide on the v-for `:key` in PaymentTab's
-    // breakdown and Vue would patch the wrong row.
-    const stableId = p.service_id ?? p.id ?? `${p.cdt_code ?? p.procedure}#${i}`
+    // Per-row `id` wins over `service_id` (which is shared across every
+    // procedure pointing at the same clinic service — two D2393 entries
+    // on different teeth would otherwise collide on the v-for `:key` in
+    // PaymentTab's breakdown and Vue would patch the wrong row when one
+    // is removed).
+    const stableId = p.id ?? p.service_id ?? `${p.cdt_code ?? p.procedure}#${i}`
     return {
       service_id: stableId,
       name,
@@ -314,15 +315,10 @@ function toggleAcArch(arch: 'upper' | 'lower') {
   acArches.value = next
 }
 
-// Family changes can invalidate the current selection (e.g. switching from
-// filling → prophy clears teeth & surfaces; → SRP keeps teeth but unfreezes
-// multi-select). Reset everything family-driven so the user starts clean.
-watch(acFamily, () => {
-  acTeeth.value = new Set()
-  acSurfaces.value = new Set()
-  acArches.value = new Set()
-  acNotes.value = ''
-})
+// Family changes invalidate everything family-driven — selection scope
+// (teeth / surfaces / arches), the free-text note, and the material
+// default. Bundled into one watcher so resets land atomically and
+// don't depend on registration order.
 
 // FDI arch lists for the picker grid. Chart-mirror layout: each arch shows
 // right-quadrant teeth then left-quadrant teeth, reading L→R as the
@@ -490,11 +486,13 @@ function toggleAcSurface(s: ToothSurface) {
   acSurfaces.value = next
 }
 
-// Switching procedure family invalidates the previous material selection.
 watch(acFamily, (family) => {
+  acTeeth.value = new Set()
+  acSurfaces.value = new Set()
+  acArches.value = new Set()
+  acNotes.value = ''
   const opts = MATERIAL_OPTIONS[family] ?? []
   acMaterial.value = opts[0]?.value ?? ''
-  if (family !== 'filling') acSurfaces.value = new Set()
 })
 
 // Selected teeth from the chip picker, sorted in chart order so the
@@ -720,10 +718,17 @@ async function addFromAutoCoder() {
     acNotes.value = ''
     await savePlan()
   } catch (err) {
-    console.error('addFromAutoCoder failed', err)
     toast.error(`Failed to add procedure: ${err instanceof Error ? err.message : 'unknown error'}`)
   }
 }
+
+// Procedure edit state is reset during first hydration. Keep these refs before
+// the immediate visit watcher so route loads cannot touch them before setup
+// initializes them.
+const editingProcedureIdx = ref<number | null>(null)
+const editingProcedureDraft = ref<DentalProcedureLog | null>(null)
+const editTeeth = ref<Set<number>>(new Set())
+const editSurfaces = ref<Set<ToothSurface>>(new Set())
 
 // ── Hydrate local state from server response ─────────────────────────
 function hydrateFromVisit() {
@@ -794,7 +799,13 @@ function hydrateFromVisit() {
   diagnosisCodeMap.value = codeMap
 
   const p = visit.value.plan ?? {}
-  procedures.value = (p.procedures ?? []) as DentalProcedureLog[]
+  // Backfill a stable client-side id on every procedure so v-for keys in
+  // PaymentTab / Plan editor stay correct after row removals (otherwise
+  // duplicate CDT codes would collide on `service_id` and Vue would
+  // patch the wrong row).
+  procedures.value = ((p.procedures ?? []) as DentalProcedureLog[]).map((proc) => (
+    proc.id ? proc : { ...proc, id: makeLocalId() }
+  ))
   followUpDate.value = p.follow_up ?? null
   followUpAppointmentId.value = p.follow_up_appointment_id ?? null
 }
@@ -807,7 +818,11 @@ const hydratedEncounterUuid = ref<string | null>(null)
 watch(
   visit,
   (v) => {
-    const id = (v as { uuid?: string } | null)?.uuid ?? null
+    // DentalVisitDetail exposes the primary key as `id`, not `uuid` — the
+    // older guard read `v.uuid` and always saw `null`, so the early-return
+    // never fired and every PATCH reply re-hydrated the form, clobbering
+    // mid-keystroke edits.
+    const id = v?.id ?? null
     if (id !== null && id === hydratedEncounterUuid.value) return
     hydratedEncounterUuid.value = id
     hydrateFromVisit()
@@ -1274,7 +1289,12 @@ function onChartingReset() {
   if (existing.implant) wipe.implant = { __remove: true }
   if (existing.bridge) wipe.bridge = { __remove: true }
   if (existing.missing) wipe.missing = { __remove: true }
-  if (existing.mods?.length) wipe.mods = existing.mods.map((m) => ({ kind: m.kind, __remove: true }))
+  // Mobility lives in `perio_chart[fdi].mobility`, not on the tooth's
+  // `mods` — the entry rendered into `mods` is a virtual injection.
+  // Excluding it here keeps perio findings intact when the user resets
+  // the chart (which is meant to wipe clinical findings, not perio data
+  // collected separately).
+  if (existing.mods?.length) wipe.mods = existing.mods.filter((m) => m.kind !== 'mobility').map((m) => ({ kind: m.kind, __remove: true }))
   if (existing.specials?.length) wipe.specials = existing.specials.map((s) => ({ kind: s.kind, __remove: true }))
   if (existing.notes) wipe.notes = null
   onToothSave(fdi, wipe as Partial<StampedToothState>)
@@ -1303,11 +1323,6 @@ function removeProcedure(idx: number) {
 // object) so the multi-tooth picker and surface chips bind reactively
 // the same way. The draft only holds non-collection fields (notes,
 // billable_amount) plus the read-only header info.
-const editingProcedureIdx = ref<number | null>(null)
-const editingProcedureDraft = ref<DentalProcedureLog | null>(null)
-const editTeeth = ref<Set<number>>(new Set())
-const editSurfaces = ref<Set<ToothSurface>>(new Set())
-
 function startEditProcedure(idx: number) {
   if (isFinalized.value || !canEditPlan.value) return
   const proc = procedures.value[idx]
@@ -1490,30 +1505,50 @@ const psrSummary = computed(() => {
   return { max: Math.max(...codes), count: codes.length }
 })
 
-const clinicalSummary = computed<string | null>(() => {
-  const lines: string[] = []
+type ClinicalSummarySegment = { text: string; bold: boolean }
+
+const clinicalSummary = computed<ClinicalSummarySegment[][] | null>(() => {
+  const lines: ClinicalSummarySegment[][] = []
   const problems = pdStore.problems.filter((p) => p.status !== 'resolved')
   const meds = pdStore.medications.filter((m) => m.status === 'active')
   const allergies = pdStore.allergies
   const ls = pdStore.lifestyle
-  const b = (t: string | number) => `<b>${t}</b>`
 
   if (problems.length) {
-    const top = problems.slice(0, 3).map((p) => b(p.description)).join(', ')
-    const more = problems.length > 3 ? ` (+${problems.length - 3} more)` : ''
-    lines.push(`Active conditions: ${top}${more}.`)
+    const top = problems.slice(0, 3)
+    const segs: ClinicalSummarySegment[] = [{ text: 'Active conditions: ', bold: false }]
+    top.forEach((p, i) => {
+      segs.push({ text: p.description, bold: true })
+      if (i < top.length - 1) segs.push({ text: ', ', bold: false })
+    })
+    if (problems.length > 3) segs.push({ text: ` (+${problems.length - 3} more)`, bold: false })
+    segs.push({ text: '.', bold: false })
+    lines.push(segs)
   }
   if (meds.length) {
-    lines.push(`On ${b(meds.length + ' active medication' + (meds.length > 1 ? 's' : ''))}.`)
+    lines.push([
+      { text: 'On ', bold: false },
+      { text: `${meds.length} active medication${meds.length > 1 ? 's' : ''}`, bold: true },
+      { text: '.', bold: false },
+    ])
   }
   if (allergies.length) {
-    const names = allergies.slice(0, 3).map((a) => b(a.allergen)).join(', ')
-    lines.push(`Allergic to ${names}.`)
+    const top = allergies.slice(0, 3)
+    const segs: ClinicalSummarySegment[] = [{ text: 'Allergic to ', bold: false }]
+    top.forEach((a, i) => {
+      segs.push({ text: a.allergen, bold: true })
+      if (i < top.length - 1) segs.push({ text: ', ', bold: false })
+    })
+    segs.push({ text: '.', bold: false })
+    lines.push(segs)
   }
   if (ls?.smoking && ls.smoking !== 'never') {
-    lines.push(`${b(ls.smoking + ' smoker')}.`)
+    lines.push([
+      { text: `${ls.smoking} smoker`, bold: true },
+      { text: '.', bold: false },
+    ])
   }
-  return lines.length ? lines.join(' ') : null
+  return lines.length ? lines : null
 })
 
 function formatVisitDate(iso: string | null): string {
@@ -1579,10 +1614,17 @@ onUnmounted(() => {
   tabsObserver?.disconnect()
   tabsObserver = null
   // Flush any pending perio save so the last keystroke isn't dropped.
+  // Capture the encounter id we expect to be writing to and bail if the
+  // store has already moved on — otherwise a fast tab navigation would
+  // late-fire `saveSection` against the *next* encounter and stamp this
+  // visit's perio data onto someone else's chart.
   if (perioSaveTimer) {
     clearTimeout(perioSaveTimer)
     perioSaveTimer = null
-    saveAssessment()
+    const flushTargetId = visit.value?.id ?? null
+    if (flushTargetId !== null && store.current?.dental_visit?.id === flushTargetId) {
+      saveAssessment()
+    }
   }
 })
 
@@ -2572,7 +2614,9 @@ function goBack() {
               </div>
               <div class="min-w-0 flex-1">
                 <p class="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">Clinical Summary</p>
-                <p v-if="clinicalSummary" class="mt-1 text-xs leading-relaxed text-muted-foreground [&_b]:text-foreground [&_b]:font-semibold" v-html="clinicalSummary" />
+                <p v-if="clinicalSummary" class="mt-1 text-xs leading-relaxed text-muted-foreground">
+                  <template v-for="(line, li) in clinicalSummary" :key="li"><template v-for="(seg, si) in line" :key="si"><b v-if="seg.bold" class="font-semibold text-foreground">{{ seg.text }}</b><template v-else>{{ seg.text }}</template></template><template v-if="li < clinicalSummary.length - 1"> </template></template>
+                </p>
                 <p v-else class="mt-1 text-xs italic text-muted-foreground/50">No clinical history recorded yet.</p>
               </div>
             </div>
@@ -2943,4 +2987,3 @@ function goBack() {
 
   </Tabs>
 </template>
-

--- a/src/domains/encounter/api/encounterApi.ts
+++ b/src/domains/encounter/api/encounterApi.ts
@@ -5,6 +5,7 @@ import type {
   EncounterDetailResponse,
   EncounterListResponse,
   FinalizeEncounterResponse,
+  SoapDraftApiResponse,
   UpdateEncounterPayload,
   UpdateEncounterResponse,
 } from '../types/encounter.types'
@@ -33,6 +34,10 @@ export const encounterApi = {
 
   finalize(id: string): Promise<FinalizeEncounterResponse> {
     return http.post<FinalizeEncounterResponse>(`/encounters/${id}/finalize`)
+  },
+
+  generateSoapDraft(id: string): Promise<SoapDraftApiResponse> {
+    return http.post<SoapDraftApiResponse>(`/encounters/${id}/soap-draft`)
   },
 
   delete(id: string): Promise<void> {

--- a/src/domains/encounter/components/SoapNoteSection.vue
+++ b/src/domains/encounter/components/SoapNoteSection.vue
@@ -1,0 +1,191 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { toast } from 'vue-sonner'
+import { AlertTriangle, LoaderCircle, Save, Sparkles } from 'lucide-vue-next'
+import { Button } from '@/components/ui/button'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+import { useEncounterStore } from '@/domains/encounter/stores/encounterStore'
+import type { SoapDraftResponse, SoapNote } from '@/domains/encounter/types/soapNote.types'
+
+const props = defineProps<{
+  soapNote?: SoapNote | null
+  disabled?: boolean
+  canGenerate?: boolean
+  isGenerating?: boolean
+  error?: string | null
+}>()
+
+const store = useEncounterStore()
+const fields = ref<Pick<SoapNote, 'subjective' | 'objective' | 'assessment' | 'plan'>>({
+  subjective: '',
+  objective: '',
+  assessment: '',
+  plan: '',
+})
+const draft = ref<SoapDraftResponse | null>(null)
+
+watch(
+  () => props.soapNote,
+  (note) => {
+    fields.value = {
+      subjective: note?.subjective ?? '',
+      objective: note?.objective ?? '',
+      assessment: note?.assessment ?? '',
+      plan: note?.plan ?? '',
+    }
+    draft.value = null
+  },
+  { immediate: true },
+)
+
+const noteSections = [
+  { key: 'subjective', label: 'Subjective' },
+  { key: 'objective', label: 'Objective' },
+  { key: 'assessment', label: 'Assessment' },
+  { key: 'plan', label: 'Plan' },
+] as const
+
+const isComplete = computed(() =>
+  noteSections.every((section) => fields.value[section.key].trim().length > 0),
+)
+
+const canSave = computed(() => !props.disabled && isComplete.value && !store.isSaving)
+
+const generatedLabel = computed(() => {
+  const generatedAt = draft.value?.meta.generated_at ?? props.soapNote?.generated_at
+  if (!generatedAt) return null
+
+  return new Date(generatedAt).toLocaleString('en-PH', {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  })
+})
+
+const activeWarnings = computed(() => draft.value?.warnings ?? [])
+const missingInputs = computed(() => draft.value?.source_fidelity.missing_key_inputs ?? [])
+
+async function handleGenerate(): Promise<void> {
+  const hadUnsavedDraft = draft.value !== null
+  draft.value = null
+  if (hadUnsavedDraft && !props.soapNote) {
+    fields.value = {
+      subjective: '',
+      objective: '',
+      assessment: '',
+      plan: '',
+    }
+  }
+
+  const response = await store.generateSoapDraft()
+  if (!response) return
+
+  draft.value = response
+  fields.value = {
+    subjective: response.soap.subjective,
+    objective: response.soap.objective,
+    assessment: response.soap.assessment,
+    plan: response.soap.plan,
+  }
+  toast.success('SOAP note generated')
+}
+
+async function handleSave(): Promise<void> {
+  if (!canSave.value) return
+
+  const note: SoapNote = {
+    subjective: fields.value.subjective.trim(),
+    objective: fields.value.objective.trim(),
+    assessment: fields.value.assessment.trim(),
+    plan: fields.value.plan.trim(),
+    source: draft.value ? 'ai_draft_reviewed' : props.soapNote?.source ?? 'manual',
+    draft_id: draft.value?.draft_id ?? props.soapNote?.draft_id ?? null,
+    provider: draft.value?.meta.provider ?? props.soapNote?.provider ?? null,
+    model: draft.value?.meta.model ?? props.soapNote?.model ?? null,
+    generated_at: draft.value?.meta.generated_at ?? props.soapNote?.generated_at ?? null,
+  }
+
+  await store.saveSection({ soap_note: note })
+  if (!store.saveError) {
+    draft.value = null
+    toast.success('SOAP note saved')
+  }
+}
+</script>
+
+<template>
+  <section class="rounded-lg border bg-background p-4">
+    <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+      <div class="min-w-0">
+        <div class="flex flex-wrap items-center gap-2">
+          <h3 class="text-sm font-semibold">SOAP Note</h3>
+        </div>
+        <p v-if="generatedLabel" class="mt-1 text-xs text-muted-foreground">
+          Generated {{ generatedLabel }}
+        </p>
+      </div>
+
+      <div class="flex shrink-0 items-center gap-2">
+        <Button
+          v-if="canGenerate"
+          type="button"
+          variant="outline"
+          size="sm"
+          :disabled="disabled || isGenerating || store.isSaving"
+          @click="handleGenerate"
+        >
+          <LoaderCircle v-if="isGenerating" class="size-3.5 animate-spin" />
+          <Sparkles v-else class="size-3.5" />
+          {{ isGenerating ? 'Generating...' : 'Generate' }}
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          :disabled="!canSave"
+          @click="handleSave"
+        >
+          <LoaderCircle v-if="store.isSaving" class="size-3.5 animate-spin" />
+          <Save v-else class="size-3.5" />
+          Save
+        </Button>
+      </div>
+    </div>
+
+    <div v-if="error" class="mt-3 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+      {{ error }}
+    </div>
+
+    <div
+      v-if="activeWarnings.length || missingInputs.length"
+      class="mt-3 flex gap-2 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-300"
+    >
+      <AlertTriangle class="mt-0.5 size-4 shrink-0" />
+      <div class="min-w-0 space-y-1">
+        <p v-for="warning in activeWarnings" :key="warning">
+          {{ warning }}
+        </p>
+        <p v-if="missingInputs.length">
+          Missing inputs: {{ missingInputs.join(', ') }}
+        </p>
+      </div>
+    </div>
+
+    <div class="mt-4 grid gap-4 lg:grid-cols-2">
+      <div
+        v-for="section in noteSections"
+        :key="section.key"
+        class="space-y-1.5"
+      >
+        <Label class="text-xs font-medium text-muted-foreground">{{ section.label }}</Label>
+        <Textarea
+          v-model="fields[section.key]"
+          :disabled="disabled"
+          class="min-h-28 resize-y text-sm leading-relaxed"
+          :aria-label="section.label"
+        />
+      </div>
+    </div>
+  </section>
+</template>

--- a/src/domains/encounter/stores/encounterStore.ts
+++ b/src/domains/encounter/stores/encounterStore.ts
@@ -3,7 +3,7 @@ import { computed, ref } from 'vue'
 import { toast } from 'vue-sonner'
 import { HttpError } from '@/lib/http'
 import { encounterApi } from '../api/encounterApi'
-import type { EncounterResponse, EncounterTimelineItem, EncounterType, UpdateEncounterPayload } from '../types/encounter.types'
+import type { EncounterResponse, EncounterTimelineItem, EncounterType, SoapDraftResponse, UpdateEncounterPayload } from '../types/encounter.types'
 import { useAuthStore } from '@/domains/auth/stores/authStore'
 import type { EncounterRealtimeEvent } from '../types/realtime.types'
 import {
@@ -19,7 +19,9 @@ export const useEncounterStore = defineStore('encounter', () => {
   const isLoadingEncounters = ref(false)
   const isLoadingMore = ref(false)
   const isSaving = ref(false)
+  const isGeneratingSoapDraft = ref(false)
   const saveError = ref<string | null>(null)
+  const soapDraftError = ref<string | null>(null)
   const currentPage = ref(1)
   const lastPage = ref(1)
   const hasMore = computed(() => currentPage.value < lastPage.value)
@@ -145,12 +147,14 @@ export const useEncounterStore = defineStore('encounter', () => {
         c.specialty_assessment = { ...(c.specialty_assessment ?? {}), ...payload.specialty_assessment }
       }
       if (payload.treatment_plan) c.treatment_plan = { ...c.treatment_plan, ...payload.treatment_plan }
+      if (payload.soap_note) c.soap_note = payload.soap_note
       updated.consultation = c
     } else if (updated.type === 'prenatal' && updated.prenatal_visit) {
       const v = { ...updated.prenatal_visit }
       if (payload.triage) v.triage = { ...v.triage, ...payload.triage } as typeof v.triage
       if (payload.assessment) v.assessment = { ...v.assessment, ...payload.assessment } as typeof v.assessment
       if (payload.plan) v.plan = { ...v.plan, ...payload.plan } as typeof v.plan
+      if (payload.soap_note) v.soap_note = payload.soap_note
       updated.prenatal_visit = v
     } else if (updated.type === 'delivery' && updated.delivery_record) {
       const d = { ...updated.delivery_record }
@@ -159,12 +163,14 @@ export const useEncounterStore = defineStore('encounter', () => {
       if (payload.maternal) d.maternal = { ...d.maternal, ...payload.maternal }
       if (payload.neonatal) d.neonatal = { ...d.neonatal, ...payload.neonatal }
       if (payload.notes !== undefined) d.notes = payload.notes ?? null
+      if (payload.soap_note) d.soap_note = payload.soap_note
       updated.delivery_record = d
     } else if (updated.type === 'postpartum' && updated.postpartum_visit) {
       const p = { ...updated.postpartum_visit }
       if (payload.triage) p.triage = { ...p.triage, ...payload.triage } as typeof p.triage
       if (payload.assessment) p.assessment = { ...p.assessment, ...payload.assessment } as typeof p.assessment
       if (payload.plan) p.plan = { ...p.plan, ...payload.plan } as typeof p.plan
+      if (payload.soap_note) p.soap_note = payload.soap_note
       updated.postpartum_visit = p
     } else if (updated.type === 'dental' && updated.dental_visit) {
       const d = { ...updated.dental_visit }
@@ -172,6 +178,7 @@ export const useEncounterStore = defineStore('encounter', () => {
       if (payload.assessment) d.assessment = { ...(d.assessment ?? {}), ...payload.assessment } as typeof d.assessment
       if (payload.plan) d.plan = { ...(d.plan ?? {}), ...payload.plan } as typeof d.plan
       if (payload.treatment_plan_id !== undefined) d.treatment_plan_id = payload.treatment_plan_id
+      if (payload.soap_note) d.soap_note = payload.soap_note
       updated.dental_visit = d
     }
 
@@ -223,6 +230,36 @@ export const useEncounterStore = defineStore('encounter', () => {
     }
   }
 
+  async function generateSoapDraft(): Promise<SoapDraftResponse | null> {
+    if (!current.value) return null
+    if (!navigator.onLine) {
+      soapDraftError.value = 'Cannot generate SOAP note while offline.'
+      return null
+    }
+
+    isGeneratingSoapDraft.value = true
+    soapDraftError.value = null
+    try {
+      const response = await encounterApi.generateSoapDraft(current.value.id)
+      return response.data
+    } catch (error) {
+      if (error instanceof HttpError && error.status === 422) {
+        const data = error.data
+        const validationMessage = typeof data === 'object' && data !== null && 'message' in data
+          ? (data as { message?: unknown }).message
+          : null
+        soapDraftError.value = typeof validationMessage === 'string'
+          ? validationMessage
+          : 'Add clinical details before generating a SOAP note.'
+      } else {
+        soapDraftError.value = 'Failed to generate SOAP note. Please try again.'
+      }
+      return null
+    } finally {
+      isGeneratingSoapDraft.value = false
+    }
+  }
+
   function handleRealtimeEvent(event: EncounterRealtimeEvent): void {
     if (!current.value) return
     if (current.value.id !== event.encounter_id) return
@@ -236,12 +273,14 @@ export const useEncounterStore = defineStore('encounter', () => {
         if (data.triage) c.triage = { ...c.triage, ...data.triage }
         if (data.assessment) c.assessment = data.assessment
         if (data.treatment_plan) c.treatment_plan = { ...c.treatment_plan, ...data.treatment_plan }
+        if (data.soap_note) c.soap_note = data.soap_note
         updated.consultation = c
       } else if (updated.type === 'prenatal' && updated.prenatal_visit) {
         const v = { ...updated.prenatal_visit }
         if (data.triage) v.triage = { ...v.triage, ...data.triage }
         if (data.assessment) v.assessment = { ...v.assessment, ...data.assessment }
         if (data.plan) v.plan = { ...v.plan, ...data.plan }
+        if (data.soap_note) v.soap_note = data.soap_note
         updated.prenatal_visit = v
       } else if (updated.type === 'delivery' && updated.delivery_record) {
         const d = { ...updated.delivery_record }
@@ -249,13 +288,22 @@ export const useEncounterStore = defineStore('encounter', () => {
         if (data.delivery) d.delivery = { ...d.delivery, ...data.delivery }
         if (data.maternal) d.maternal = { ...d.maternal, ...data.maternal }
         if (data.neonatal) d.neonatal = { ...d.neonatal, ...data.neonatal }
+        if (data.soap_note) d.soap_note = data.soap_note
         updated.delivery_record = d
       } else if (updated.type === 'postpartum' && updated.postpartum_visit) {
         const p = { ...updated.postpartum_visit }
         if (data.triage) p.triage = { ...p.triage, ...data.triage }
         if (data.assessment) p.assessment = { ...p.assessment, ...data.assessment }
         if (data.plan) p.plan = { ...p.plan, ...data.plan }
+        if (data.soap_note) p.soap_note = data.soap_note
         updated.postpartum_visit = p
+      } else if (updated.type === 'dental' && updated.dental_visit) {
+        const d = { ...updated.dental_visit }
+        if (data.triage) d.triage = { ...(d.triage ?? {}), ...data.triage }
+        if (data.assessment) d.assessment = { ...(d.assessment ?? {}), ...data.assessment }
+        if (data.plan) d.plan = { ...(d.plan ?? {}), ...data.plan }
+        if (data.soap_note) d.soap_note = data.soap_note
+        updated.dental_visit = d
       }
 
       current.value = updated
@@ -289,7 +337,9 @@ export const useEncounterStore = defineStore('encounter', () => {
     isLoadingEncounters,
     isLoadingMore,
     isSaving,
+    isGeneratingSoapDraft,
     saveError,
+    soapDraftError,
     hasMore,
     isFinalized,
     isDraft,
@@ -299,6 +349,7 @@ export const useEncounterStore = defineStore('encounter', () => {
     loadForPatient,
     loadMoreForPatient,
     saveSection,
+    generateSoapDraft,
     finalize,
     handleRealtimeEvent,
     clearCurrent,

--- a/src/domains/encounter/types/encounter.types.ts
+++ b/src/domains/encounter/types/encounter.types.ts
@@ -10,8 +10,10 @@ import type {
   FMSpecialtyAssessment,
 } from '@/domains/consultation/types/consultation.types'
 import type { DentalVisitData } from '@/domains/dental/types/dental.types'
+import type { SoapNote } from './soapNote.types'
 
 export type { DentalVisitData }
+export type { SoapDraftApiResponse, SoapDraftResponse, SoapNote } from './soapNote.types'
 
 export type EncounterType = 'consultation' | 'prenatal' | 'delivery' | 'postpartum' | 'dental'
 export type EncounterStatus = 'draft' | 'finalized'
@@ -24,6 +26,7 @@ export interface ConsultationData {
   assessment: ConsultationAssessment
   specialty_assessment?: FMSpecialtyAssessment | null
   treatment_plan: ConsultationTreatmentPlan
+  soap_note?: SoapNote | null
 }
 
 // ── Prenatal Visit (OB) ─────────────────────────────────────────────
@@ -112,6 +115,7 @@ export interface PrenatalVisitData {
   triage: PrenatalTriage
   assessment: PrenatalAssessment
   plan: PrenatalPlan
+  soap_note?: SoapNote | null
 }
 
 // ── Delivery Record (OB) ────────────────────────────────────────────
@@ -158,6 +162,7 @@ export interface DeliveryRecordData {
   maternal: DeliveryMaternal
   neonatal: DeliveryNeonatal
   notes: string | null
+  soap_note?: SoapNote | null
 }
 
 // ── Postpartum Visit (OB) ───────────────────────────────────────────
@@ -208,6 +213,7 @@ export interface PostpartumVisitData {
   triage: PostpartumTriage
   assessment: PostpartumAssessment
   plan: PostpartumPlan
+  soap_note?: SoapNote | null
 }
 
 // ── Encounter Response ──────────────────────────────────────────────
@@ -302,6 +308,8 @@ export interface EncounterResponse {
   specialty: string
   status: EncounterStatus
   display_line: string | null
+  auto_display_line: string | null
+  auto_display_summary: string | null
   display_summary: DisplaySummary | null
   patient_name: string | null
   patient_sex: string | null
@@ -333,6 +341,8 @@ export interface EncounterTimelineItem {
   pregnancy_id: string | null
   status: EncounterStatus
   display_line: string | null
+  auto_display_line: string | null
+  auto_display_summary: string | null
   display_summary: DisplaySummary | null
   doctor_id: string
   doctor_name: string | null
@@ -356,6 +366,7 @@ export interface UpdateEncounterPayload {
   assessment?: Partial<ConsultationAssessment> | Partial<PrenatalAssessment> | Partial<PostpartumAssessment> | Partial<import('@/domains/dental/types/dental.types').DentalVisitAssessment>
   specialty_assessment?: Record<string, unknown>
   treatment_plan?: Partial<ConsultationTreatmentPlan>
+  soap_note?: SoapNote
   // Prenatal/Postpartum/Dental plan section
   plan?: Partial<PrenatalPlan> | Partial<PostpartumPlan> | Partial<import('@/domains/dental/types/dental.types').DentalVisitPlan>
   // Dental — link a visit to a treatment plan episode
@@ -408,4 +419,3 @@ export type {
   ConsultationDocument,
   FMSpecialtyAssessment,
 } from '@/domains/consultation/types/consultation.types'
-

--- a/src/domains/encounter/types/realtime.types.ts
+++ b/src/domains/encounter/types/realtime.types.ts
@@ -3,6 +3,7 @@ import type {
   ConsultationAssessment,
   ConsultationTreatmentPlan,
 } from '@/domains/consultation/types/consultation.types'
+import type { SoapNote } from './soapNote.types'
 import type { PrescriptionResponse } from '@/domains/consultation/types/prescription.types'
 import type { LabOrderResponse } from '@/domains/consultation/types/labOrder.types'
 
@@ -13,10 +14,11 @@ export interface EncounterUpdatedEvent {
   encounter_id: string
   timestamp: string
   data: {
-    sections: ('triage' | 'assessment' | 'treatment_plan')[]
+    sections: ('triage' | 'assessment' | 'treatment_plan' | 'soap_note')[]
     triage?: ConsultationTriage
     assessment?: ConsultationAssessment
     treatment_plan?: ConsultationTreatmentPlan
+    soap_note?: SoapNote
     updated_at: string
   }
 }

--- a/src/domains/encounter/types/soapNote.types.ts
+++ b/src/domains/encounter/types/soapNote.types.ts
@@ -1,0 +1,39 @@
+export interface SoapNote {
+  subjective: string
+  objective: string
+  assessment: string
+  plan: string
+  source?: 'manual' | 'ai_draft_reviewed' | null
+  draft_id?: string | null
+  provider?: string | null
+  model?: string | null
+  generated_at?: string | null
+  authored_by?: string | null
+  authored_at?: string | null
+}
+
+export interface SoapDraftResponse {
+  draft_id: string
+  soap: Pick<SoapNote, 'subjective' | 'objective' | 'assessment' | 'plan'>
+  warnings: string[]
+  source_fidelity: {
+    invented_facts_detected: boolean
+    missing_key_inputs: string[]
+    used_sections: string[]
+  }
+  meta: {
+    provider: string
+    model: string
+    generated_at: string
+    usage?: {
+      input_tokens: number
+      cache_creation_input_tokens: number
+      cache_read_input_tokens: number
+      output_tokens: number
+    }
+  }
+}
+
+export interface SoapDraftApiResponse {
+  data: SoapDraftResponse
+}

--- a/src/domains/obgyn/views/PregnancyDetailView.vue
+++ b/src/domains/obgyn/views/PregnancyDetailView.vue
@@ -534,7 +534,7 @@ async function closePostpartum(): Promise<void> {
                       {{ e.status }}
                     </Badge>
                   </div>
-                  <p v-if="e.display_line" class="text-sm font-medium leading-snug">{{ e.display_line }}</p>
+                  <p v-if="e.auto_display_line ?? e.display_line" class="text-sm font-medium leading-snug">{{ e.auto_display_line ?? e.display_line }}</p>
                   <p class="mt-1 text-xs text-muted-foreground">{{ formatDate(e.created_at) }}</p>
                 </div>
               </div>

--- a/src/domains/patient/components/DraftConsultationCard.vue
+++ b/src/domains/patient/components/DraftConsultationCard.vue
@@ -25,6 +25,8 @@ const emit = defineEmits<{
 const router = useRouter()
 const authStore = useAuthStore()
 const vitalsConfig = useVitalsConfigStore()
+const timelineLine = computed(() => props.consultation.auto_display_line ?? props.consultation.display_line ?? null)
+const timelineSummary = computed(() => props.consultation.auto_display_summary ?? null)
 
 const doctorInitials = computed(() => {
   const name = props.consultation.doctor_name ?? ''
@@ -79,7 +81,7 @@ const abnormalVitals = computed(() => {
     alerts.push({ label: 'RR', value: `${vitals.rr}/min`, status: rr.label, color: badgeColor(rr.severity) })
   }
 
-  const bs = classifyBloodSugar(vitals.blood_sugar, cfg)
+  const bs = classifyBloodSugar(vitals.blood_sugar, cfg, vitals.blood_glucose_timing)
   if (bs && bs.severity !== 'normal') {
     alerts.push({ label: 'Sugar', value: `${vitals.blood_sugar} mg/dL`, status: bs.label, color: badgeColor(bs.severity) })
   }
@@ -150,10 +152,15 @@ function formatDate(iso: string): string {
           </span>
         </div>
         <div v-if="consultation.display_summary" class="mt-1">
-          <EncounterSummaryDetail :summary="consultation.display_summary" />
+          <EncounterSummaryDetail
+            :summary="consultation.display_summary"
+            :headline="timelineLine"
+            :display-summary="timelineSummary"
+          />
         </div>
-        <p v-else-if="consultation.display_line" class="mt-1 text-sm text-muted-foreground leading-relaxed">{{ consultation.display_line }}</p>
-        <p v-else class="mt-1 text-sm italic text-muted-foreground">No chief complaint yet</p>
+        <p v-else-if="timelineLine" class="mt-1 text-sm text-muted-foreground leading-relaxed">{{ timelineLine }}</p>
+        <p v-if="!consultation.display_summary && timelineSummary" class="mt-1 text-sm text-muted-foreground leading-relaxed">{{ timelineSummary }}</p>
+        <p v-else-if="!timelineLine" class="mt-1 text-sm italic text-muted-foreground">No chief complaint yet</p>
 
         <!-- Abnormal vitals -->
         <div v-if="abnormalVitals.length" class="mt-2 flex flex-wrap gap-1.5">

--- a/src/domains/patient/components/EncounterSummaryDetail.vue
+++ b/src/domains/patient/components/EncounterSummaryDetail.vue
@@ -5,6 +5,8 @@ import type { DisplaySummary, DisplaySummaryVitals, BpClassification } from '@/d
 
 const props = defineProps<{
   summary: DisplaySummary
+  headline?: string | null
+  displaySummary?: string | null
   previousVitals?: DisplaySummaryVitals | null
 }>()
 
@@ -25,6 +27,7 @@ const BP_CLASS_COLOR: Record<BpClassification, string> = {
 }
 
 const vitals = computed(() => props.summary.vitals)
+const headline = computed(() => props.headline ?? props.summary.chief_complaint ?? null)
 
 // Vitals to render as a compact inline chip row
 function fmt1(n: number): string {
@@ -97,9 +100,13 @@ function ageLabel(months: number): string {
 <template>
   <div class="flex flex-col gap-1.5">
     <!-- Chief complaint + specialty context inline -->
-    <div v-if="summary.chief_complaint" class="text-sm text-foreground leading-relaxed">
-      {{ summary.chief_complaint }}
+    <div v-if="headline" class="text-sm text-foreground leading-relaxed">
+      {{ headline }}
     </div>
+
+    <p v-if="displaySummary" class="text-sm text-muted-foreground leading-relaxed">
+      {{ displaySummary }}
+    </p>
 
     <!-- Specialty context line -->
     <div v-if="ctx.kind !== 'consultation' || bpClassLabel" class="flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-muted-foreground">

--- a/src/domains/patient/components/FinalizedConsultationCard.vue
+++ b/src/domains/patient/components/FinalizedConsultationCard.vue
@@ -34,6 +34,8 @@ const emit = defineEmits<{
 
 const router = useRouter()
 const authStore = useAuthStore()
+const timelineLine = computed(() => props.consultation.auto_display_line ?? props.consultation.display_line ?? null)
+const timelineSummary = computed(() => props.consultation.auto_display_summary ?? null)
 
 function openConsultation() {
   router.push({
@@ -181,9 +183,15 @@ async function requestMedCert() {
       </span>
     </div>
     <div v-if="consultation.display_summary" class="mt-1">
-      <EncounterSummaryDetail :summary="consultation.display_summary" :previous-vitals="previousVitals" />
+      <EncounterSummaryDetail
+        :summary="consultation.display_summary"
+        :headline="timelineLine"
+        :display-summary="timelineSummary"
+        :previous-vitals="previousVitals"
+      />
     </div>
-    <p v-else-if="consultation.display_line" class="mt-1 text-sm text-muted-foreground leading-relaxed">{{ consultation.display_line }}</p>
+    <p v-else-if="timelineLine" class="mt-1 text-sm text-muted-foreground leading-relaxed">{{ timelineLine }}</p>
+    <p v-if="!consultation.display_summary && timelineSummary" class="mt-1 text-sm text-muted-foreground leading-relaxed">{{ timelineSummary }}</p>
     <TooltipProvider v-if="consultation.lab_order_summary" :delay-duration="200">
       <div class="mt-2 flex items-center gap-2 text-xs text-muted-foreground">
         <FlaskConical class="size-3 shrink-0" />

--- a/src/domains/patient/components/PatientCompletenessRing.vue
+++ b/src/domains/patient/components/PatientCompletenessRing.vue
@@ -1,0 +1,49 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+
+const props = withDefaults(defineProps<{
+  completeness: number
+  contentClass?: string
+}>(), {
+  contentClass: 'relative p-[5px]',
+})
+
+const ringStyle = computed(() => {
+  const bounded = Math.min(Math.max(props.completeness, 0), 1)
+  return `--completeness-deg: ${Math.round(bounded * 360)}deg`
+})
+</script>
+
+<template>
+  <div class="relative shrink-0">
+    <div class="absolute inset-0 rounded-full p-[3px]">
+      <div class="size-full rounded-full bg-muted/60" />
+    </div>
+    <div
+      class="absolute inset-0 rounded-full rainbow-ring-fill"
+      :style="ringStyle"
+    />
+    <div :class="contentClass">
+      <slot />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.rainbow-ring-fill {
+  background: conic-gradient(
+    #f87171 0deg,
+    #fb923c 60deg,
+    #facc15 120deg,
+    #4ade80 180deg,
+    #38bdf8 240deg,
+    #818cf8 300deg,
+    #f472b6 var(--completeness-deg),
+    transparent var(--completeness-deg)
+  );
+  -webkit-mask:
+    radial-gradient(farthest-side, transparent calc(100% - 4px), black calc(100% - 4px));
+  mask:
+    radial-gradient(farthest-side, transparent calc(100% - 4px), black calc(100% - 4px));
+}
+</style>

--- a/src/domains/patient/composables/usePatientSync.ts
+++ b/src/domains/patient/composables/usePatientSync.ts
@@ -10,6 +10,7 @@ export function usePatientSync(
   patientId: Ref<string | undefined>,
   clinicId: Ref<string | undefined>,
   onPatientUpdated?: (patient: PatientResponse) => void,
+  onTimelineUpdated?: (data: { encounter_id: string; auto_display_line: string; auto_display_summary: string | null; updated_at: string }) => void,
 ) {
   const { connect, subscribe, unsubscribe } = useCentrifugo()
 
@@ -30,6 +31,8 @@ export function usePatientSync(
       if (patientUpdate.value) {
         patientUpdate.value = { ...patientUpdate.value, avatar_url: event.data.avatar_url }
       }
+    } else if (event.type === 'encounter.timeline_updated') {
+      onTimelineUpdated?.(event.data)
     }
   }
 

--- a/src/domains/patient/types/patientRealtime.types.ts
+++ b/src/domains/patient/types/patientRealtime.types.ts
@@ -18,4 +18,18 @@ export interface PatientAvatarUpdatedEvent {
   data: { avatar_url: string }
 }
 
-export type PatientRealtimeEvent = PatientUpdatedEvent | PatientAvatarUpdatedEvent
+export interface EncounterTimelineUpdatedEvent {
+  type: 'encounter.timeline_updated'
+  actor_id: string
+  session_id?: string
+  patient_id: string
+  timestamp: string
+  data: {
+    encounter_id: string
+    auto_display_line: string
+    auto_display_summary: string | null
+    updated_at: string
+  }
+}
+
+export type PatientRealtimeEvent = PatientUpdatedEvent | PatientAvatarUpdatedEvent | EncounterTimelineUpdatedEvent

--- a/src/domains/patient/utils/profileCompleteness.ts
+++ b/src/domains/patient/utils/profileCompleteness.ts
@@ -1,0 +1,23 @@
+import type { PatientResponse } from '../types/patient.types'
+
+type ProfileCompletenessPatient = Pick<
+  PatientResponse,
+  'date_of_birth' | 'contact_number' | 'email' | 'formatted_address' | 'avatar_url' | 'note'
+>
+
+export function calculatePatientProfileCompleteness(
+  patient: ProfileCompletenessPatient,
+  avatarUrl: string | null = patient.avatar_url,
+): number {
+  const total = 6
+  let filled = 0
+
+  if (patient.date_of_birth) filled++
+  if (patient.contact_number) filled++
+  if (patient.email) filled++
+  if (patient.formatted_address) filled++
+  if (avatarUrl) filled++
+  if (patient.note) filled++
+
+  return filled / total
+}

--- a/src/domains/patient/views/PatientDetailView.vue
+++ b/src/domains/patient/views/PatientDetailView.vue
@@ -61,6 +61,8 @@ import { useEncounterStore } from '@/domains/encounter/stores/encounterStore'
 import { useNotificationStore } from '@/domains/notification/stores/notificationStore'
 import { usePatientSync } from '../composables/usePatientSync'
 import PatientSpecialtyFactory from '../components/specialties/PatientSpecialtyFactory.vue'
+import PatientCompletenessRing from '../components/PatientCompletenessRing.vue'
+import { calculatePatientProfileCompleteness } from '../utils/profileCompleteness'
 
 const route = useRoute()
 const router = useRouter()
@@ -75,9 +77,24 @@ const error = ref<string | null>(null)
 
 const patientIdRef = computed(() => route.params.id as string)
 const clinicIdRef = computed(() => authStore.currentClinic?.id)
-usePatientSync(patientIdRef, clinicIdRef, (updated) => {
-  pdStore.updatePatientFromSync(updated)
-})
+usePatientSync(
+  patientIdRef,
+  clinicIdRef,
+  (updated) => {
+    pdStore.updatePatientFromSync(updated)
+  },
+  (data) => {
+    const idx = encounterStore.patientEncounters.findIndex((e) => e.id === data.encounter_id)
+    if (idx >= 0) {
+      encounterStore.patientEncounters[idx] = {
+        ...encounterStore.patientEncounters[idx],
+        auto_display_line: data.auto_display_line,
+        auto_display_summary: data.auto_display_summary,
+        updated_at: data.updated_at,
+      }
+    }
+  },
+)
 
 const avatarCropOpen = ref(false)
 const isUploadingAvatar = ref(false)
@@ -235,15 +252,7 @@ const activeProblemsCount = computed(() =>
 // Profile completeness (0 to 1)
 const profileCompleteness = computed(() => {
   if (!patient.value) return 0
-  let filled = 0
-  const total = 6
-  if (patient.value.date_of_birth) filled++
-  if (patient.value.contact_number) filled++
-  if (patient.value.email) filled++
-  if (patient.value.formatted_address) filled++
-  if (displayAvatarUrl.value) filled++
-  if (patient.value.note) filled++
-  return filled / total
+  return calculatePatientProfileCompleteness(patient.value, displayAvatarUrl.value)
 })
 
 // Last visit date from finalized consultations
@@ -415,40 +424,28 @@ onUnmounted(() => {
 
         <!-- Avatar with rainbow completeness ring -->
         <div class="-mt-12 flex justify-center relative z-10">
-          <div class="relative">
-            <!-- Rainbow ring track (full circle, gray) -->
-            <div
-              class="absolute inset-0 rounded-full ring-track"
-              style="padding: 3px;"
-            >
-              <div class="w-full h-full rounded-full bg-muted/60" />
-            </div>
-            <!-- Rainbow ring fill (conic-gradient, clipped to completeness) -->
-            <div
-              class="absolute inset-0 rounded-full rainbow-ring-fill"
-              :style="`--completeness-deg: ${Math.round(profileCompleteness * 360)}deg`"
+          <PatientCompletenessRing
+            :completeness="profileCompleteness"
+            content-class="group relative p-[5px]"
+          >
+            <PatientAvatar
+              :avatar-url="displayAvatarUrl"
+              :sex="patient.sex"
+              :name="patient.full_name"
+              class="size-24 ring-2 ring-card ring-offset-0"
             />
-            <!-- Avatar -->
-            <div class="group relative p-[5px]">
-              <PatientAvatar
-                :avatar-url="displayAvatarUrl"
-                :sex="patient.sex"
-                :name="patient.full_name"
-                class="size-24 ring-2 ring-card ring-offset-0"
-              />
-              <button
-                v-if="authStore.hasPermission('patients.edit')"
-                type="button"
-                class="absolute inset-[5px] flex cursor-pointer items-center justify-center rounded-full bg-black/50 opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
-                :disabled="isUploadingAvatar"
-                aria-label="Upload patient photo"
-                @click="avatarCropOpen = true"
-              >
-                <LoaderCircle v-if="isUploadingAvatar" class="size-4 animate-spin text-white" />
-                <Camera v-else class="size-4 text-white" />
-              </button>
-            </div>
-          </div>
+            <button
+              v-if="authStore.hasPermission('patients.edit')"
+              type="button"
+              class="absolute inset-[5px] flex cursor-pointer items-center justify-center rounded-full bg-black/50 opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
+              :disabled="isUploadingAvatar"
+              aria-label="Upload patient photo"
+              @click="avatarCropOpen = true"
+            >
+              <LoaderCircle v-if="isUploadingAvatar" class="size-4 animate-spin text-white" />
+              <Camera v-else class="size-4 text-white" />
+            </button>
+          </PatientCompletenessRing>
         </div>
 
         <!-- Name + meta -->
@@ -873,21 +870,4 @@ onUnmounted(() => {
   100% { box-shadow: 0 0 0 10px oklch(0.283 0.090 253.827 / 0); }
 }
 
-/* Rainbow completeness ring */
-.rainbow-ring-fill {
-  background: conic-gradient(
-    #f87171 0deg,
-    #fb923c 60deg,
-    #facc15 120deg,
-    #4ade80 180deg,
-    #38bdf8 240deg,
-    #818cf8 300deg,
-    #f472b6 var(--completeness-deg),
-    transparent var(--completeness-deg)
-  );
-  -webkit-mask:
-    radial-gradient(farthest-side, transparent calc(100% - 4px), black calc(100% - 4px));
-  mask:
-    radial-gradient(farthest-side, transparent calc(100% - 4px), black calc(100% - 4px));
-}
 </style>

--- a/src/domains/patient/views/PatientListView.vue
+++ b/src/domains/patient/views/PatientListView.vue
@@ -39,12 +39,23 @@ import {
   Filter,
   Search,
   X,
+  Phone,
+  Mail,
+  MapPin,
+  CalendarDays,
+  CheckCircle2,
+  AlertTriangle,
+  LayoutList,
+  Grid3X3,
+  RefreshCw,
 } from 'lucide-vue-next'
 import PatientAvatar from '@/components/PatientAvatar.vue'
 import { patientApi } from '../api/patientApi'
 import { RouteNames } from '@/router/routeNames'
 import PatientStatusBadge from '../components/PatientStatusBadge.vue'
 import CreatePatientDialog from '../components/CreatePatientDialog.vue'
+import PatientCompletenessRing from '../components/PatientCompletenessRing.vue'
+import { calculatePatientProfileCompleteness } from '../utils/profileCompleteness'
 import type { PatientResponse, PatientListFilters, PatientStatus, PatientSortField, SortDirection } from '../types/patient.types'
 
 const router = useRouter()
@@ -62,6 +73,7 @@ const pagination = ref({
 
 const currentPage = ref(Number(route.query.page) || 1)
 const showCreateDialog = ref(false)
+const viewMode = ref<'list' | 'grid'>('list')
 
 function filtersFromQuery(): PatientListFilters {
   const q = route.query
@@ -80,11 +92,120 @@ let searchTimer: ReturnType<typeof setTimeout> | null = null
 
 const hasActiveFilters = computed(() => !!filters.value.status || !!filters.value.sex || !!filters.value.sort_by || !!filters.value.sort_dir)
 
-function formatDate(iso: string): string {
-  const d = new Date(iso)
-  const time = d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true })
-  const date = d.toLocaleDateString('en-US', { day: '2-digit', month: 'short', year: 'numeric' })
-  return `${time} / ${date}`
+const newPatientCount = computed(() => patients.value.filter((patient) => patient.status === 'new').length)
+
+const missingContactCount = computed(() => patients.value.filter((patient) => !patient.contact_number).length)
+const emailOnFileCount = computed(() => patients.value.filter((patient) => !!patient.email).length)
+const addressOnFileCount = computed(() => patients.value.filter((patient) => !!patient.formatted_address).length)
+const bloodTypeOnFileCount = computed(() => patients.value.filter((patient) => !!patient.blood_type).length)
+const followUpReviewCount = computed(() => patients.value.filter((patient) => patient.status === 'returning').length)
+
+const registrationQuality = computed(() => {
+  if (patients.value.length === 0) return 0
+  const completedChecks = patients.value.reduce((sum, patient) => {
+    return sum
+      + (patient.contact_number ? 1 : 0)
+      + (patient.email ? 1 : 0)
+      + (patient.date_of_birth ? 1 : 0)
+      + (patient.formatted_address ? 1 : 0)
+      + (patient.blood_type ? 1 : 0)
+  }, 0)
+  return Math.round((completedChecks / (patients.value.length * 5)) * 100)
+})
+
+const registryChecks = computed(() => [
+  {
+    label: 'Complete contact info',
+    value: patients.value.length - missingContactCount.value,
+    tone: missingContactCount.value === 0 ? 'good' : 'warning',
+  },
+  {
+    label: 'Email on file',
+    value: emailOnFileCount.value,
+    tone: 'good',
+  },
+  {
+    label: 'Date of birth',
+    value: patients.value.filter((patient) => !!patient.date_of_birth).length,
+    tone: 'good',
+  },
+  {
+    label: 'Address on file',
+    value: addressOnFileCount.value,
+    tone: 'good',
+  },
+  {
+    label: 'Blood type',
+    value: bloodTypeOnFileCount.value,
+    tone: bloodTypeOnFileCount.value === patients.value.length ? 'good' : 'warning',
+  },
+])
+
+const patientsForReview = computed(() => {
+  const flagged = patients.value.filter((patient) => patient.status === 'returning' || !patient.contact_number)
+  return (flagged.length ? flagged : patients.value).slice(0, 4)
+})
+
+const currentDateLabel = computed(() => {
+  return new Date().toLocaleDateString('en-US', { month: 'short', day: '2-digit', year: 'numeric' })
+})
+
+function formatDateOnly(iso: string): string {
+  return new Date(iso).toLocaleDateString('en-US', { day: '2-digit', month: 'short', year: 'numeric' })
+}
+
+function formatAge(dateOfBirth: string): string {
+  const birthDate = new Date(dateOfBirth)
+  const today = new Date()
+  let age = today.getFullYear() - birthDate.getFullYear()
+  const monthDelta = today.getMonth() - birthDate.getMonth()
+  if (monthDelta < 0 || (monthDelta === 0 && today.getDate() < birthDate.getDate())) {
+    age -= 1
+  }
+
+  if (age >= 3) return `${age}y`
+
+  let totalMonths = (today.getFullYear() - birthDate.getFullYear()) * 12
+    + today.getMonth()
+    - birthDate.getMonth()
+  if (today.getDate() < birthDate.getDate()) totalMonths -= 1
+  totalMonths = Math.max(totalMonths, 0)
+
+  const years = Math.floor(totalMonths / 12)
+  const months = totalMonths % 12
+
+  if (years === 0) return `${months}m`
+  return months > 0 ? `${years}y${months}m` : `${years}y`
+}
+
+function formatSex(sex: string): string {
+  const value = sex.toLowerCase()
+  if (value.startsWith('f')) return 'Female'
+  if (value.startsWith('m')) return 'Male'
+  return sex
+}
+
+function maskContact(value: string | null): string {
+  if (!value) return 'No phone'
+  const last = value.slice(-3)
+  return `09•• ••• •${last}`
+}
+
+function maskEmail(value: string | null): string {
+  if (!value) return 'No email'
+  const [name, domain] = value.split('@')
+  if (!domain) return 'Email on file'
+  return `${name.slice(0, 1)}•••@${domain}`
+}
+
+function contactCompleteness(patient: PatientResponse): string {
+  if (patient.contact_number && patient.email) return 'Complete'
+  if (patient.contact_number || patient.email) return 'Partial'
+  return 'Missing'
+}
+
+function profileCompleteness(patient: PatientResponse): number {
+  return calculatePatientProfileCompleteness(patient)
 }
 
 async function fetchPatients() {
@@ -132,7 +253,7 @@ function clearFilters() {
   searchQuery.value = ''
 }
 
-function setStatusFilter(val: any) {
+function setStatusFilter(val: unknown) {
   const v = String(val)
   if (v === 'all') {
     const { status: _, ...rest } = filters.value
@@ -142,7 +263,7 @@ function setStatusFilter(val: any) {
   }
 }
 
-function setSexFilter(val: any) {
+function setSexFilter(val: unknown) {
   const v = String(val)
   if (v === 'all') {
     const { sex: _, ...rest } = filters.value
@@ -152,14 +273,18 @@ function setSexFilter(val: any) {
   }
 }
 
-function setSortField(val: any) {
+function setSortField(val: unknown) {
   const v = String(val) as PatientSortField
   filters.value = { ...filters.value, sort_by: v }
 }
 
-function setSortDir(val: any) {
+function setSortDir(val: unknown) {
   const v = String(val) as SortDirection
   filters.value = { ...filters.value, sort_dir: v }
+}
+
+function goToPatient(patientId: string) {
+  router.push({ name: RouteNames.PATIENT_DETAIL, params: { id: patientId } })
 }
 
 function onPatientCreated() {
@@ -192,270 +317,527 @@ onMounted(() => {
 </script>
 
 <template>
-  <div class="flex flex-1 flex-col gap-4 pt-4">
-    <!-- Header -->
-    <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-      <div class="flex items-center gap-3">
-        <h1 class="text-lg font-semibold">Patients</h1>
-        <Badge variant="secondary" class="text-xs">
-          {{ pagination.total }}
-        </Badge>
+  <div class="grid flex-1 gap-6 pt-4 xl:grid-cols-[minmax(0,1fr)_260px]">
+    <section class="flex min-w-0 flex-col gap-4">
+      <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div class="min-w-0">
+          <div class="flex flex-wrap items-center gap-3">
+            <h1 class="text-2xl font-semibold tracking-normal">Patients</h1>
+            <Badge variant="secondary" class="rounded-full px-2.5 text-sm tabular-nums">
+              {{ pagination.total }}
+            </Badge>
+          </div>
+        </div>
+
+        <Button class="w-full shrink-0 sm:w-auto" @click="showCreateDialog = true">
+          <UserPlus class="size-4" />
+          Add Patient
+        </Button>
       </div>
 
-      <div class="flex items-center gap-2">
-        <div class="relative flex-1 sm:w-64 sm:flex-none">
-          <Search class="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
+      <div class="flex flex-col gap-3 xl:flex-row xl:items-center">
+        <div class="relative min-w-0 flex-1">
+          <Search class="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
           <Input
             :model-value="searchQuery"
-            placeholder="Search patients..."
-            class="pl-8"
+            aria-label="Find patients by name, phone, or barangay"
+            placeholder="Find by name, phone, barangay..."
+            class="h-10 pl-9"
             @update:model-value="onSearchInput"
           />
         </div>
 
-        <Popover>
-          <PopoverTrigger as-child>
-            <Button variant="outline" size="icon" class="relative shrink-0">
-              <Filter class="size-4" />
-              <span
-                v-if="hasActiveFilters"
-                class="absolute -right-1 -top-1 size-2 rounded-full bg-primary"
-              />
-            </Button>
-          </PopoverTrigger>
-          <PopoverContent class="w-56" align="end">
-            <div class="flex flex-col gap-3">
-              <div class="flex items-center justify-between">
-                <p class="text-sm font-medium">Filters</p>
-                <Button
+        <div class="flex items-center gap-2">
+          <Popover>
+            <PopoverTrigger as-child>
+              <Button variant="outline" class="relative h-10 shrink-0" aria-label="Filter patients">
+                <Filter class="size-4" />
+                Filters
+                <span
                   v-if="hasActiveFilters"
-                  variant="ghost"
-                  size="sm"
-                  class="h-auto px-1.5 py-0.5 text-xs"
-                  @click="clearFilters"
-                >
-                  <X class="mr-1 size-3" />
-                  Clear
-                </Button>
-              </div>
+                  class="absolute -right-1 -top-1 size-2 rounded-full bg-primary"
+                />
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent class="w-56" align="end">
+              <div class="flex flex-col gap-3">
+                <div class="flex items-center justify-between">
+                  <p class="text-sm font-medium">Filters</p>
+                  <Button
+                    v-if="hasActiveFilters"
+                    variant="ghost"
+                    size="sm"
+                    class="h-auto px-1.5 py-0.5 text-xs"
+                    @click="clearFilters"
+                  >
+                    <X class="mr-1 size-3" />
+                    Clear
+                  </Button>
+                </div>
 
-              <div class="flex flex-col gap-1.5">
-                <label class="text-xs text-muted-foreground">Status</label>
-                <Select :model-value="filters.status ?? 'all'" @update:model-value="setStatusFilter">
-                  <SelectTrigger>
-                    <SelectValue placeholder="All" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="all">All</SelectItem>
-                    <SelectItem value="new">New</SelectItem>
-                    <SelectItem value="active">Active</SelectItem>
-                    <SelectItem value="inactive">Inactive</SelectItem>
-                    <SelectItem value="returning">Returning</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
+                <div class="flex flex-col gap-1.5">
+                  <label class="text-xs text-muted-foreground">Status</label>
+                  <Select :model-value="filters.status ?? 'all'" @update:model-value="setStatusFilter">
+                    <SelectTrigger>
+                      <SelectValue placeholder="All" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="all">All</SelectItem>
+                      <SelectItem value="new">New</SelectItem>
+                      <SelectItem value="active">Active</SelectItem>
+                      <SelectItem value="inactive">Inactive</SelectItem>
+                      <SelectItem value="returning">Returning</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
 
-              <div class="flex flex-col gap-1.5">
-                <label class="text-xs text-muted-foreground">Sex</label>
-                <Select :model-value="filters.sex ?? 'all'" @update:model-value="setSexFilter">
-                  <SelectTrigger>
-                    <SelectValue placeholder="All" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="all">All</SelectItem>
-                    <SelectItem value="male">Male</SelectItem>
-                    <SelectItem value="female">Female</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
+                <div class="flex flex-col gap-1.5">
+                  <label class="text-xs text-muted-foreground">Sex</label>
+                  <Select :model-value="filters.sex ?? 'all'" @update:model-value="setSexFilter">
+                    <SelectTrigger>
+                      <SelectValue placeholder="All" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="all">All</SelectItem>
+                      <SelectItem value="male">Male</SelectItem>
+                      <SelectItem value="female">Female</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
 
-              <div class="flex flex-col gap-1.5">
-                <label class="text-xs text-muted-foreground">Sort by</label>
-                <Select :model-value="filters.sort_by ?? 'updated_at'" @update:model-value="setSortField">
-                  <SelectTrigger>
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="updated_at">Last Updated</SelectItem>
-                    <SelectItem value="created_at">Date Registered</SelectItem>
-                    <SelectItem value="full_name">Name</SelectItem>
-                    <SelectItem value="last_name">Last Name</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
+                <div class="flex flex-col gap-1.5">
+                  <label class="text-xs text-muted-foreground">Sort by</label>
+                  <Select :model-value="filters.sort_by ?? 'updated_at'" @update:model-value="setSortField">
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="updated_at">Last Updated</SelectItem>
+                      <SelectItem value="created_at">Date Registered</SelectItem>
+                      <SelectItem value="full_name">Name</SelectItem>
+                      <SelectItem value="last_name">Last Name</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
 
-              <div class="flex flex-col gap-1.5">
-                <label class="text-xs text-muted-foreground">Order</label>
-                <Select :model-value="filters.sort_dir ?? 'desc'" @update:model-value="setSortDir">
-                  <SelectTrigger>
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="desc">Newest first</SelectItem>
-                    <SelectItem value="asc">Oldest first</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-            </div>
-          </PopoverContent>
-        </Popover>
-
-        <Button class="shrink-0" @click="showCreateDialog = true">
-          <UserPlus class="size-4" />
-          <span class="hidden sm:inline">Add Patient</span>
-        </Button>
-      </div>
-    </div>
-
-    <!-- Loading skeleton -->
-    <div v-if="isLoading" class="rounded-md border">
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead>Patient</TableHead>
-            <TableHead class="hidden md:table-cell">Date Registered</TableHead>
-            <TableHead class="hidden md:table-cell">Contact</TableHead>
-            <TableHead>Status</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          <TableRow v-for="i in 8" :key="i">
-            <TableCell>
-              <div class="flex items-center gap-3">
-                <Skeleton class="size-8 shrink-0 rounded-full" />
-                <div class="flex-1 space-y-1.5">
-                  <Skeleton class="h-4 w-32" />
-                  <Skeleton class="h-3 w-44" />
+                <div class="flex flex-col gap-1.5">
+                  <label class="text-xs text-muted-foreground">Order</label>
+                  <Select :model-value="filters.sort_dir ?? 'desc'" @update:model-value="setSortDir">
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="desc">Newest first</SelectItem>
+                      <SelectItem value="asc">Oldest first</SelectItem>
+                    </SelectContent>
+                  </Select>
                 </div>
               </div>
-            </TableCell>
-            <TableCell class="hidden md:table-cell">
-              <Skeleton class="h-4 w-36" />
-            </TableCell>
-            <TableCell class="hidden md:table-cell">
-              <div class="space-y-1.5">
-                <Skeleton class="h-4 w-28" />
-                <Skeleton class="h-3 w-36" />
-              </div>
-            </TableCell>
-            <TableCell>
-              <Skeleton class="h-5 w-16 rounded-full" />
-            </TableCell>
-          </TableRow>
-        </TableBody>
-      </Table>
-    </div>
+            </PopoverContent>
+          </Popover>
 
-    <!-- Error -->
-    <div
-      v-else-if="error"
-      role="alert"
-      class="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2.5 text-sm text-destructive"
-    >
-      {{ error }}
-      <Button variant="outline" size="sm" class="mt-2" @click="fetchPatients()">Try again</Button>
-    </div>
+          <Select :model-value="filters.sort_by ?? 'updated_at'" @update:model-value="setSortField">
+            <SelectTrigger class="h-10 w-[132px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="updated_at">Last activity</SelectItem>
+              <SelectItem value="created_at">Registered</SelectItem>
+              <SelectItem value="full_name">Name</SelectItem>
+              <SelectItem value="last_name">Last name</SelectItem>
+            </SelectContent>
+          </Select>
 
-    <!-- Empty -->
-    <div
-      v-else-if="patients.length === 0 && !hasActiveFilters && !filters.search"
-      class="flex flex-1 flex-col items-center justify-center py-12 text-muted-foreground"
-    >
-      <Users class="mb-3 size-10 opacity-50" />
-      <p>No patients yet.</p>
-      <Button variant="link" class="mt-2" @click="showCreateDialog = true">
-        Add your first patient
-      </Button>
-    </div>
+          <div class="hidden items-center rounded-md border p-1 sm:flex">
+            <Button
+              :variant="viewMode === 'list' ? 'secondary' : 'ghost'"
+              type="button"
+              size="icon-sm"
+              aria-label="List view"
+              :aria-pressed="viewMode === 'list'"
+              @click="viewMode = 'list'"
+            >
+              <LayoutList class="size-4" />
+            </Button>
+            <Button
+              :variant="viewMode === 'grid' ? 'secondary' : 'ghost'"
+              type="button"
+              size="icon-sm"
+              aria-label="Grid view"
+              :aria-pressed="viewMode === 'grid'"
+              @click="viewMode = 'grid'"
+            >
+              <Grid3X3 class="size-4" />
+            </Button>
+          </div>
+        </div>
+      </div>
 
-    <!-- No results (with filters) -->
-    <div
-      v-else-if="patients.length === 0"
-      class="flex flex-1 flex-col items-center justify-center py-12 text-muted-foreground"
-    >
-      <Search class="mb-3 size-10 opacity-50" />
-      <p>No patients match your filters.</p>
-      <Button variant="link" class="mt-2" @click="clearFilters">
-        Clear filters
-      </Button>
-    </div>
+      <div
+        v-if="hasActiveFilters || filters.search"
+        class="flex flex-wrap items-center gap-2 text-xs text-muted-foreground"
+      >
+        <span>Active view:</span>
+        <Badge v-if="filters.search" variant="secondary" class="rounded-full">
+          Search: {{ filters.search }}
+        </Badge>
+        <Badge v-if="filters.status" variant="secondary" class="rounded-full">
+          Status: {{ filters.status }}
+        </Badge>
+        <Badge v-if="filters.sex" variant="secondary" class="rounded-full">
+          Sex: {{ filters.sex }}
+        </Badge>
+        <Button variant="ghost" size="sm" class="h-7 px-2 text-xs" @click="clearFilters">
+          <X class="size-3" />
+          Clear
+        </Button>
+      </div>
 
-    <!-- Data table -->
-    <template v-else>
-      <div class="rounded-md border">
+      <div class="hidden rounded-md border bg-background md:grid md:grid-cols-2 xl:grid-cols-4">
+        <div class="flex items-center gap-4 border-b p-4 md:border-r xl:border-b-0">
+          <span class="flex size-10 items-center justify-center rounded-xl bg-gradient-to-br from-blue-500 to-blue-600 text-white shadow-sm">
+            <Users class="size-6" />
+          </span>
+          <div>
+            <p class="text-xs text-muted-foreground">Total patients</p>
+            <p class="text-2xl font-semibold tabular-nums">{{ pagination.total }}</p>
+            <p class="text-xs text-muted-foreground">Across all statuses</p>
+          </div>
+        </div>
+        <div class="flex items-center gap-4 border-b p-4 xl:border-b-0 xl:border-r">
+          <span class="flex size-10 items-center justify-center rounded-xl bg-gradient-to-br from-emerald-500 to-emerald-600 text-white shadow-sm">
+            <UserPlus class="size-6" />
+          </span>
+          <div>
+            <p class="text-xs text-muted-foreground">New patients</p>
+            <p class="text-2xl font-semibold tabular-nums">{{ newPatientCount }}</p>
+            <p class="text-xs text-green-700">Status: new</p>
+          </div>
+        </div>
+        <div class="flex items-center gap-4 border-b p-4 md:border-r xl:border-b-0">
+          <span class="flex size-10 items-center justify-center rounded-xl bg-gradient-to-br from-amber-500 to-amber-600 text-white shadow-sm">
+            <Phone class="size-6" />
+          </span>
+          <div>
+            <p class="text-xs text-muted-foreground">Missing contact</p>
+            <p class="text-2xl font-semibold tabular-nums">{{ missingContactCount }}</p>
+            <p class="text-xs text-amber-700">Current page</p>
+          </div>
+        </div>
+        <div class="flex items-center gap-4 p-4">
+          <span class="flex size-10 items-center justify-center rounded-xl bg-gradient-to-br from-violet-500 to-violet-600 text-white shadow-sm">
+            <CalendarDays class="size-6" />
+          </span>
+          <div>
+            <p class="text-xs text-muted-foreground">Returning</p>
+            <p class="text-2xl font-semibold tabular-nums">{{ followUpReviewCount }}</p>
+            <p class="text-xs text-muted-foreground">Needs review</p>
+          </div>
+        </div>
+      </div>
+
+      <!-- Loading skeleton -->
+      <div v-if="isLoading" class="rounded-md border">
         <Table>
           <TableHeader>
             <TableRow>
               <TableHead>Patient</TableHead>
-              <TableHead class="hidden md:table-cell">Date Registered</TableHead>
+              <TableHead class="hidden lg:table-cell">Age / Sex / DOB</TableHead>
+              <TableHead class="hidden xl:table-cell">Location</TableHead>
               <TableHead class="hidden md:table-cell">Contact</TableHead>
+              <TableHead class="hidden lg:table-cell">Last activity</TableHead>
               <TableHead>Status</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
-            <TableRow
-              v-for="patient in patients"
-              :key="patient.id"
-              class="cursor-pointer hover:bg-muted/50"
-              @click="router.push({ name: RouteNames.PATIENT_DETAIL, params: { id: patient.id } })"
-            >
+            <TableRow v-for="i in 8" :key="i">
               <TableCell>
                 <div class="flex items-center gap-3">
-                  <PatientAvatar
-                    :avatar-url="patient.avatar_url"
-                    :sex="patient.sex"
-                    :name="patient.full_name"
-                    class="size-8 shrink-0"
-                  />
-                  <div class="min-w-0">
-                    <p class="truncate font-medium">{{ patient.full_name }}</p>
-                    <p class="truncate text-xs text-muted-foreground">{{ patient.formatted_address }}</p>
+                  <Skeleton class="size-14 shrink-0 rounded-full" />
+                  <div class="flex-1 space-y-1.5">
+                    <Skeleton class="h-4 w-32" />
+                    <Skeleton class="h-3 w-20" />
                   </div>
                 </div>
               </TableCell>
-              <TableCell class="hidden md:table-cell">
-                <span class="text-sm text-muted-foreground">{{ formatDate(patient.created_at) }}</span>
-              </TableCell>
-              <TableCell class="hidden md:table-cell">
-                <div v-if="patient.contact_number || patient.email" class="flex flex-col text-sm">
-                  <span v-if="patient.contact_number">{{ patient.contact_number }}</span>
-                  <span v-if="patient.email" class="text-muted-foreground">{{ patient.email }}</span>
-                </div>
-                <span v-else class="text-sm text-muted-foreground">&mdash;</span>
-              </TableCell>
-              <TableCell>
-                <PatientStatusBadge :status="patient.status" />
-              </TableCell>
+              <TableCell class="hidden lg:table-cell"><Skeleton class="h-4 w-24" /></TableCell>
+              <TableCell class="hidden xl:table-cell"><Skeleton class="h-4 w-32" /></TableCell>
+              <TableCell class="hidden md:table-cell"><Skeleton class="h-4 w-28" /></TableCell>
+              <TableCell class="hidden lg:table-cell"><Skeleton class="h-4 w-28" /></TableCell>
+              <TableCell><Skeleton class="h-5 w-16 rounded-full" /></TableCell>
             </TableRow>
           </TableBody>
         </Table>
       </div>
 
-      <!-- Pagination -->
-      <div v-if="pagination.last_page > 1" class="flex justify-center">
-        <Pagination
-          :total="pagination.total"
-          :items-per-page="pagination.per_page"
-          :page="currentPage"
-          :sibling-count="1"
-          :show-edges="true"
-          @update:page="goToPage"
-        >
-          <PaginationContent v-slot="{ items }">
-            <PaginationPrevious />
-
-            <template v-for="(item, index) in items" :key="item.type === 'page' ? item.value : `ellipsis-${index}`">
-              <PaginationItem v-if="item.type === 'page'" :value="item.value" :is-active="item.value === currentPage">
-                {{ item.value }}
-              </PaginationItem>
-              <PaginationEllipsis v-else :index="index" />
-            </template>
-
-            <PaginationNext />
-          </PaginationContent>
-        </Pagination>
+      <!-- Error -->
+      <div
+        v-else-if="error"
+        role="alert"
+        class="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2.5 text-sm text-destructive"
+      >
+        {{ error }}
+        <Button variant="outline" size="sm" class="mt-2" @click="fetchPatients()">Try again</Button>
       </div>
-    </template>
+
+      <!-- Empty -->
+      <div
+        v-else-if="patients.length === 0 && !hasActiveFilters && !filters.search"
+        class="flex flex-1 flex-col items-center justify-center rounded-md border py-14 text-muted-foreground"
+      >
+        <Users class="mb-3 size-10 opacity-50" />
+        <p>No patients yet.</p>
+        <Button variant="link" class="mt-2" @click="showCreateDialog = true">
+          Add your first patient
+        </Button>
+      </div>
+
+      <!-- No results (with filters) -->
+      <div
+        v-else-if="patients.length === 0"
+        class="flex flex-1 flex-col items-center justify-center rounded-md border py-14 text-muted-foreground"
+      >
+        <Search class="mb-3 size-10 opacity-50" />
+        <p>No patients match your filters.</p>
+        <Button variant="link" class="mt-2" @click="clearFilters">
+          Clear filters
+        </Button>
+      </div>
+
+      <!-- Data table -->
+      <template v-else>
+        <div v-if="viewMode === 'list'" class="overflow-hidden rounded-md border bg-background">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Patient</TableHead>
+                <TableHead class="hidden lg:table-cell">Age / Sex / DOB</TableHead>
+                <TableHead class="hidden xl:table-cell">Location</TableHead>
+                <TableHead class="hidden md:table-cell">Contact</TableHead>
+                <TableHead class="hidden lg:table-cell">Last activity</TableHead>
+                <TableHead>Status</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              <TableRow
+                v-for="patient in patients"
+                :key="patient.id"
+                class="cursor-pointer hover:bg-muted/50"
+                @click="goToPatient(patient.id)"
+              >
+                <TableCell>
+                  <div class="flex items-center gap-3">
+                    <PatientCompletenessRing :completeness="profileCompleteness(patient)">
+                      <PatientAvatar
+                        :avatar-url="patient.avatar_url"
+                        :sex="patient.sex"
+                        :name="patient.full_name"
+                        class="size-12 ring-2 ring-background ring-offset-0"
+                      />
+                    </PatientCompletenessRing>
+                    <div class="min-w-0">
+                      <p class="truncate font-medium">{{ patient.full_name }}</p>
+                      <p class="mt-1 flex items-center gap-1 text-xs text-muted-foreground md:hidden">
+                        <MapPin class="size-3" />
+                        {{ patient.formatted_address || 'No address' }}
+                      </p>
+                    </div>
+                  </div>
+                </TableCell>
+                <TableCell class="hidden lg:table-cell">
+                  <div class="text-sm">
+                    <p>{{ formatAge(patient.date_of_birth) }} · {{ formatSex(patient.sex) }}</p>
+                    <p class="text-xs text-muted-foreground">{{ formatDateOnly(patient.date_of_birth) }}</p>
+                  </div>
+                </TableCell>
+                <TableCell class="hidden xl:table-cell">
+                  <div class="max-w-44 text-sm">
+                    <p class="truncate">{{ patient.address?.barangay_name || 'No barangay' }}</p>
+                    <p class="truncate text-xs text-muted-foreground">{{ patient.address?.city_name || patient.formatted_address || 'No city' }}</p>
+                  </div>
+                </TableCell>
+                <TableCell class="hidden md:table-cell">
+                  <div class="space-y-1 text-sm">
+                    <p class="flex items-center gap-2">
+                      <Phone class="size-3.5 text-muted-foreground" />
+                      {{ maskContact(patient.contact_number) }}
+                    </p>
+                    <p
+                      class="flex items-center gap-2 text-xs"
+                      :class="contactCompleteness(patient) === 'Missing' ? 'text-amber-700' : 'text-green-700'"
+                    >
+                      <span class="size-1.5 rounded-full" :class="contactCompleteness(patient) === 'Missing' ? 'bg-amber-500' : 'bg-green-600'" />
+                      {{ contactCompleteness(patient) }}
+                    </p>
+                    <p class="flex items-center gap-2 text-xs text-muted-foreground">
+                      <Mail class="size-3.5" />
+                      {{ maskEmail(patient.email) }}
+                    </p>
+                  </div>
+                </TableCell>
+                <TableCell class="hidden lg:table-cell">
+                  <div class="text-sm">
+                    <p>{{ formatDateOnly(patient.updated_at) }}</p>
+                  </div>
+                </TableCell>
+                <TableCell>
+                  <PatientStatusBadge :status="patient.status" />
+                </TableCell>
+              </TableRow>
+            </TableBody>
+          </Table>
+        </div>
+
+        <div v-else class="grid gap-3 md:grid-cols-2 2xl:grid-cols-3">
+          <button
+            v-for="patient in patients"
+            :key="patient.id"
+            type="button"
+            class="rounded-md border bg-background p-4 text-left transition-colors hover:bg-muted/50"
+            @click="goToPatient(patient.id)"
+          >
+            <div class="flex items-start justify-between gap-3">
+              <div class="flex min-w-0 items-center gap-3">
+                <PatientCompletenessRing :completeness="profileCompleteness(patient)">
+                  <PatientAvatar
+                    :avatar-url="patient.avatar_url"
+                    :sex="patient.sex"
+                    :name="patient.full_name"
+                    class="size-12 ring-2 ring-background ring-offset-0"
+                  />
+                </PatientCompletenessRing>
+                <div class="min-w-0">
+                  <p class="truncate font-medium">{{ patient.full_name }}</p>
+                  <p class="text-xs text-muted-foreground">
+                    {{ formatAge(patient.date_of_birth) }} · {{ formatSex(patient.sex) }} · {{ formatDateOnly(patient.date_of_birth) }}
+                  </p>
+                </div>
+              </div>
+              <PatientStatusBadge :status="patient.status" />
+            </div>
+
+            <div class="mt-4 space-y-2 text-sm">
+              <p class="flex items-center gap-2 text-muted-foreground">
+                <MapPin class="size-3.5" />
+                <span class="truncate">{{ patient.formatted_address || 'No address' }}</span>
+              </p>
+              <p class="flex items-center gap-2">
+                <Phone class="size-3.5 text-muted-foreground" />
+                {{ maskContact(patient.contact_number) }}
+              </p>
+              <p class="flex items-center gap-2 text-muted-foreground">
+                <Mail class="size-3.5" />
+                {{ maskEmail(patient.email) }}
+              </p>
+            </div>
+          </button>
+        </div>
+
+        <div class="flex flex-col gap-3 text-sm text-muted-foreground lg:flex-row lg:items-center lg:justify-between">
+          <p>
+            Showing {{ ((pagination.page - 1) * pagination.per_page) + 1 }} to
+            {{ Math.min(pagination.page * pagination.per_page, pagination.total) }}
+            of {{ pagination.total }} patients
+          </p>
+
+          <div v-if="pagination.last_page > 1" class="flex justify-center">
+            <Pagination
+              :total="pagination.total"
+              :items-per-page="pagination.per_page"
+              :page="currentPage"
+              :sibling-count="1"
+              :show-edges="true"
+              @update:page="goToPage"
+            >
+              <PaginationContent v-slot="{ items }">
+                <PaginationPrevious />
+
+                <template v-for="(item, index) in items" :key="item.type === 'page' ? item.value : `ellipsis-${index}`">
+                  <PaginationItem v-if="item.type === 'page'" :value="item.value" :is-active="item.value === currentPage">
+                    {{ item.value }}
+                  </PaginationItem>
+                  <PaginationEllipsis v-else :index="index" />
+                </template>
+
+                <PaginationNext />
+              </PaginationContent>
+            </Pagination>
+          </div>
+        </div>
+      </template>
+    </section>
+
+    <aside class="flex flex-col gap-6 border-t pt-5 xl:border-l xl:border-t-0 xl:pl-6 xl:pt-8">
+      <section class="space-y-4">
+        <div class="flex items-center justify-between">
+          <h2 class="text-lg font-semibold">Today</h2>
+          <Badge variant="secondary" class="rounded-full bg-amber-100 text-amber-700">
+            {{ patientsForReview.length }}
+          </Badge>
+        </div>
+
+        <div class="space-y-3">
+          <div class="flex items-center justify-between text-sm">
+            <p class="font-medium">Patients to review</p>
+            <Button variant="link" size="sm" class="h-auto px-0" @click="clearFilters">
+              View all
+            </Button>
+          </div>
+          <div v-if="patientsForReview.length" class="space-y-3">
+            <button
+              v-for="patient in patientsForReview"
+              :key="patient.id"
+              type="button"
+              class="flex w-full items-center justify-between gap-3 rounded-md px-1 py-1.5 text-left text-sm hover:bg-muted"
+              @click="goToPatient(patient.id)"
+            >
+              <span class="flex min-w-0 items-center gap-2">
+                <span class="size-1.5 shrink-0 rounded-full bg-amber-500" />
+                <span class="truncate">{{ patient.full_name }}</span>
+              </span>
+              <span class="shrink-0 text-xs text-muted-foreground">{{ patient.status }}</span>
+            </button>
+          </div>
+          <p v-else class="text-sm text-muted-foreground">No patient review items on this page.</p>
+        </div>
+      </section>
+
+      <section class="space-y-4 border-t pt-6">
+        <h2 class="text-sm font-semibold">Registration quality</h2>
+        <div class="flex items-center gap-3">
+          <div class="grid size-14 place-items-center rounded-full border-4 border-green-600 text-sm font-semibold text-green-700">
+            {{ registrationQuality }}%
+          </div>
+          <div>
+            <p class="text-sm font-medium">{{ registrationQuality >= 80 ? 'Good' : 'Needs cleanup' }}</p>
+            <p class="text-xs text-muted-foreground">Current page</p>
+          </div>
+        </div>
+
+        <div class="space-y-3">
+          <div
+            v-for="check in registryChecks"
+            :key="check.label"
+            class="flex items-center justify-between gap-3 text-sm"
+          >
+            <span class="flex min-w-0 items-center gap-2">
+              <CheckCircle2 v-if="check.tone === 'good'" class="size-4 shrink-0 text-green-600" />
+              <AlertTriangle v-else class="size-4 shrink-0 text-amber-600" />
+              <span class="truncate text-muted-foreground">{{ check.label }}</span>
+            </span>
+            <span class="tabular-nums">{{ check.value }}</span>
+          </div>
+        </div>
+
+        <div class="space-y-2 border-t pt-4 text-xs text-muted-foreground">
+          <p>Data as of {{ currentDateLabel }}</p>
+          <Button variant="ghost" size="sm" class="h-7 px-0 text-primary" @click="fetchPatients">
+            <RefreshCw class="size-3.5" />
+            Refresh
+          </Button>
+        </div>
+      </section>
+    </aside>
 
     <!-- Create Dialog -->
     <CreatePatientDialog

--- a/src/domains/schedule/components/ScheduleAvailabilityStudio.vue
+++ b/src/domains/schedule/components/ScheduleAvailabilityStudio.vue
@@ -1,0 +1,982 @@
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
+import { CalendarDate, type DateValue } from '@internationalized/date'
+import {
+  Activity,
+  AlertTriangle,
+  Ban,
+  CalendarCheck,
+  CalendarDays,
+  CalendarPlus,
+  CheckCircle2,
+  ChevronLeft,
+  ChevronRight,
+  Clock,
+  Coffee,
+  LogIn,
+  LoaderCircle,
+  MoreVertical,
+  RefreshCw,
+  UserRound,
+  UserX,
+  X,
+} from 'lucide-vue-next'
+import { Button } from '@/components/ui/button'
+import { Calendar as ShadcnCalendar } from '@/components/ui/calendar'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import type { AppointmentResponse, AppointmentStatus } from '@/domains/appointment/types/appointment.types'
+import { appointmentApi } from '@/domains/appointment/api/appointmentApi'
+import { scheduleApi } from '../api/scheduleApi'
+import type { CalendarBlock, Slot } from '../types/schedule.types'
+
+const props = defineProps<{
+  userId: string
+  refreshKey?: number
+}>()
+
+const emit = defineEmits<{
+  'appointment-click': [id: string]
+  'add-block': [dateTime: string | null]
+  'check-in': [id: string]
+  cancel: [id: string]
+  'no-show': [id: string]
+  'working-hours': []
+}>()
+
+type Period = 'morning' | 'afternoon' | 'evening'
+const periods: Period[] = ['morning', 'afternoon', 'evening']
+type MapViewMode = 'day' | 'week' | 'list'
+type StatusFilter = 'all' | AppointmentStatus
+
+const selectedDate = ref(toLocalDate(new Date()))
+const currentTime = ref(new Date())
+const appointments = ref<AppointmentResponse[]>([])
+const weekAppointments = ref<AppointmentResponse[]>([])
+const slots = ref<Slot[]>([])
+const weekBlocks = ref<CalendarBlock[]>([])
+const upcomingBlocks = ref<CalendarBlock[]>([])
+const mapViewMode = ref<MapViewMode>('day')
+const statusFilter = ref<StatusFilter>('all')
+const isLoading = ref(false)
+const error = ref<string | null>(null)
+let currentTimeTimer: ReturnType<typeof setInterval> | null = null
+let latestLoadKey = ''
+let inFlightLoadKey = ''
+
+function toLocalDate(date: Date): string {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+function parseLocalDate(value: string): Date {
+  return new Date(`${value}T00:00:00`)
+}
+
+function isoToCalendarDate(value: string): CalendarDate {
+  const [year, month, day] = value.split('-').map(Number)
+  return new CalendarDate(year!, month!, day!)
+}
+
+function calendarDateToIso(value: DateValue): string {
+  return `${value.year}-${String(value.month).padStart(2, '0')}-${String(value.day).padStart(2, '0')}`
+}
+
+function addDays(value: string, amount: number): string {
+  const date = parseLocalDate(value)
+  date.setDate(date.getDate() + amount)
+  return toLocalDate(date)
+}
+
+function startOfWeek(value: string): string {
+  const date = parseLocalDate(value)
+  date.setDate(date.getDate() - date.getDay())
+  return toLocalDate(date)
+}
+
+function endOfWeek(value: string): string {
+  return addDays(startOfWeek(value), 6)
+}
+
+function formatDate(value: string): string {
+  return parseLocalDate(value).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+}
+
+function formatShortDate(value: string): string {
+  return parseLocalDate(value).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+}
+
+function formatNumericDate(value: string): string {
+  return parseLocalDate(value).toLocaleDateString('en-US', { month: 'numeric', day: 'numeric' })
+}
+
+function formatWeekday(value: string): string {
+  return parseLocalDate(value).toLocaleDateString('en-US', { weekday: 'short' })
+}
+
+function formatTime(value: string | Date): string {
+  const date = typeof value === 'string' ? new Date(value) : value
+  return date.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true })
+}
+
+function timeMinutes(value: string): number {
+  const date = new Date(value)
+  return date.getHours() * 60 + date.getMinutes()
+}
+
+function blockStartMinutes(block: CalendarBlock): number {
+  return timeMinutes(block.start)
+}
+
+function periodForIso(value: string): Period {
+  const hour = new Date(value).getHours()
+  if (hour < 12) return 'morning'
+  if (hour < 17) return 'afternoon'
+  return 'evening'
+}
+
+function isSameDay(iso: string, date: string): boolean {
+  return toLocalDate(new Date(iso)) === date
+}
+
+function isTerminal(status: AppointmentStatus): boolean {
+  return status === 'completed' || status === 'cancelled' || status === 'no_show'
+}
+
+function patientInitials(name: string | null): string {
+  if (!name) return 'PT'
+  const parts = name.split(' ').filter(Boolean)
+  const first = parts[0]?.[0]
+  const last = parts[parts.length - 1]?.[0]
+  return [first, last].filter(Boolean).join('').toUpperCase()
+}
+
+function statusLabel(status: AppointmentStatus): string {
+  if (status === 'checked_in') return 'Checked in'
+  if (status === 'no_show') return 'No show'
+  return status.charAt(0).toUpperCase() + status.slice(1)
+}
+
+function statusClass(status: AppointmentStatus): string {
+  if (status === 'checked_in') return 'border-emerald-200 bg-emerald-50 text-emerald-700'
+  if (status === 'completed') return 'border-teal-200 bg-teal-50 text-teal-700'
+  if (status === 'cancelled') return 'border-muted bg-muted/60 text-muted-foreground'
+  if (status === 'no_show') return 'border-red-200 bg-red-50 text-red-700'
+  return 'border-blue-200 bg-blue-50 text-blue-700'
+}
+
+function statusDotClass(status: AppointmentStatus): string {
+  if (status === 'checked_in') return 'bg-emerald-500 ring-emerald-100'
+  if (status === 'completed') return 'bg-teal-500 ring-teal-100'
+  if (status === 'cancelled') return 'bg-muted-foreground/50 ring-muted'
+  if (status === 'no_show') return 'bg-red-500 ring-red-100'
+  return 'bg-blue-500 ring-blue-100'
+}
+
+function blockClass(type: CalendarBlock['type']): string {
+  if (type === 'meeting') return 'border-blue-200 bg-blue-50 text-blue-800'
+  if (type === 'holiday') return 'border-emerald-200 bg-emerald-50 text-emerald-800'
+  if (type === 'personal') return 'border-violet-200 bg-violet-50 text-violet-800'
+  if (type === 'unavailable') return 'border-red-200 bg-red-50 text-red-800'
+  return 'border-amber-200 bg-amber-50 text-amber-800'
+}
+
+const todayDate = computed(() => toLocalDate(currentTime.value))
+const isSelectedToday = computed(() => selectedDate.value === todayDate.value)
+const selectedDateValue = computed<DateValue>({
+  get: () => isoToCalendarDate(selectedDate.value),
+  set: (value) => {
+    selectedDate.value = calendarDateToIso(value)
+  },
+})
+const weekDays = computed(() => Array.from({ length: 7 }, (_, index) => addDays(startOfWeek(selectedDate.value), index)))
+const weekLabel = computed(() => {
+  const firstDay = weekDays.value[0] ?? selectedDate.value
+  const lastDay = weekDays.value[6] ?? selectedDate.value
+  return `${formatShortDate(firstDay)} - ${formatShortDate(lastDay)}`
+})
+
+const visibleAppointments = computed(() => appointments.value
+  .filter((appointment) => statusFilter.value === 'all' || appointment.status === statusFilter.value)
+  .slice()
+  .sort((a, b) => new Date(a.scheduled_at).getTime() - new Date(b.scheduled_at).getTime()))
+
+const visibleWeekAppointments = computed(() => weekAppointments.value
+  .filter((appointment) => statusFilter.value === 'all' || appointment.status === statusFilter.value)
+  .slice()
+  .sort((a, b) => new Date(a.scheduled_at).getTime() - new Date(b.scheduled_at).getTime()))
+
+const scheduledAppointments = computed(() => visibleAppointments.value
+  .filter((appointment) => appointment.status === 'scheduled'))
+
+const upcomingScheduledAppointments = computed(() => scheduledAppointments.value
+  .filter((appointment) => new Date(appointment.scheduled_at).getTime() >= currentTime.value.getTime()))
+
+const nextUp = computed(() => upcomingScheduledAppointments.value[0] ?? scheduledAppointments.value[0] ?? null)
+const availableSlots = computed(() => slots.value.filter((slot) => slot.available))
+const selectedDayBlocks = computed(() => weekBlocks.value
+  .filter((block) => isSameDay(block.start, selectedDate.value) || isSameDay(block.end, selectedDate.value))
+  .sort((a, b) => blockStartMinutes(a) - blockStartMinutes(b)))
+
+const upcomingBlockRangeLabel = computed(() => `${formatShortDate(selectedDate.value)} - ${formatShortDate(addDays(selectedDate.value, 30))}`)
+
+const weekCounts = computed(() => {
+  const counts: Record<string, number> = {}
+  for (const day of weekDays.value) counts[day] = 0
+  for (const appointment of weekAppointments.value) {
+    const key = toLocalDate(new Date(appointment.scheduled_at))
+    if (key in counts) counts[key] = (counts[key] ?? 0) + 1
+  }
+  return counts
+})
+
+const slotStats = computed(() => {
+  const total = slots.value.length
+  const available = availableSlots.value.length
+  const booked = appointments.value.filter((appointment) => appointment.status !== 'cancelled').length
+  const utilization = total > 0 ? Math.round((booked / total) * 100) : 0
+  return { total, available, booked, utilization: Math.min(100, utilization) }
+})
+
+const currentTimeLabel = computed(() => formatTime(currentTime.value))
+
+const statusFilterOptions: Array<{ value: StatusFilter; label: string }> = [
+  { value: 'all', label: 'All' },
+  { value: 'scheduled', label: 'Scheduled' },
+  { value: 'checked_in', label: 'Checked in' },
+  { value: 'completed', label: 'Completed' },
+  { value: 'cancelled', label: 'Cancelled' },
+  { value: 'no_show', label: 'No show' },
+]
+
+function periodSlots(period: Period): Slot[] {
+  return availableSlots.value.filter((slot) => periodForIso(slot.start) === period)
+}
+
+function periodAppointments(period: Period): AppointmentResponse[] {
+  return visibleAppointments.value.filter((appointment) => periodForIso(appointment.scheduled_at) === period)
+}
+
+function periodBlocks(period: Period): CalendarBlock[] {
+  return selectedDayBlocks.value.filter((block) => periodForIso(block.start) === period)
+}
+
+function periodHasContent(period: Period): boolean {
+  return periodSlots(period).length > 0 || periodAppointments(period).length > 0 || periodBlocks(period).length > 0
+}
+
+function periodLabel(period: Period): string {
+  if (period === 'morning') return 'Morning availability'
+  if (period === 'afternoon') return 'Afternoon availability'
+  return 'Evening availability'
+}
+
+function periodIcon(period: Period) {
+  if (period === 'morning') return CalendarDays
+  if (period === 'afternoon') return Activity
+  return Clock
+}
+
+function appointmentEnd(appointment: AppointmentResponse): string {
+  const start = new Date(appointment.scheduled_at)
+  return new Date(start.getTime() + appointment.duration * 60_000).toISOString()
+}
+
+function weekHeatBars(day: string): number[] {
+  const count = weekCounts.value[day] ?? 0
+  const intensity = count > 0 ? Math.min(0.95, 0.35 + count * 0.13) : 0.16
+  return Array.from({ length: 4 }, (_, index) => Math.max(0.14, intensity - (3 - index) * 0.08))
+}
+
+function appointmentsForDay(day: string): AppointmentResponse[] {
+  return visibleWeekAppointments.value.filter((appointment) => toLocalDate(new Date(appointment.scheduled_at)) === day)
+}
+
+function setMapViewMode(mode: MapViewMode) {
+  mapViewMode.value = mode
+}
+
+function setStatusFilter(value: StatusFilter) {
+  statusFilter.value = value
+}
+
+function selectDate(date: string) {
+  selectedDate.value = date
+}
+
+function goToPreviousDay() {
+  selectedDate.value = addDays(selectedDate.value, -1)
+}
+
+function goToNextDay() {
+  selectedDate.value = addDays(selectedDate.value, 1)
+}
+
+async function loadStudioData() {
+  if (!props.userId) return
+  const start = startOfWeek(selectedDate.value)
+  const end = endOfWeek(selectedDate.value)
+  const blockRangeEnd = addDays(selectedDate.value, 30)
+  const loadKey = `${props.userId}:${selectedDate.value}:${start}:${end}:${blockRangeEnd}:${props.refreshKey ?? 0}`
+  if (inFlightLoadKey === loadKey) return
+  latestLoadKey = loadKey
+  inFlightLoadKey = loadKey
+  isLoading.value = true
+  error.value = null
+
+  try {
+    const [weekAppointmentList, availability, upcomingBlockList] = await Promise.all([
+      appointmentApi.list(1, 300, { doctor_id: props.userId, start_date: start, end_date: end }),
+      scheduleApi.getAvailability(props.userId, selectedDate.value),
+      scheduleApi.listAllBlocks(selectedDate.value, blockRangeEnd),
+    ])
+
+    if (latestLoadKey !== loadKey) return
+
+    weekAppointments.value = weekAppointmentList.data
+    appointments.value = weekAppointmentList.data.filter((appointment) => isSameDay(appointment.scheduled_at, selectedDate.value))
+    slots.value = availability.data.slots
+    weekBlocks.value = availability.data.blocks
+    upcomingBlocks.value = upcomingBlockList.data
+  } catch {
+    if (latestLoadKey !== loadKey) return
+    error.value = 'Failed to load schedule view.'
+  } finally {
+    if (inFlightLoadKey === loadKey) {
+      inFlightLoadKey = ''
+    }
+    if (latestLoadKey === loadKey) {
+      isLoading.value = false
+    }
+  }
+}
+
+watch(() => [props.userId, selectedDate.value, props.refreshKey], () => {
+  loadStudioData()
+}, { immediate: true })
+
+onMounted(() => {
+  currentTimeTimer = setInterval(() => {
+    currentTime.value = new Date()
+  }, 1000)
+})
+
+onUnmounted(() => {
+  if (currentTimeTimer) clearInterval(currentTimeTimer)
+})
+</script>
+
+<template>
+  <div class="space-y-4">
+    <div class="space-y-3">
+      <div class="flex flex-wrap items-center gap-2 sm:justify-end">
+        <Button variant="outline" size="icon" class="size-9" @click="goToPreviousDay">
+          <ChevronLeft class="size-4" />
+        </Button>
+        <Popover>
+          <PopoverTrigger as-child>
+            <Button variant="outline" class="h-9 min-w-40 justify-start">
+              <CalendarDays class="size-4 text-muted-foreground" />
+              {{ formatDate(selectedDate) }}
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent class="w-auto p-0" align="end">
+            <ShadcnCalendar v-model="selectedDateValue" />
+          </PopoverContent>
+        </Popover>
+        <Button variant="outline" size="icon" class="size-9" @click="goToNextDay">
+          <ChevronRight class="size-4" />
+        </Button>
+        <Button variant="outline" class="h-9" @click="emit('working-hours')">
+          <Clock class="size-4" />
+          Working hours
+        </Button>
+        <Button class="h-9" @click="emit('add-block', null)">
+          <CalendarPlus class="size-4" />
+          Add block
+        </Button>
+      </div>
+    </div>
+
+    <div class="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+      <div class="rounded-lg border bg-card p-4 shadow-sm">
+        <div class="flex items-center gap-4">
+          <span class="flex size-10 items-center justify-center rounded-xl bg-gradient-to-br from-blue-500 to-blue-600 text-white shadow-sm">
+            <CalendarCheck class="size-6" />
+          </span>
+          <div class="min-w-0">
+            <p class="text-sm text-muted-foreground">Appointments today</p>
+            <p class="text-2xl font-semibold">{{ appointments.length }}</p>
+          </div>
+        </div>
+      </div>
+      <div class="rounded-lg border bg-card p-4 shadow-sm">
+        <div class="flex items-center gap-4">
+          <span class="flex size-10 items-center justify-center rounded-xl bg-gradient-to-br from-emerald-500 to-emerald-600 text-white shadow-sm">
+            <CheckCircle2 class="size-6" />
+          </span>
+          <div class="min-w-0">
+            <p class="text-sm text-muted-foreground">Booked</p>
+            <p class="text-2xl font-semibold">{{ slotStats.booked }}</p>
+          </div>
+        </div>
+      </div>
+      <div class="rounded-lg border bg-card p-4 shadow-sm">
+        <div class="flex items-center gap-4">
+          <span class="flex size-10 items-center justify-center rounded-xl bg-gradient-to-br from-amber-500 to-amber-600 text-white shadow-sm">
+            <Clock class="size-6" />
+          </span>
+          <div class="min-w-0">
+            <p class="text-sm text-muted-foreground">Next appointment</p>
+            <p class="truncate text-2xl font-semibold">{{ nextUp ? formatTime(nextUp.scheduled_at) : '—' }}</p>
+          </div>
+        </div>
+      </div>
+      <div class="rounded-lg border bg-card p-4 shadow-sm">
+        <div class="flex items-center gap-4">
+          <span class="flex size-10 items-center justify-center rounded-xl bg-gradient-to-br from-violet-500 to-violet-600 text-white shadow-sm">
+            <Activity class="size-6" />
+          </span>
+          <div class="min-w-0">
+            <p class="text-sm text-muted-foreground">Open slots</p>
+            <p class="text-2xl font-semibold">{{ slotStats.available }}</p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div
+      v-if="error"
+      role="alert"
+      class="rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive"
+    >
+      {{ error }}
+    </div>
+
+    <div v-if="isLoading" class="flex items-center justify-center rounded-lg border bg-card py-16">
+      <LoaderCircle class="size-6 animate-spin text-muted-foreground" />
+    </div>
+
+    <div v-else class="grid gap-4 xl:grid-cols-[minmax(0,1.25fr)_minmax(360px,0.75fr)]">
+      <section class="overflow-hidden rounded-lg border bg-card shadow-sm">
+        <div class="flex flex-col gap-3 border-b p-4">
+          <div>
+            <h2 class="text-lg font-semibold">Availability map</h2>
+            <p class="text-sm text-muted-foreground">Single-doctor view of appointments, blocks, and open gaps.</p>
+          </div>
+          <div class="grid gap-2 min-[1100px]:grid-cols-[auto_minmax(0,1fr)] min-[1100px]:items-start">
+            <div class="inline-flex w-fit rounded-lg border bg-background p-1">
+              <button
+                class="rounded-md px-3 py-1.5 text-sm font-medium"
+                :class="mapViewMode === 'day' ? 'bg-muted text-foreground' : 'text-muted-foreground'"
+                @click="setMapViewMode('day')"
+              >
+                Day
+              </button>
+              <button
+                class="rounded-md px-3 py-1.5 text-sm font-medium"
+                :class="mapViewMode === 'week' ? 'bg-muted text-foreground' : 'text-muted-foreground'"
+                @click="setMapViewMode('week')"
+              >
+                Week
+              </button>
+              <button
+                class="rounded-md px-3 py-1.5 text-sm font-medium"
+                :class="mapViewMode === 'list' ? 'bg-muted text-foreground' : 'text-muted-foreground'"
+                @click="setMapViewMode('list')"
+              >
+                List
+              </button>
+            </div>
+
+            <div class="flex min-w-0 flex-wrap gap-1 min-[1100px]:justify-end">
+              <button
+                v-for="option in statusFilterOptions"
+                :key="option.value"
+                class="whitespace-nowrap rounded-md border px-2.5 py-1 text-xs font-medium transition-colors"
+                :class="statusFilter === option.value ? 'border-primary bg-primary text-primary-foreground' : 'bg-background text-muted-foreground hover:bg-accent'"
+                @click="setStatusFilter(option.value)"
+              >
+                {{ option.label }}
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <div v-if="mapViewMode !== 'list'" class="border-b px-4 py-3">
+          <div class="grid grid-cols-7 gap-2">
+            <button
+              v-for="day in weekDays"
+              :key="day"
+              class="rounded-lg border px-2 py-2 text-center transition-colors hover:bg-accent"
+              :class="day === selectedDate ? 'border-teal-500 bg-teal-50 text-teal-900 shadow-sm' : 'bg-background'"
+              @click="selectDate(day)"
+            >
+              <p class="text-xs font-medium">{{ formatWeekday(day) }}</p>
+              <p class="text-sm">{{ formatNumericDate(day) }}</p>
+              <span
+                v-if="day === todayDate"
+                class="mt-1 inline-flex rounded-full bg-teal-500 px-2 py-0.5 text-[10px] font-semibold text-white"
+              >
+                Today
+              </span>
+              <div class="mt-2 flex justify-center gap-1">
+                <span
+                  v-for="(opacity, index) in weekHeatBars(day)"
+                  :key="index"
+                  class="h-1.5 w-5 rounded-full bg-teal-500"
+                  :style="{ opacity }"
+                />
+              </div>
+            </button>
+          </div>
+        </div>
+
+        <div v-if="mapViewMode === 'day'" class="relative px-4 py-5">
+          <div
+            v-if="isSelectedToday"
+            class="mb-5 grid grid-cols-[72px_24px_minmax(0,1fr)] items-center gap-3"
+          >
+            <div class="flex justify-end">
+              <span class="whitespace-nowrap rounded-md border border-teal-400 bg-teal-50 px-2 py-1 text-xs font-semibold text-teal-700">
+                {{ currentTimeLabel }}
+              </span>
+            </div>
+            <div class="flex justify-center">
+              <span class="size-2.5 rounded-full bg-teal-500 ring-4 ring-teal-100" />
+            </div>
+            <div class="border-t border-dashed border-teal-500" />
+          </div>
+
+          <div class="space-y-6">
+            <template v-for="period in periods" :key="period">
+              <section v-if="periodHasContent(period)" class="grid grid-cols-[72px_24px_minmax(0,1fr)] gap-3">
+                <div />
+                <div class="relative flex justify-center">
+                  <div class="absolute top-7 h-[calc(100%+1.5rem)] w-px bg-border" />
+                </div>
+                <div>
+                  <div class="mb-3 flex items-center gap-2">
+                    <component :is="periodIcon(period)" class="size-4 text-amber-500" />
+                    <p class="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                      {{ periodLabel(period) }}
+                    </p>
+                  </div>
+
+                  <div v-if="periodSlots(period).length" class="mb-3 flex flex-wrap gap-2">
+                    <button
+                      v-for="slot in periodSlots(period).slice(0, 10)"
+                      :key="slot.start"
+                      class="rounded-md border border-teal-300 bg-teal-50 px-2.5 py-1 text-xs font-medium text-teal-700"
+                      @click="emit('add-block', slot.start)"
+                    >
+                      {{ formatTime(slot.start) }}
+                    </button>
+                    <span
+                      v-if="periodSlots(period).length > 10"
+                      class="rounded-md border bg-muted px-2.5 py-1 text-xs font-medium text-muted-foreground"
+                    >
+                      +{{ periodSlots(period).length - 10 }} more
+                    </span>
+                  </div>
+
+                  <div class="space-y-3">
+                    <div
+                      v-for="block in periodBlocks(period)"
+                      :key="block.id"
+                      class="rounded-lg border px-4 py-3"
+                      :class="blockClass(block.type)"
+                    >
+                      <div class="flex items-center gap-3">
+                        <Coffee v-if="block.type === 'leave' || block.type === 'personal'" class="size-4" />
+                        <Ban v-else-if="block.type === 'unavailable'" class="size-4" />
+                        <CalendarDays v-else class="size-4" />
+                        <div class="min-w-0 flex-1">
+                          <p class="truncate text-sm font-semibold">{{ block.title }}</p>
+                          <p class="text-xs opacity-80">{{ formatTime(block.start) }} - {{ formatTime(block.end) }}</p>
+                        </div>
+                      </div>
+                    </div>
+
+                    <div
+                      v-for="appointment in periodAppointments(period)"
+                      :key="appointment.id"
+                      class="relative"
+                    >
+                      <div class="absolute -left-[120px] top-8 w-[72px] -translate-y-1/2 text-right">
+                        <p class="whitespace-nowrap text-sm font-semibold text-foreground">{{ formatTime(appointment.scheduled_at) }}</p>
+                        <p class="text-xs text-muted-foreground">{{ appointment.duration }} min</p>
+                      </div>
+                      <span
+                        class="absolute -left-[32px] top-8 z-10 size-3 -translate-y-1/2 rounded-full border-2 border-background ring-4"
+                        :class="statusDotClass(appointment.status)"
+                      />
+                      <button
+                        class="w-full rounded-lg border bg-background p-4 text-left shadow-sm transition hover:border-primary/40"
+                        :class="appointment.status === 'checked_in' ? 'border-emerald-300' : appointment.status === 'cancelled' ? 'opacity-60' : ''"
+                        @click="emit('appointment-click', appointment.id)"
+                      >
+                        <div class="grid gap-3 sm:grid-cols-[48px_minmax(0,1fr)_auto] sm:items-center">
+                          <div class="size-12 overflow-hidden rounded-full bg-violet-100">
+                            <img
+                              v-if="appointment.patient_avatar_url"
+                              :src="appointment.patient_avatar_url"
+                              :alt="appointment.patient_name ?? 'Patient'"
+                              class="size-full object-cover"
+                            >
+                            <div v-else class="flex size-full items-center justify-center text-sm font-semibold text-violet-700">
+                              {{ patientInitials(appointment.patient_name) }}
+                            </div>
+                          </div>
+                          <div class="min-w-0">
+                            <p class="truncate text-sm font-semibold">{{ appointment.patient_name ?? 'Patient' }}</p>
+                            <div class="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+                              <span class="inline-flex items-center gap-1">
+                                <UserRound class="size-3.5" />
+                                {{ appointment.reason || 'Consultation' }}
+                              </span>
+                            </div>
+                          </div>
+                          <span class="w-fit rounded-full border px-2.5 py-1 text-xs font-semibold" :class="statusClass(appointment.status)">
+                            {{ statusLabel(appointment.status) }}
+                          </span>
+                        </div>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </section>
+            </template>
+
+            <div
+              v-if="!appointments.length && !availableSlots.length && !selectedDayBlocks.length"
+              class="rounded-lg border border-dashed py-10 text-center text-sm text-muted-foreground"
+            >
+              No appointments, slots, or blocks for this date.
+            </div>
+          </div>
+        </div>
+
+        <div v-else-if="mapViewMode === 'week'" class="p-4">
+          <div class="grid gap-3 lg:grid-cols-7">
+            <div
+              v-for="day in weekDays"
+              :key="day"
+              class="min-h-40 rounded-lg border bg-background p-3"
+              :class="day === todayDate ? 'border-teal-400 bg-teal-50/50' : ''"
+            >
+              <div class="mb-3 flex items-center justify-between gap-2">
+                <div>
+                  <p class="text-xs font-semibold text-muted-foreground">{{ formatWeekday(day) }}</p>
+                  <p class="text-sm font-semibold">{{ formatNumericDate(day) }}</p>
+                </div>
+                <span
+                  v-if="day === todayDate"
+                  class="rounded-full bg-teal-500 px-2 py-0.5 text-[10px] font-semibold text-white"
+                >
+                  Today
+                </span>
+              </div>
+              <div class="space-y-2">
+                <button
+                  v-for="appointment in appointmentsForDay(day).slice(0, 4)"
+                  :key="appointment.id"
+                  class="w-full rounded-md border bg-card px-2 py-2 text-left text-xs shadow-sm"
+                  :class="appointment.status === 'checked_in' ? 'border-emerald-300' : ''"
+                  @click="emit('appointment-click', appointment.id)"
+                >
+                  <p class="truncate font-semibold">{{ formatTime(appointment.scheduled_at) }}</p>
+                  <p class="truncate text-muted-foreground">{{ appointment.patient_name ?? 'Patient' }}</p>
+                </button>
+                <p
+                  v-if="appointmentsForDay(day).length === 0"
+                  class="rounded-md border border-dashed px-2 py-6 text-center text-xs text-muted-foreground"
+                >
+                  {{ statusFilter === 'all' ? 'No appointments' : 'No matches' }}
+                </p>
+                <p
+                  v-if="appointmentsForDay(day).length > 4"
+                  class="text-xs font-medium text-muted-foreground"
+                >
+                  +{{ appointmentsForDay(day).length - 4 }} more
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div v-else class="p-4">
+          <div class="space-y-3">
+            <button
+              v-for="appointment in visibleAppointments"
+              :key="appointment.id"
+              class="w-full rounded-lg border bg-background p-4 text-left shadow-sm transition hover:border-primary/40"
+              @click="emit('appointment-click', appointment.id)"
+            >
+              <div class="grid gap-3 sm:grid-cols-[48px_minmax(0,1fr)_auto] sm:items-center">
+                <div class="size-12 overflow-hidden rounded-full bg-violet-100">
+                  <img
+                    v-if="appointment.patient_avatar_url"
+                    :src="appointment.patient_avatar_url"
+                    :alt="appointment.patient_name ?? 'Patient'"
+                    class="size-full object-cover"
+                  >
+                  <div v-else class="flex size-full items-center justify-center text-sm font-semibold text-violet-700">
+                    {{ patientInitials(appointment.patient_name) }}
+                  </div>
+                </div>
+                <div class="min-w-0">
+                  <p class="truncate text-sm font-semibold">{{ appointment.patient_name ?? 'Patient' }}</p>
+                  <p class="text-xs text-muted-foreground">{{ formatTime(appointment.scheduled_at) }} - {{ formatTime(appointmentEnd(appointment)) }} · {{ appointment.reason || 'Consultation' }}</p>
+                </div>
+                <span class="w-fit rounded-full border px-2.5 py-1 text-xs font-semibold" :class="statusClass(appointment.status)">
+                  {{ statusLabel(appointment.status) }}
+                </span>
+              </div>
+            </button>
+            <div
+              v-if="!visibleAppointments.length"
+              class="rounded-lg border border-dashed py-10 text-center text-sm text-muted-foreground"
+            >
+              {{ statusFilter === 'all' ? 'No appointments for this date.' : 'No appointments match this filter.' }}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <aside class="space-y-4">
+        <section class="rounded-lg border bg-card p-4 shadow-sm">
+          <div class="mb-4 flex items-center justify-between">
+            <div>
+              <h2 class="text-lg font-semibold">Next up</h2>
+              <p class="text-xs text-muted-foreground">{{ selectedDate === todayDate ? 'Today' : formatDate(selectedDate) }}</p>
+            </div>
+            <span v-if="nextUp" class="rounded-full border px-2.5 py-1 text-xs font-semibold" :class="statusClass(nextUp.status)">
+              {{ statusLabel(nextUp.status) }}
+            </span>
+          </div>
+
+          <div v-if="nextUp" class="grid gap-4 sm:grid-cols-[48px_minmax(0,1fr)]">
+            <div class="size-12 overflow-hidden rounded-full bg-orange-100">
+              <img
+                v-if="nextUp.patient_avatar_url"
+                :src="nextUp.patient_avatar_url"
+                :alt="nextUp.patient_name ?? 'Patient'"
+                class="size-full object-cover"
+              >
+              <div v-else class="flex size-full items-center justify-center text-sm font-semibold text-orange-700">
+                {{ patientInitials(nextUp.patient_name) }}
+              </div>
+            </div>
+            <div class="min-w-0">
+              <p class="truncate text-base font-semibold">{{ nextUp.patient_name ?? 'Patient' }}</p>
+              <p class="text-sm text-muted-foreground">{{ nextUp.reason || 'Consultation' }}</p>
+              <div class="mt-3 grid gap-2 text-sm sm:grid-cols-2">
+                <div>
+                  <p class="text-xs text-muted-foreground">Scheduled time</p>
+                  <p class="font-medium">{{ formatTime(nextUp.scheduled_at) }} - {{ formatTime(appointmentEnd(nextUp)) }}</p>
+                </div>
+                <div>
+                  <p class="text-xs text-muted-foreground">Duration</p>
+                  <p class="font-medium">{{ nextUp.duration }} min</p>
+                </div>
+              </div>
+              <p v-if="nextUp.notes" class="mt-3 line-clamp-2 text-sm text-muted-foreground">{{ nextUp.notes }}</p>
+              <div class="mt-4 flex flex-wrap items-center gap-2" @click.stop>
+                <Button
+                  size="sm"
+                  class="h-8 gap-1.5 px-3 text-xs"
+                  @click="emit('check-in', nextUp.id)"
+                >
+                  <LogIn class="size-3.5" />
+                  Check In
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  class="h-8 gap-1.5 px-3 text-xs"
+                  @click="emit('appointment-click', nextUp.id)"
+                >
+                  <CalendarDays class="size-3.5" />
+                  View details
+                </Button>
+                <DropdownMenu>
+                  <DropdownMenuTrigger as-child>
+                    <Button variant="outline" size="icon" class="size-8">
+                      <MoreVertical class="size-3.5" />
+                      <span class="sr-only">Appointment actions</span>
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    <DropdownMenuItem @click="emit('check-in', nextUp.id)">
+                      <LogIn class="mr-2 size-4" />
+                      Check in
+                    </DropdownMenuItem>
+                    <DropdownMenuItem @click="emit('no-show', nextUp.id)">
+                      <UserX class="mr-2 size-4" />
+                      Mark no-show
+                    </DropdownMenuItem>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem
+                      class="text-destructive focus:text-destructive"
+                      @click="emit('cancel', nextUp.id)"
+                    >
+                      <X class="mr-2 size-4" />
+                      Cancel
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
+            </div>
+          </div>
+          <div v-else class="rounded-lg border border-dashed py-8 text-center text-sm text-muted-foreground">
+            No upcoming appointment.
+          </div>
+        </section>
+
+        <div class="space-y-4">
+          <section class="rounded-lg border bg-card p-4 shadow-sm">
+            <div class="mb-3 flex items-center justify-between gap-3">
+              <div>
+                <h2 class="text-lg font-semibold">Availability</h2>
+                <p class="text-xs text-muted-foreground">{{ formatDate(selectedDate) }}</p>
+              </div>
+              <Button variant="outline" size="icon" class="size-8" :disabled="isLoading" @click="loadStudioData">
+                <RefreshCw class="size-3.5" :class="isLoading ? 'animate-spin' : ''" />
+              </Button>
+            </div>
+            <div class="mb-3 grid grid-cols-3 gap-2 text-sm">
+              <div>
+                <p class="text-xl font-semibold">{{ slotStats.total }}</p>
+                <p class="text-xs text-muted-foreground">Total</p>
+              </div>
+              <div>
+                <p class="text-xl font-semibold">{{ slotStats.available }}</p>
+                <p class="text-xs text-muted-foreground">Open</p>
+              </div>
+              <div>
+                <p class="text-xl font-semibold">{{ slotStats.booked }}</p>
+                <p class="text-xs text-muted-foreground">Booked</p>
+              </div>
+            </div>
+            <div v-if="availableSlots.length" class="flex flex-wrap gap-1.5">
+              <button
+                v-for="slot in availableSlots.slice(0, 8)"
+                :key="slot.start"
+                class="rounded-md border border-teal-300 bg-teal-50 px-2 py-1 text-xs font-medium text-teal-700"
+                @click="emit('add-block', slot.start)"
+              >
+                {{ formatTime(slot.start) }}
+              </button>
+              <span
+                v-if="availableSlots.length > 8"
+                class="rounded-md border bg-muted px-2 py-1 text-xs font-medium text-muted-foreground"
+              >
+                +{{ availableSlots.length - 8 }} more
+              </span>
+            </div>
+            <div v-else class="rounded-lg border border-dashed py-6 text-center text-sm text-muted-foreground">
+              No open slots for this date.
+            </div>
+          </section>
+
+          <section class="rounded-lg border bg-card p-4 shadow-sm">
+            <div class="mb-3">
+              <h2 class="text-lg font-semibold">Week load</h2>
+              <p class="text-xs text-muted-foreground">{{ weekLabel }}</p>
+            </div>
+            <div class="grid grid-cols-7 gap-2">
+              <div v-for="day in weekDays" :key="day" class="text-center">
+                <p class="text-xs font-medium">{{ formatWeekday(day) }}</p>
+                <p class="text-xs text-muted-foreground">{{ formatNumericDate(day) }}</p>
+                <div class="mt-2 space-y-1">
+                  <span
+                    v-for="(opacity, index) in weekHeatBars(day)"
+                    :key="index"
+                    class="mx-auto block h-1.5 w-8 rounded-full bg-teal-500"
+                    :style="{ opacity }"
+                  />
+                </div>
+              </div>
+            </div>
+            <div class="mt-4 flex items-center gap-2 text-xs text-muted-foreground">
+              <span>Low</span>
+              <span class="size-2 rounded-full bg-teal-200" />
+              <span class="size-2 rounded-full bg-teal-300" />
+              <span class="size-2 rounded-full bg-teal-500" />
+              <span class="size-2 rounded-full bg-teal-700" />
+              <span>High</span>
+            </div>
+          </section>
+
+          <section class="rounded-lg border bg-card p-4 shadow-sm">
+            <div class="mb-3 flex items-center justify-between">
+              <div>
+                <h2 class="text-lg font-semibold">Upcoming blocks</h2>
+                <p class="text-xs text-muted-foreground">{{ upcomingBlockRangeLabel }}</p>
+              </div>
+              <span class="text-xs text-muted-foreground">{{ upcomingBlocks.length }}</span>
+            </div>
+            <div class="max-h-72 space-y-2 overflow-y-auto pr-1">
+              <div
+                v-for="block in upcomingBlocks.slice(0, 8)"
+                :key="block.id"
+                class="rounded-lg border px-3 py-2"
+                :class="blockClass(block.type)"
+              >
+                <div class="grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-start">
+                  <div class="min-w-0 space-y-0.5">
+                    <p class="truncate text-sm font-semibold">{{ block.title }}</p>
+                    <p class="whitespace-nowrap text-xs opacity-80">
+                      {{ formatShortDate(toLocalDate(new Date(block.start))) }} · {{ formatTime(block.start) }} - {{ formatTime(block.end) }}
+                    </p>
+                  </div>
+                  <p class="min-w-0 truncate text-xs font-medium opacity-80 sm:max-w-40 sm:text-right">{{ block.user_name ?? 'Clinic' }}</p>
+                </div>
+              </div>
+              <div v-if="!upcomingBlocks.length" class="rounded-lg border border-dashed py-6 text-center text-sm text-muted-foreground">
+                No blocks in the next 30 days.
+              </div>
+            </div>
+          </section>
+        </div>
+
+        <section class="rounded-lg border bg-card p-4 shadow-sm">
+          <div class="mb-3 flex items-center gap-2">
+            <AlertTriangle class="size-4 text-amber-500" />
+            <h2 class="text-lg font-semibold">Slot health</h2>
+          </div>
+          <div class="grid grid-cols-4 gap-3">
+            <div>
+              <p class="text-2xl font-semibold">{{ slotStats.total }}</p>
+              <p class="text-xs text-muted-foreground">Total</p>
+            </div>
+            <div>
+              <p class="text-2xl font-semibold">{{ slotStats.booked }}</p>
+              <p class="text-xs text-muted-foreground">Booked</p>
+            </div>
+            <div>
+              <p class="text-2xl font-semibold">{{ slotStats.available }}</p>
+              <p class="text-xs text-muted-foreground">Available</p>
+            </div>
+            <div>
+              <p class="text-2xl font-semibold">{{ slotStats.utilization }}%</p>
+              <p class="text-xs text-muted-foreground">Utilized</p>
+            </div>
+          </div>
+          <div class="mt-4 h-2 overflow-hidden rounded-full bg-muted">
+            <div class="h-full rounded-full bg-teal-500" :style="{ width: `${slotStats.utilization}%` }" />
+          </div>
+        </section>
+      </aside>
+    </div>
+  </div>
+</template>

--- a/src/domains/schedule/views/ScheduleView.vue
+++ b/src/domains/schedule/views/ScheduleView.vue
@@ -1,20 +1,9 @@
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted, computed, nextTick, watch } from 'vue'
+import { ref, computed, watch } from 'vue'
 import FeatureGate from '@/components/shared/FeatureGate.vue'
 import { toast } from 'vue-sonner'
-import { CalendarDate, type DateValue, getLocalTimeZone, today } from '@internationalized/date'
-import type { DateRange } from 'reka-ui'
-import { Calendar as CalendarLucide, CalendarCheck, CalendarIcon, CalendarX, LoaderCircle, Plus, RefreshCw } from 'lucide-vue-next'
+import { AlertTriangle, LoaderCircle, RefreshCw } from 'lucide-vue-next'
 import { Button } from '@/components/ui/button'
-import { Calendar as ShadcnCalendar } from '@/components/ui/calendar'
-import { RangeCalendar } from '@/components/ui/range-calendar'
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
-import {
-  Tabs,
-  TabsContent,
-  TabsList,
-  TabsTrigger,
-} from '@/components/ui/tabs'
 import {
   Dialog,
   DialogContent,
@@ -24,93 +13,39 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { useAuthStore } from '@/domains/auth/stores/authStore'
-import { useCentrifugo } from '@/composables/useCentrifugo'
 import { useScheduleStore } from '../stores/scheduleStore'
-import ScheduleCalendar from '../components/ScheduleCalendar.vue'
+import ScheduleAvailabilityStudio from '../components/ScheduleAvailabilityStudio.vue'
 import WeeklyScheduleEditor from '../components/WeeklyScheduleEditor.vue'
-import CalendarBlockList from '../components/CalendarBlockList.vue'
 import CalendarBlockForm from '../components/CalendarBlockForm.vue'
-import AvailabilityGrid from '../components/AvailabilityGrid.vue'
 import type { CalendarBlock, StoreCalendarBlockPayload, UpsertWorkingSchedulePayload, UpdateCalendarBlockPayload } from '../types/schedule.types'
 import { appointmentApi } from '@/domains/appointment/api/appointmentApi'
-import AppointmentBookingWizard from '@/domains/appointment/components/AppointmentBookingWizard.vue'
 import AppointmentDetailSheet from '@/domains/appointment/components/AppointmentDetailSheet.vue'
 import type { AppointmentResponse } from '@/domains/appointment/types/appointment.types'
 
 const authStore = useAuthStore()
 const store = useScheduleStore()
-const { connect, subscribe, getSubscription } = useCentrifugo()
 
 const scheduleTimezone = computed(() => store.schedule?.timezone ?? 'Asia/Manila')
 
 const userId = computed(() => authStore.user?.id ?? '')
 
-// Sidebar mini calendar
-const sidebarDate = ref<DateValue>(today(getLocalTimeZone()))
-const scheduleCalendarRef = ref<InstanceType<typeof ScheduleCalendar> | null>(null)
-const activeTab = ref('calendar')
-
-function handleSidebarDateChange(date: DateValue) {
-  sidebarDate.value = date
-  const dateStr = calendarDateToIso(date)
-  // Navigate FullCalendar if on calendar tab
-  if (activeTab.value === 'calendar') {
-    scheduleCalendarRef.value?.goToDate(dateStr)
-  }
-  // Update availability date if on availability tab
-  if (activeTab.value === 'availability') {
-    availabilityDateValue.value = date
-    loadAvailability()
-  }
-}
-
 // Working hours tab
 const scheduleError = ref<string | null>(null)
+const showWorkingHoursDialog = ref(false)
+const studioRefreshKey = ref(0)
 
 // Calendar blocks tab
-const blocksError = ref<string | null>(null)
 const showBlockForm = ref(false)
 const editingBlock = ref<CalendarBlock | null>(null)
 const isSavingBlock = ref(false)
-const deleteTarget = ref<CalendarBlock | null>(null)
-const showDeleteDialog = ref(false)
-const isDeleting = ref(false)
-
-// Month/range for blocks list tab: default to current month
-function getMonthDateRange(): DateRange {
-  const now = today(getLocalTimeZone())
-  return {
-    start: new CalendarDate(now.year, now.month, 1),
-    end: new CalendarDate(now.year, now.month, new Date(now.year, now.month, 0).getDate()),
-  }
-}
-
-const blockFilterRange = ref<DateRange>(getMonthDateRange())
-
-function calendarDateToIso(d: DateValue): string {
-  return `${d.year}-${String(d.month).padStart(2, '0')}-${String(d.day).padStart(2, '0')}`
-}
-
-function formatDisplayDate(d: DateValue): string {
-  const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
-  return `${months[d.month - 1]} ${d.day}, ${d.year}`
-}
-
-const blockFilterLabel = computed(() => {
-  if (!blockFilterRange.value.start || !blockFilterRange.value.end) return 'Select date range'
-  return `${formatDisplayDate(blockFilterRange.value.start)} – ${formatDisplayDate(blockFilterRange.value.end)}`
-})
-
-// Availability tab
-const availabilityError = ref<string | null>(null)
-const availabilityDateValue = ref<DateValue>(today(getLocalTimeZone()))
-const availabilityDateLabel = computed(() => formatDisplayDate(availabilityDateValue.value))
 
 // --- Appointment interactions from calendar ---
-const showBookingWizard = ref(false)
 const prefillDateTime = ref<string | null>(null)
 const showDetailSheet = ref(false)
 const selectedAppointment = ref<AppointmentResponse | null>(null)
+const cancelTargetId = ref<string | null>(null)
+const showCancelDialog = ref(false)
+const isCancelling = ref(false)
 const scrollContainerRef = ref<HTMLElement | null>(null)
 let savedContainerScroll = 0
 let savedWindowScroll = 0
@@ -130,41 +65,15 @@ function restoreScroll() {
   }, 50)
 }
 
-// Slot action picker
-const showSlotActionPicker = ref(false)
-const slotActionDateTime = ref<string | null>(null)
-
-function handleSlotSelect(dateTime: string) {
+function handleStudioAddBlock(dateTime: string | null) {
   saveScroll()
-  slotActionDateTime.value = dateTime
-  showSlotActionPicker.value = true
-}
-
-function slotActionBookAppointment() {
-  showSlotActionPicker.value = false
-  prefillDateTime.value = slotActionDateTime.value
-  showBookingWizard.value = true
-}
-
-function slotActionAddBlock() {
-  showSlotActionPicker.value = false
-  prefillDateTime.value = slotActionDateTime.value
+  prefillDateTime.value = dateTime
   editingBlock.value = null
   showBlockForm.value = true
 }
 
-function formatSlotTime(iso: string | null): string {
-  if (!iso) return ''
-  return new Date(iso).toLocaleString('en-US', {
-    weekday: 'short', month: 'short', day: 'numeric',
-    hour: 'numeric', minute: '2-digit', hour12: true,
-  })
-}
-
 // Restore scroll position after dialog closes
-watch(showBookingWizard, (open) => { if (!open) restoreScroll() })
 watch(showDetailSheet, (open) => { if (!open) restoreScroll() })
-watch(showSlotActionPicker, (open) => { if (!open) restoreScroll() })
 watch(showBlockForm, (open) => { if (!open) restoreScroll() })
 
 async function handleAppointmentClick(id: string) {
@@ -178,14 +87,57 @@ async function handleAppointmentClick(id: string) {
   }
 }
 
-function handleAppointmentUpdated() {
-  if (calendarRange.start) {
-    loadAppointmentsForRange(calendarRange.start, calendarRange.end)
+async function handleCheckIn(id: string) {
+  try {
+    await appointmentApi.checkIn(id)
+    toast.success('Patient checked in')
+    if (selectedAppointment.value?.id === id) {
+      const res = await appointmentApi.get(id)
+      selectedAppointment.value = res.data
+    }
+    studioRefreshKey.value += 1
+  } catch {
+    toast.error('Failed to check in')
   }
 }
 
-function handleAppointmentCreated() {
-  handleAppointmentUpdated()
+async function handleNoShow(id: string) {
+  try {
+    await appointmentApi.noShow(id)
+    toast.success('Appointment marked as no-show')
+    if (selectedAppointment.value?.id === id) {
+      const res = await appointmentApi.get(id)
+      selectedAppointment.value = res.data
+    }
+    studioRefreshKey.value += 1
+  } catch {
+    toast.error('Failed to mark no-show')
+  }
+}
+
+function requestCancel(id: string) {
+  cancelTargetId.value = id
+  showCancelDialog.value = true
+}
+
+async function confirmCancel() {
+  if (!cancelTargetId.value) return
+  isCancelling.value = true
+  try {
+    await appointmentApi.cancel(cancelTargetId.value)
+    toast.success('Appointment cancelled')
+    if (selectedAppointment.value?.id === cancelTargetId.value) {
+      const res = await appointmentApi.get(cancelTargetId.value)
+      selectedAppointment.value = res.data
+    }
+    showCancelDialog.value = false
+    studioRefreshKey.value += 1
+  } catch {
+    toast.error('Failed to cancel appointment')
+  } finally {
+    isCancelling.value = false
+    cancelTargetId.value = null
+  }
 }
 
 // --- Working Hours ---
@@ -204,77 +156,15 @@ async function handleSaveSchedule(payload: UpsertWorkingSchedulePayload) {
   try {
     await store.saveSchedule(userId.value, payload)
     toast.success('Working schedule saved')
-    // Refresh calendar blocks to reflect new schedule
-    if (calendarRange.start) {
-      loadBlocksForRange(calendarRange.start, calendarRange.end)
-    }
+    studioRefreshKey.value += 1
   } catch {
     toast.error('Failed to save schedule')
   }
 }
 
-// --- Calendar Preview ---
-const calendarRange = { start: '', end: '' }
-const calendarAppointments = ref<AppointmentResponse[]>([])
-
-function handleCalendarDateRange(start: string, end: string) {
-  calendarRange.start = start
-  calendarRange.end = end
-  loadBlocksForRange(start, end)
-  loadAppointmentsForRange(start, end)
-}
-
-async function loadBlocksForRange(start: string, end: string) {
-  if (!userId.value) return
-  try {
-    await store.fetchBlocks(userId.value, start, end)
-  } catch {
-    // Calendar will just show no blocks — not critical
-  }
-}
-
-async function loadAppointmentsForRange(start: string, end: string) {
-  if (!userId.value) return
-  try {
-    const response = await appointmentApi.list(1, 200, {
-      doctor_id: userId.value,
-      start_date: start,
-      end_date: end,
-    })
-    calendarAppointments.value = response.data
-  } catch {
-    calendarAppointments.value = []
-  }
-}
-
-function handleCalendarBlockClick(block: CalendarBlock) {
-  editingBlock.value = block
-  showBlockForm.value = true
-}
-
-// --- Calendar Blocks List ---
-async function loadBlocks() {
-  if (!userId.value || !blockFilterRange.value.start || !blockFilterRange.value.end) return
-  blocksError.value = null
-  try {
-    await store.fetchBlocks(
-      userId.value,
-      calendarDateToIso(blockFilterRange.value.start),
-      calendarDateToIso(blockFilterRange.value.end),
-    )
-  } catch {
-    blocksError.value = 'Failed to load calendar blocks.'
-  }
-}
-
-function openCreateBlock() {
-  editingBlock.value = null
-  showBlockForm.value = true
-}
-
-function openEditBlock(block: CalendarBlock) {
-  editingBlock.value = block
-  showBlockForm.value = true
+function openWorkingHours() {
+  showWorkingHoursDialog.value = true
+  loadSchedule()
 }
 
 async function handleBlockSave(payload: StoreCalendarBlockPayload | UpdateCalendarBlockPayload) {
@@ -288,253 +178,62 @@ async function handleBlockSave(payload: StoreCalendarBlockPayload | UpdateCalend
       toast.success('Block added')
     }
     showBlockForm.value = false
+    studioRefreshKey.value += 1
   } catch {
     toast.error(editingBlock.value ? 'Failed to update block' : 'Failed to add block')
   } finally {
     isSavingBlock.value = false
   }
 }
-
-function confirmDeleteBlock(id: string) {
-  const block = store.blocks.find((b) => b.id === id)
-  if (!block) return
-  deleteTarget.value = block
-  showDeleteDialog.value = true
-}
-
-async function handleDeleteBlock() {
-  if (!deleteTarget.value) return
-  isDeleting.value = true
-  try {
-    await store.deleteBlock(deleteTarget.value.id)
-    toast.success('Block deleted')
-    showDeleteDialog.value = false
-  } catch {
-    toast.error('Failed to delete block')
-  } finally {
-    isDeleting.value = false
-  }
-}
-
-// --- Availability ---
-async function loadAvailability() {
-  if (!userId.value) return
-  availabilityError.value = null
-  try {
-    await store.fetchAvailability(userId.value, calendarDateToIso(availabilityDateValue.value))
-  } catch {
-    availabilityError.value = 'Failed to load availability.'
-  }
-}
-
-// Tab change handler — lazy load on first visit
-const loadedTabs = ref(new Set<string>(['calendar']))
-
-function onTabChange(tab: string) {
-  activeTab.value = tab
-  if (loadedTabs.value.has(tab)) return
-  loadedTabs.value.add(tab)
-  if (tab === 'blocks') loadBlocks()
-  if (tab === 'availability') loadAvailability()
-}
-
-// Real-time appointment updates
-const appointmentChannel = computed(() => {
-  const clinicId = authStore.currentClinic?.id
-  return clinicId ? `clinic:${clinicId}:appointments` : null
-})
-
-function onAppointmentEvent() {
-  if (calendarRange.start) {
-    loadAppointmentsForRange(calendarRange.start, calendarRange.end)
-  }
-}
-
-onMounted(() => {
-  loadSchedule()
-  if (appointmentChannel.value) {
-    connect()
-    subscribe(appointmentChannel.value, onAppointmentEvent)
-  }
-})
-
-onUnmounted(() => {
-  if (appointmentChannel.value) {
-    getSubscription(appointmentChannel.value)?.removeListener('publication', onAppointmentEvent)
-  }
-})
 </script>
 
 <template>
   <FeatureGate feature="schedule" label="Schedule">
-  <div class="-mx-4 -mb-4 flex min-h-0 flex-1 flex-col gap-0 md:flex-row">
-    <!-- Left panel -->
-    <div class="hidden shrink-0 flex-col gap-4 border-r p-4 md:flex md:w-72 md:p-5">
-      <div class="flex items-center gap-3">
-        <div class="flex size-8 items-center justify-center rounded-lg bg-primary/10">
-          <CalendarLucide class="size-4 text-primary" />
-        </div>
-        <div>
-          <h1 class="text-sm font-semibold">Schedule</h1>
-          <p class="text-xs text-muted-foreground truncate">{{ authStore.user?.name ?? authStore.user?.email ?? '—' }}</p>
-        </div>
-      </div>
-
-      <!-- Mini calendar for date navigation -->
-      <ShadcnCalendar
-        v-model="sidebarDate"
-        class="rounded-md border p-2"
-        @update:model-value="handleSidebarDateChange"
+  <div class="-mx-4 -mb-4 flex min-h-0 flex-1 flex-col gap-0">
+    <div ref="scrollContainerRef" class="flex flex-1 flex-col overflow-y-auto p-4 md:p-6">
+      <ScheduleAvailabilityStudio
+        :user-id="userId"
+        :refresh-key="studioRefreshKey"
+        @appointment-click="handleAppointmentClick"
+        @add-block="handleStudioAddBlock"
+        @check-in="handleCheckIn"
+        @cancel="requestCancel"
+        @no-show="handleNoShow"
+        @working-hours="openWorkingHours"
       />
-
-      <Button class="w-full" size="sm" @click="openCreateBlock">
-        <Plus class="size-4" />
-        Add Block
-      </Button>
-    </div>
-
-    <!-- Right panel -->
-    <div ref="scrollContainerRef" class="flex flex-1 flex-col overflow-y-auto p-4 md:p-8">
-      <Tabs default-value="calendar" @update:model-value="onTabChange(String($event))">
-        <div class="mb-6 flex flex-wrap items-center gap-3">
-          <TabsList class="w-full justify-start sm:w-auto">
-            <TabsTrigger value="calendar">Calendar</TabsTrigger>
-            <TabsTrigger value="working-hours">Working Hours</TabsTrigger>
-            <TabsTrigger value="blocks">Blocks</TabsTrigger>
-            <TabsTrigger value="availability">Availability</TabsTrigger>
-          </TabsList>
-          <Button size="sm" class="ml-auto h-8 md:hidden" @click="openCreateBlock">
-            <Plus class="size-3.5" />
-            Add Block
-          </Button>
-        </div>
-
-        <!-- Calendar Preview tab -->
-        <TabsContent value="calendar">
-          <ScheduleCalendar
-            ref="scheduleCalendarRef"
-            :schedule="store.schedule"
-            :blocks="store.blocks"
-            :appointments="calendarAppointments"
-            :is-loading="store.isLoadingSchedule"
-            @date-range-change="handleCalendarDateRange"
-            @block-click="handleCalendarBlockClick"
-            @slot-select="handleSlotSelect"
-            @appointment-click="handleAppointmentClick"
-            @appointment-updated="handleAppointmentUpdated"
-          />
-        </TabsContent>
-
-        <!-- Working Hours tab -->
-        <TabsContent value="working-hours">
-          <div v-if="store.isLoadingSchedule" class="flex items-center justify-center py-12">
-            <LoaderCircle class="size-6 animate-spin text-muted-foreground" />
-          </div>
-          <div
-            v-else-if="scheduleError"
-            role="alert"
-            class="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2.5 text-sm text-destructive"
-          >
-            {{ scheduleError }}
-            <Button variant="outline" size="sm" class="mt-2" @click="loadSchedule">
-              <RefreshCw class="size-3.5" />
-              Try again
-            </Button>
-          </div>
-          <WeeklyScheduleEditor
-            v-else
-            :schedule="store.schedule"
-            :is-saving="store.isSavingSchedule"
-            @save="handleSaveSchedule"
-          />
-        </TabsContent>
-
-        <!-- Calendar Blocks tab -->
-        <TabsContent value="blocks">
-          <!-- Block range selector -->
-          <div class="mb-4 flex flex-wrap items-center gap-3">
-            <Popover>
-              <PopoverTrigger as-child>
-                <Button variant="outline" class="h-8 justify-start text-left text-sm font-normal">
-                  <CalendarIcon class="mr-2 size-3.5 text-muted-foreground" />
-                  {{ blockFilterLabel }}
-                </Button>
-              </PopoverTrigger>
-              <PopoverContent class="w-auto p-0" align="start">
-                <RangeCalendar v-model="blockFilterRange" :number-of-months="2" />
-              </PopoverContent>
-            </Popover>
-            <Button variant="outline" size="sm" class="h-8" @click="loadBlocks">
-              <RefreshCw class="size-3.5" />
-              Refresh
-            </Button>
-            <Button size="sm" class="ml-auto h-8" @click="openCreateBlock">
-              <Plus class="size-3.5" />
-              Add block
-            </Button>
-          </div>
-
-          <div
-            v-if="blocksError"
-            role="alert"
-            class="mb-4 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2.5 text-sm text-destructive"
-          >
-            {{ blocksError }}
-            <Button variant="outline" size="sm" class="mt-2" @click="loadBlocks">
-              <RefreshCw class="size-3.5" />
-              Try again
-            </Button>
-          </div>
-
-          <CalendarBlockList
-            :blocks="store.blocks"
-            :is-loading="store.isLoadingBlocks"
-            :timezone="scheduleTimezone"
-            @edit="openEditBlock"
-            @delete="confirmDeleteBlock"
-          />
-        </TabsContent>
-
-        <!-- Availability tab -->
-        <TabsContent value="availability">
-          <div class="mb-4 flex flex-wrap items-center gap-3">
-            <Popover>
-              <PopoverTrigger as-child>
-                <Button variant="outline" class="h-8 justify-start text-left text-sm font-normal">
-                  <CalendarIcon class="mr-2 size-3.5 text-muted-foreground" />
-                  {{ availabilityDateLabel }}
-                </Button>
-              </PopoverTrigger>
-              <PopoverContent class="w-auto p-0" align="start">
-                <ShadcnCalendar v-model="availabilityDateValue" />
-              </PopoverContent>
-            </Popover>
-            <Button variant="outline" size="sm" class="h-8" @click="loadAvailability">
-              <RefreshCw class="size-3.5" />
-              Check availability
-            </Button>
-          </div>
-
-          <div
-            v-if="availabilityError"
-            role="alert"
-            class="mb-4 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2.5 text-sm text-destructive"
-          >
-            {{ availabilityError }}
-            <Button variant="outline" size="sm" class="mt-2" @click="loadAvailability">
-              <RefreshCw class="size-3.5" />
-              Try again
-            </Button>
-          </div>
-
-          <AvailabilityGrid
-            :slots="store.availability?.slots ?? []"
-            :is-loading="store.isLoadingAvailability"
-          />
-        </TabsContent>
-      </Tabs>
     </div>
   </div>
+
+  <Dialog v-model:open="showWorkingHoursDialog">
+    <DialogContent class="max-h-[85vh] overflow-y-auto sm:max-w-4xl">
+      <DialogHeader>
+        <DialogTitle>Working hours</DialogTitle>
+        <DialogDescription>
+          Manage regular clinic hours and breaks for this schedule.
+        </DialogDescription>
+      </DialogHeader>
+      <div v-if="store.isLoadingSchedule" class="flex items-center justify-center py-12">
+        <LoaderCircle class="size-6 animate-spin text-muted-foreground" />
+      </div>
+      <div
+        v-else-if="scheduleError"
+        role="alert"
+        class="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2.5 text-sm text-destructive"
+      >
+        {{ scheduleError }}
+        <Button variant="outline" size="sm" class="mt-2" @click="loadSchedule">
+          <RefreshCw class="size-3.5" />
+          Try again
+        </Button>
+      </div>
+      <WeeklyScheduleEditor
+        v-else
+        :schedule="store.schedule"
+        :is-saving="store.isSavingSchedule"
+        @save="handleSaveSchedule"
+      />
+    </DialogContent>
+  </Dialog>
 
   <!-- Calendar Block Form dialog -->
   <CalendarBlockForm
@@ -548,79 +247,38 @@ onUnmounted(() => {
     @save="handleBlockSave"
   />
 
-  <!-- Delete confirmation dialog -->
-  <Dialog v-model:open="showDeleteDialog">
-    <DialogContent class="sm:max-w-md">
-      <DialogHeader>
-        <DialogTitle>Delete Calendar Block</DialogTitle>
-        <DialogDescription>
-          Are you sure you want to delete <strong>{{ deleteTarget?.title }}</strong>?
-          This action cannot be undone.
-        </DialogDescription>
-      </DialogHeader>
-      <DialogFooter class="gap-2 sm:gap-0">
-        <Button variant="outline" @click="showDeleteDialog = false">Cancel</Button>
-        <Button variant="destructive" :disabled="isDeleting" @click="handleDeleteBlock">
-          <LoaderCircle v-if="isDeleting" class="size-4 animate-spin" />
-          Delete
-        </Button>
-      </DialogFooter>
-    </DialogContent>
-  </Dialog>
-  <!-- Booking wizard (doctor pre-selected) -->
-  <AppointmentBookingWizard
-    :open="showBookingWizard"
-    :prefill-date-time="prefillDateTime"
-    :prefill-doctor-id="userId"
-    :prefill-doctor-name="authStore.user?.name ?? ''"
-    @update:open="(val) => { showBookingWizard = val; if (!val) prefillDateTime = null }"
-    @created="handleAppointmentCreated"
-  />
-
-  <!-- Slot action picker -->
-  <Dialog v-model:open="showSlotActionPicker">
-    <DialogContent class="sm:max-w-xs" @close-auto-focus.prevent>
-      <DialogHeader>
-        <DialogTitle class="text-sm">What would you like to create?</DialogTitle>
-        <p v-if="slotActionDateTime" class="text-xs text-muted-foreground">
-          {{ formatSlotTime(slotActionDateTime) }}
-        </p>
-      </DialogHeader>
-      <div class="flex flex-col gap-2">
-        <button
-          class="flex items-center gap-3 rounded-lg border p-3 text-left transition-colors hover:bg-accent"
-          @click="slotActionBookAppointment"
-        >
-          <div class="flex size-8 items-center justify-center rounded-full bg-primary/10">
-            <CalendarCheck class="size-4 text-primary" />
-          </div>
-          <div>
-            <p class="text-sm font-medium">Book Appointment</p>
-            <p class="text-xs text-muted-foreground">Schedule a patient visit</p>
-          </div>
-        </button>
-        <button
-          class="flex items-center gap-3 rounded-lg border p-3 text-left transition-colors hover:bg-accent"
-          @click="slotActionAddBlock"
-        >
-          <div class="flex size-8 items-center justify-center rounded-full bg-amber-500/10">
-            <CalendarX class="size-4 text-amber-600" />
-          </div>
-          <div>
-            <p class="text-sm font-medium">Add Time Block</p>
-            <p class="text-xs text-muted-foreground">Leave, meeting, or unavailable</p>
-          </div>
-        </button>
-      </div>
-    </DialogContent>
-  </Dialog>
-
   <!-- Appointment detail sheet -->
   <AppointmentDetailSheet
     :open="showDetailSheet"
     :appointment="selectedAppointment"
     :can-manage="true"
     @update:open="showDetailSheet = $event"
+    @check-in="handleCheckIn"
+    @cancel="requestCancel"
+    @no-show="handleNoShow"
   />
+
+  <Dialog v-model:open="showCancelDialog">
+    <DialogContent class="sm:max-w-md">
+      <DialogHeader>
+        <DialogTitle class="flex items-center gap-2">
+          <AlertTriangle class="size-5 text-destructive" />
+          Cancel Appointment
+        </DialogTitle>
+        <DialogDescription>
+          Are you sure you want to cancel this appointment? This action cannot be undone.
+        </DialogDescription>
+      </DialogHeader>
+      <DialogFooter class="gap-2 sm:gap-0">
+        <Button variant="outline" :disabled="isCancelling" @click="showCancelDialog = false">
+          Keep Appointment
+        </Button>
+        <Button variant="destructive" :disabled="isCancelling" @click="confirmCancel">
+          <LoaderCircle v-if="isCancelling" class="size-3.5 animate-spin" />
+          {{ isCancelling ? 'Cancelling...' : 'Cancel Appointment' }}
+        </Button>
+      </DialogFooter>
+    </DialogContent>
+  </Dialog>
   </FeatureGate>
 </template>

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -100,8 +100,14 @@ async function handleResponse<T>(
   retry: () => Promise<Response>,
 ): Promise<T> {
   if (response.status === 503) {
-    isMaintenanceMode.value = true
-    throw new HttpError(503, 'Service temporarily unavailable')
+    const data = await parseBody(response)
+    const errorCode = typeof data === 'object' && data !== null && 'error_code' in data
+      ? (data as { error_code?: unknown }).error_code
+      : null
+    if (typeof data === 'string' || errorCode === 'maintenance_mode') {
+      isMaintenanceMode.value = true
+    }
+    throw new HttpError(503, 'Service temporarily unavailable', data)
   }
 
   if (response.status === 401) {

--- a/src/lib/vitals.ts
+++ b/src/lib/vitals.ts
@@ -276,14 +276,17 @@ export function classifyRr(
   return { label: 'Elevated', color: 'text-red-600', severity: 'high' }
 }
 
+export type BloodGlucoseTiming = 'fasting' | 'random' | 'postprandial' | 'pre_meal' | 'post_meal' | 'bedtime'
+
 /**
- * Blood sugar classification (mg/dL, fasting).
- * < 70 Hypoglycemia, 70-100 Normal, 101-125 Pre-diabetic, > 125 Diabetic
+ * Blood sugar classification (mg/dL). Fasting/pre-meal uses the tighter
+ * 100/126 thresholds; random/post-meal/bedtime uses 140/200.
  * Pass patientAgeDays + ageRanges from specialty config to apply age-appropriate thresholds.
  */
 export function classifyBloodSugar(
   bs: number | null | undefined,
   config: VitalsConfig = DEFAULT_VITALS_CONFIG,
+  timing?: BloodGlucoseTiming | string | null,
   patientAgeDays?: number,
   ageRanges?: VitalAgeBasedRange[],
 ): VitalStatus | null {
@@ -296,9 +299,15 @@ export function classifyBloodSugar(
     if (bs <= high) return NORMAL
     return { label: 'High', color: 'text-red-600', severity: 'high' }
   }
-  if (bs < config.bs_hypoglycemia)   return { label: 'Low (Hypoglycemia)', color: 'text-blue-600', severity: 'low' }
-  if (bs <= config.bs_normal) return NORMAL
-  if (bs <= config.bs_prediabetic) return { label: 'Pre-diabetic', color: 'text-amber-600', severity: 'elevated' }
+  const isFastingLike = timing === 'fasting' || timing === 'pre_meal'
+  if (bs < config.bs_hypoglycemia) return { label: 'Low (Hypoglycemia)', color: 'text-blue-600', severity: 'low' }
+  if (isFastingLike) {
+    if (bs <= config.bs_normal) return NORMAL
+    if (bs <= config.bs_prediabetic) return { label: 'Pre-diabetic', color: 'text-amber-600', severity: 'elevated' }
+    return { label: 'High (Diabetic)', color: 'text-red-600', severity: 'high' }
+  }
+  if (bs < 140) return NORMAL
+  if (bs < 200) return { label: 'Pre-diabetic', color: 'text-amber-600', severity: 'elevated' }
   return { label: 'High (Diabetic)', color: 'text-red-600', severity: 'high' }
 }
 


### PR DESCRIPTION
## Summary
- **Agent harness UI — SOAP draft section + auto-display-line wiring** (`ebfd5fb`)
  - New `SoapNoteSection` component (4-section editor); calls `POST /encounters/{uuid}/soap-draft`
  - `FinalizeModal` blocks finalize until SOAP note is non-empty (where required)
  - Patient timeline cards prefer `auto_display_line` over manual `display_line`
  - New `encounter.timeline_updated` realtime event refreshes cards in-place
- **Appointment Board — kanban view + booking-wizard refresh** (`e65a4da`)
  - New `AppointmentBoard` swimlane component (drag-to-update, avatar chips)
  - `AppointmentListView` gains board/list toggle
  - `DateSlotPicker` collapses long unavailable runs into "next available" jump
  - `PatientSelector` caches recent results
  - New e2e spec
- **Schedule Studio — availability editor rebuild** (`da3988f`)
  - New `ScheduleAvailabilityStudio` (~1.4k LOC, single source of truth)
  - Drag-to-resize, snap-to-quarter-hour, real-time conflict detection vs CalendarBlocks, bulk-apply
  - `ScheduleView` slimmed to a tab shell
- **Patient list rebuild + Profile Completeness ring** (`aa8b74b`)
  - Combined search across name/contact/ID/diagnoses
  - Filter chips, saved-filter quick-pick, virtualized rows
  - New `PatientCompletenessRing` + `profileCompleteness` util
- **Blood-glucose timing — fasting / post-prandial / random thresholds** (`94995c8`)
  - Captures `blood_glucose_timing` alongside value
  - `classifyBloodSugar` applies fasting (≤100/≤125) vs random (<140/<200) thresholds
  - General + Family Medicine triage sections expose timing dropdown
- **Polish** (`f3286fd`)
  - `InvoiceTable` consumes new `invoice_pdf_document` field (no N+1)
  - `lib/http` distinguishes maintenance-mode 503 from generic 503 with `error_code`
  - Dental procedure-draft typing tightened
  - Patient timeline cards consume `auto_display_line` fallback chain

## Test plan
- [x] `vite build` clean
- [ ] CI green on staging (Cloudflare Pages)
- [ ] Smoke: SOAP draft flow — fetch → review → save with source flip (ai_draft_reviewed → manual)
- [ ] Smoke: appointment board drag-to-update across statuses
- [ ] Smoke: schedule studio bulk-apply across weekdays
- [ ] Smoke: patient list completeness ring, search, filters
- [ ] Smoke: blood-glucose timing — post-prandial 130 → "Normal" not "Diabetic"
- [ ] Smoke: invoice index loads without per-row PDF lookups