### PR TITLE
Add Google sign-in frontend flow

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,0 @@
-VITE_API_URL=/api
-VITE_CENTRIFUGO_URL=/centrifugo/connection/websocket
-VITE_RECAPTCHA_SITE_KEY=6Lc4G5QsAAAAACo6TnSAMNezdE_2yvZdpjnh_rQC

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ lerna-debug.log*
 node_modules
 dist
 dist-ssr
+.env
 *.local
 
 # Editor directories and files

--- a/src/domains/auth/api/authApi.ts
+++ b/src/domains/auth/api/authApi.ts
@@ -1,5 +1,5 @@
 import { http, getAuthToken } from '@/lib/http'
-import type { LoginCredentials, LoginResponse, MeResponse, MessageResponse, RefreshResponse, SelectClinicResponse, SignupCredentials, SignupResponse, VerifyEmailPayload } from '../types/auth.types'
+import type { GoogleAuthResponse, LoginCredentials, LoginResponse, MeResponse, MessageResponse, RefreshResponse, SelectClinicResponse, SignupCredentials, SignupResponse, VerifyEmailPayload } from '../types/auth.types'
 
 export const authApi = {
   async login(credentials: LoginCredentials): Promise<LoginResponse> {
@@ -14,6 +14,18 @@ export const authApi = {
       ...credentials,
       password: btoa(credentials.password),
     })
+  },
+
+  async googleAuth(data: { credential: string; remember_me?: boolean }): Promise<GoogleAuthResponse> {
+    return http.post<GoogleAuthResponse>('/auth/google', data)
+  },
+
+  async requestGoogleLink(data: { credential: string }): Promise<MessageResponse> {
+    return http.post<MessageResponse>('/auth/google/link-request', data)
+  },
+
+  async confirmGoogleLink(data: { email: string; token: string; remember_me?: boolean }): Promise<GoogleAuthResponse> {
+    return http.post<GoogleAuthResponse>('/auth/google/link-confirm', data)
   },
 
   async verifyEmail(payload: VerifyEmailPayload): Promise<MessageResponse> {

--- a/src/domains/auth/components/GoogleSignInButton.vue
+++ b/src/domains/auth/components/GoogleSignInButton.vue
@@ -1,0 +1,94 @@
+<script setup lang="ts">
+import { nextTick, onMounted, ref } from 'vue'
+
+const props = withDefaults(defineProps<{
+  disabled?: boolean
+  text?: 'signin_with' | 'signup_with' | 'continue_with'
+}>(), {
+  disabled: false,
+  text: 'continue_with',
+})
+
+const emit = defineEmits<{
+  credential: [credential: string]
+}>()
+
+const clientId = import.meta.env.VITE_GOOGLE_CLIENT_ID as string | undefined
+const buttonRef = ref<HTMLElement | null>(null)
+const ready = ref(false)
+
+let scriptPromise: Promise<void> | null = null
+
+function loadGoogleIdentityScript(): Promise<void> {
+  if (window.google?.accounts?.id) {
+    return Promise.resolve()
+  }
+
+  if (scriptPromise) {
+    return scriptPromise
+  }
+
+  scriptPromise = new Promise((resolve, reject) => {
+    const existing = document.querySelector<HTMLScriptElement>('script[src="https://accounts.google.com/gsi/client"]')
+    if (existing) {
+      existing.addEventListener('load', () => resolve(), { once: true })
+      existing.addEventListener('error', () => reject(new Error('Google sign-in failed to load.')), { once: true })
+      return
+    }
+
+    const script = document.createElement('script')
+    script.src = 'https://accounts.google.com/gsi/client'
+    script.async = true
+    script.defer = true
+    script.onload = () => resolve()
+    script.onerror = () => reject(new Error('Google sign-in failed to load.'))
+    document.head.appendChild(script)
+  })
+
+  return scriptPromise
+}
+
+async function renderButton(): Promise<void> {
+  if (!clientId || !buttonRef.value || props.disabled) {
+    return
+  }
+
+  await loadGoogleIdentityScript()
+  await nextTick()
+
+  if (!window.google?.accounts?.id || !buttonRef.value) {
+    return
+  }
+
+  buttonRef.value.innerHTML = ''
+  window.google.accounts.id.initialize({
+    client_id: clientId,
+    callback: (response) => {
+      if (response.credential) {
+        emit('credential', response.credential)
+      }
+    },
+  })
+  window.google.accounts.id.renderButton(buttonRef.value, {
+    theme: 'outline',
+    size: 'large',
+    type: 'standard',
+    text: props.text,
+    shape: 'rectangular',
+    width: 320,
+  })
+  ready.value = true
+}
+
+onMounted(() => {
+  renderButton().catch(() => {
+    ready.value = false
+  })
+})
+</script>
+
+<template>
+  <div v-if="clientId" class="flex min-h-11 justify-center">
+    <div ref="buttonRef" :class="{ 'pointer-events-none opacity-60': disabled || !ready }" />
+  </div>
+</template>

--- a/src/domains/auth/stores/authStore.ts
+++ b/src/domains/auth/stores/authStore.ts
@@ -4,7 +4,7 @@ import { useTheme } from '@/composables/useTheme'
 import { useCentrifugo } from '@/composables/useCentrifugo'
 import { setAuthToken } from '@/lib/http'
 import { authApi } from '../api/authApi'
-import type { ClinicContext, LoginCredentials, Membership, SignupCredentials, User } from '../types/auth.types'
+import type { ClinicContext, GoogleAuthResponse, LoginCredentials, LoginResponse, Membership, SignupCredentials, User } from '../types/auth.types'
 
 export const useAuthStore = defineStore('auth', () => {
   const token = ref<string | null>(null)
@@ -90,8 +90,7 @@ export const useAuthStore = defineStore('auth', () => {
     await fetchUser()
   }
 
-  async function login(credentials: LoginCredentials): Promise<void> {
-    const response = await authApi.login(credentials)
+  async function completeTokenLogin(response: LoginResponse | GoogleAuthResponse): Promise<void> {
     setToken(response.data.access_token)
     memberships.value = response.meta.memberships
     const activeMemberships = response.meta.memberships.filter((m) => m.status === 'active')
@@ -103,6 +102,22 @@ export const useAuthStore = defineStore('auth', () => {
     } else {
       await fetchUser()
     }
+  }
+
+  async function login(credentials: LoginCredentials): Promise<void> {
+    await completeTokenLogin(await authApi.login(credentials))
+  }
+
+  async function googleLogin(credential: string, rememberMe: boolean): Promise<void> {
+    await completeTokenLogin(await authApi.googleAuth({ credential, remember_me: rememberMe }))
+  }
+
+  async function requestGoogleLink(credential: string): Promise<void> {
+    await authApi.requestGoogleLink({ credential })
+  }
+
+  async function confirmGoogleLink(email: string, token: string, rememberMe: boolean): Promise<void> {
+    await completeTokenLogin(await authApi.confirmGoogleLink({ email, token, remember_me: rememberMe }))
   }
 
   async function signup(credentials: SignupCredentials): Promise<void> {
@@ -166,6 +181,9 @@ export const useAuthStore = defineStore('auth', () => {
     setToken,
     fetchUser,
     login,
+    googleLogin,
+    requestGoogleLink,
+    confirmGoogleLink,
     signup,
     selectClinic,
     logout,

--- a/src/domains/auth/types/auth.types.ts
+++ b/src/domains/auth/types/auth.types.ts
@@ -117,6 +117,15 @@ export type LoginResponse = {
   meta: { memberships: Membership[] }
 }
 
+export type GoogleAuthResponse = LoginResponse
+
+export interface GoogleLinkRequiredResponse {
+  message: string
+  status: 'link_required'
+  email: string
+  error_code?: string
+}
+
 export type SignupResponse = {
   message: string
 }

--- a/src/domains/auth/views/LinkGoogleView.vue
+++ b/src/domains/auth/views/LinkGoogleView.vue
@@ -1,0 +1,85 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { Button } from '@/components/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import AppLogo from '@/components/AppLogo.vue'
+import { HttpError } from '@/lib/http'
+import { RouteNames } from '@/router/routeNames'
+import { useAuthStore } from '../stores/authStore'
+import { CheckCircle2, LoaderCircle, XCircle } from 'lucide-vue-next'
+
+const route = useRoute()
+const router = useRouter()
+const authStore = useAuthStore()
+
+const isLoading = ref(true)
+const isSuccess = ref(false)
+const errorMessage = ref<string | null>(null)
+
+const email = computed(() => (typeof route.query.email === 'string' ? route.query.email : null))
+const token = computed(() => (typeof route.query.token === 'string' ? route.query.token : null))
+
+async function confirmLink(): Promise<void> {
+  if (!email.value || !token.value) {
+    errorMessage.value = 'This Google link is missing required data.'
+    isLoading.value = false
+    return
+  }
+
+  try {
+    await authStore.confirmGoogleLink(email.value, token.value, true)
+    isSuccess.value = true
+    router.push({ name: RouteNames.HOME })
+  } catch (err) {
+    if (err instanceof HttpError && err.status === 422) {
+      errorMessage.value = 'This Google link is invalid or expired.'
+    } else {
+      errorMessage.value = 'Unable to link Google sign-in. Please request a new link.'
+    }
+  } finally {
+    isLoading.value = false
+  }
+}
+
+onMounted(() => {
+  confirmLink()
+})
+</script>
+
+<template>
+  <div class="flex min-h-screen items-center justify-center bg-background px-4">
+    <div class="w-full max-w-sm">
+      <div class="mb-4 flex justify-center">
+        <AppLogo class="h-24 w-auto" />
+      </div>
+
+      <Card class="backdrop-blur-sm bg-card/90">
+        <CardHeader class="text-center">
+          <div class="mb-2 flex justify-center">
+            <LoaderCircle v-if="isLoading" class="size-8 animate-spin text-primary" />
+            <CheckCircle2 v-else-if="isSuccess" class="size-8 text-emerald-600" />
+            <XCircle v-else class="size-8 text-destructive" />
+          </div>
+          <CardTitle class="text-xl">
+            {{ isLoading ? 'Linking Google' : isSuccess ? 'Google linked' : 'Link expired' }}
+          </CardTitle>
+          <CardDescription>
+            {{ isLoading ? 'Confirming your one-time link...' : isSuccess ? 'Taking you to MediFlow.' : errorMessage }}
+          </CardDescription>
+        </CardHeader>
+        <CardContent v-if="!isLoading && !isSuccess" class="flex flex-col gap-3">
+          <Button class="w-full" @click="router.push({ name: RouteNames.LOGIN, query: email ? { email } : {} })">
+            Back to sign in
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  </div>
+</template>

--- a/src/domains/auth/views/LoginView.vue
+++ b/src/domains/auth/views/LoginView.vue
@@ -8,6 +8,16 @@ import { Input } from '@/components/ui/input'
 import { PasswordInput } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+import {
   Card,
   CardContent,
   CardDescription,
@@ -21,11 +31,13 @@ import { HttpError } from '@/lib/http'
 import { loginSchema } from '@/lib/validationRules'
 import { RouteNames } from '@/router/routeNames'
 import { useNeuralNetwork } from '@/composables/useNeuralNetwork'
-import type { ValidationError } from '../types/auth.types'
+import GoogleSignInButton from '../components/GoogleSignInButton.vue'
+import type { GoogleLinkRequiredResponse, ValidationError } from '../types/auth.types'
 
 const router = useRouter()
 const authStore = useAuthStore()
 const { canvasRef } = useNeuralNetwork()
+const hasGoogleSignIn = Boolean(import.meta.env.VITE_GOOGLE_CLIENT_ID)
 
 const { handleSubmit, setFieldError } = useForm({
   validationSchema: loginSchema,
@@ -36,11 +48,17 @@ const { value: password, errorMessage: passwordError } = useField<string>('passw
 
 const isLoading = ref(false)
 const generalError = ref<string | null>(null)
+const generalNotice = ref<string | null>(null)
 const showResendLink = ref(false)
 const rememberMe = ref(true)
+const linkDialogOpen = ref(false)
+const pendingGoogleCredential = ref<string | null>(null)
+const pendingGoogleEmail = ref<string | null>(null)
+const linkRequestLoading = ref(false)
 
 const ready = ref(false)
 onMounted(() => {
+  void canvasRef.value
   requestAnimationFrame(() => {
     ready.value = true
   })
@@ -48,6 +66,7 @@ onMounted(() => {
 
 const onSubmit = handleSubmit(async (values) => {
   generalError.value = null
+  generalNotice.value = null
   showResendLink.value = false
   isLoading.value = true
 
@@ -85,6 +104,63 @@ const onSubmit = handleSubmit(async (values) => {
     isLoading.value = false
   }
 })
+
+function handleGoogleError(err: unknown): void {
+  if (err instanceof HttpError) {
+    if (err.status === 409) {
+      const body = err.data as GoogleLinkRequiredResponse
+      if (body.status === 'link_required') {
+        pendingGoogleEmail.value = body.email
+        linkDialogOpen.value = true
+        return
+      }
+    }
+
+    if (err.status === 422) {
+      const body = err.data as ValidationError
+      generalError.value = body.message ?? 'Google sign-in could not be verified.'
+      return
+    }
+  }
+
+  generalError.value = 'Google sign-in failed. Please try again.'
+}
+
+async function onGoogleCredential(credential: string): Promise<void> {
+  generalError.value = null
+  generalNotice.value = null
+  showResendLink.value = false
+  pendingGoogleCredential.value = credential
+  isLoading.value = true
+
+  try {
+    await authStore.googleLogin(credential, rememberMe.value)
+    router.push({ name: RouteNames.HOME })
+  } catch (err) {
+    handleGoogleError(err)
+  } finally {
+    isLoading.value = false
+  }
+}
+
+async function requestGoogleLink(): Promise<void> {
+  if (!pendingGoogleCredential.value) {
+    return
+  }
+
+  linkRequestLoading.value = true
+  generalError.value = null
+
+  try {
+    await authStore.requestGoogleLink(pendingGoogleCredential.value)
+    linkDialogOpen.value = false
+    generalNotice.value = `Check ${pendingGoogleEmail.value ?? 'your email'} to finish linking Google sign-in.`
+  } catch {
+    generalError.value = 'Unable to send the Google link email. Please try again.'
+  } finally {
+    linkRequestLoading.value = false
+  }
+}
 </script>
 
 <template>
@@ -127,6 +203,32 @@ const onSubmit = handleSubmit(async (values) => {
                 >
                   Resend verification email
                 </RouterLink>
+              </div>
+
+              <div
+                v-if="generalNotice"
+                role="status"
+                class="rounded-md border border-emerald-600/30 bg-emerald-50 px-3 py-2.5 text-sm text-emerald-700"
+              >
+                {{ generalNotice }}
+              </div>
+
+              <div
+                v-if="hasGoogleSignIn"
+                class="transition-all delay-300 duration-500 ease-out"
+                :class="ready ? 'translate-y-0 opacity-100' : 'translate-y-4 opacity-0'"
+              >
+                <GoogleSignInButton :disabled="isLoading" text="signin_with" @credential="onGoogleCredential" />
+              </div>
+
+              <div
+                v-if="hasGoogleSignIn"
+                class="flex items-center gap-3 transition-all delay-300 duration-500 ease-out"
+                :class="ready ? 'translate-y-0 opacity-100' : 'translate-y-4 opacity-0'"
+              >
+                <div class="h-px flex-1 bg-border" />
+                <span class="text-xs text-muted-foreground">or</span>
+                <div class="h-px flex-1 bg-border" />
               </div>
 
               <div
@@ -223,5 +325,23 @@ const onSubmit = handleSubmit(async (values) => {
         </Card>
       </div>
     </div>
+
+    <AlertDialog :open="linkDialogOpen" @update:open="linkDialogOpen = $event">
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Link Google sign-in?</AlertDialogTitle>
+          <AlertDialogDescription>
+            {{ pendingGoogleEmail }} already has a MediFlow account. We will email a one-time confirmation link before enabling Google sign-in for that account.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel :disabled="linkRequestLoading">Cancel</AlertDialogCancel>
+          <AlertDialogAction :disabled="linkRequestLoading" @click.prevent="requestGoogleLink">
+            <LoaderCircle v-if="linkRequestLoading" class="size-4 animate-spin" />
+            Send link email
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
   </div>
 </template>

--- a/src/domains/auth/views/SignupView.vue
+++ b/src/domains/auth/views/SignupView.vue
@@ -6,6 +6,16 @@ import { Button } from '@/components/ui/button'
 import { Input, PasswordInput } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+import {
   Card,
   CardContent,
   CardDescription,
@@ -20,13 +30,15 @@ import { signupSchema } from '@/lib/validationRules'
 import { RouteNames } from '@/router/routeNames'
 import { useRecaptcha } from '@/composables/useRecaptcha'
 import { useNeuralNetwork } from '@/composables/useNeuralNetwork'
-import type { ValidationError } from '../types/auth.types'
+import type { GoogleLinkRequiredResponse, ValidationError } from '../types/auth.types'
 import PasswordStrengthBar from '../components/PasswordStrengthBar.vue'
+import GoogleSignInButton from '../components/GoogleSignInButton.vue'
 
 const router = useRouter()
 const route = useRoute()
 const authStore = useAuthStore()
 const { canvasRef } = useNeuralNetwork()
+const hasGoogleSignIn = Boolean(import.meta.env.VITE_GOOGLE_CLIENT_ID)
 
 const { handleSubmit, setFieldError } = useForm({
   validationSchema: signupSchema,
@@ -40,9 +52,15 @@ const { value: password, errorMessage: passwordError } = useField<string>('passw
 const { load: loadRecaptcha, execute: executeRecaptcha } = useRecaptcha()
 const isLoading = ref(false)
 const generalError = ref<string | null>(null)
+const generalNotice = ref<string | null>(null)
+const linkDialogOpen = ref(false)
+const pendingGoogleCredential = ref<string | null>(null)
+const pendingGoogleEmail = ref<string | null>(null)
+const linkRequestLoading = ref(false)
 
 const ready = ref(false)
 onMounted(() => {
+  void canvasRef.value
   loadRecaptcha()
   requestAnimationFrame(() => {
     ready.value = true
@@ -55,6 +73,7 @@ onMounted(() => {
 
 const onSubmit = handleSubmit(async (values) => {
   generalError.value = null
+  generalNotice.value = null
   isLoading.value = true
 
   try {
@@ -88,6 +107,62 @@ const onSubmit = handleSubmit(async (values) => {
     isLoading.value = false
   }
 })
+
+function handleGoogleError(err: unknown): void {
+  if (err instanceof HttpError) {
+    if (err.status === 409) {
+      const body = err.data as GoogleLinkRequiredResponse
+      if (body.status === 'link_required') {
+        pendingGoogleEmail.value = body.email
+        linkDialogOpen.value = true
+        return
+      }
+    }
+
+    if (err.status === 422) {
+      const body = err.data as ValidationError
+      generalError.value = body.message ?? 'Google sign-up could not be verified.'
+      return
+    }
+  }
+
+  generalError.value = 'Google sign-up failed. Please try again.'
+}
+
+async function onGoogleCredential(credential: string): Promise<void> {
+  generalError.value = null
+  generalNotice.value = null
+  pendingGoogleCredential.value = credential
+  isLoading.value = true
+
+  try {
+    await authStore.googleLogin(credential, true)
+    router.push({ name: RouteNames.HOME })
+  } catch (err) {
+    handleGoogleError(err)
+  } finally {
+    isLoading.value = false
+  }
+}
+
+async function requestGoogleLink(): Promise<void> {
+  if (!pendingGoogleCredential.value) {
+    return
+  }
+
+  linkRequestLoading.value = true
+  generalError.value = null
+
+  try {
+    await authStore.requestGoogleLink(pendingGoogleCredential.value)
+    linkDialogOpen.value = false
+    generalNotice.value = `Check ${pendingGoogleEmail.value ?? 'your email'} to finish linking Google sign-in.`
+  } catch {
+    generalError.value = 'Unable to send the Google link email. Please try again.'
+  } finally {
+    linkRequestLoading.value = false
+  }
+}
 </script>
 
 <template>
@@ -123,6 +198,32 @@ const onSubmit = handleSubmit(async (values) => {
                 class="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2.5 text-sm text-destructive"
               >
                 {{ generalError }}
+              </div>
+
+              <div
+                v-if="generalNotice"
+                role="status"
+                class="rounded-md border border-emerald-600/30 bg-emerald-50 px-3 py-2.5 text-sm text-emerald-700"
+              >
+                {{ generalNotice }}
+              </div>
+
+              <div
+                v-if="hasGoogleSignIn"
+                class="transition-all delay-300 duration-500 ease-out"
+                :class="ready ? 'translate-y-0 opacity-100' : 'translate-y-4 opacity-0'"
+              >
+                <GoogleSignInButton :disabled="isLoading" text="signup_with" @credential="onGoogleCredential" />
+              </div>
+
+              <div
+                v-if="hasGoogleSignIn"
+                class="flex items-center gap-3 transition-all delay-300 duration-500 ease-out"
+                :class="ready ? 'translate-y-0 opacity-100' : 'translate-y-4 opacity-0'"
+              >
+                <div class="h-px flex-1 bg-border" />
+                <span class="text-xs text-muted-foreground">or</span>
+                <div class="h-px flex-1 bg-border" />
               </div>
 
               <div
@@ -255,5 +356,23 @@ const onSubmit = handleSubmit(async (values) => {
         </Card>
       </div>
     </div>
+
+    <AlertDialog :open="linkDialogOpen" @update:open="linkDialogOpen = $event">
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Link Google sign-in?</AlertDialogTitle>
+          <AlertDialogDescription>
+            {{ pendingGoogleEmail }} already has a MediFlow account. We will email a one-time confirmation link before enabling Google sign-in for that account.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel :disabled="linkRequestLoading">Cancel</AlertDialogCancel>
+          <AlertDialogAction :disabled="linkRequestLoading" @click.prevent="requestGoogleLink">
+            <LoaderCircle v-if="linkRequestLoading" class="size-4 animate-spin" />
+            Send link email
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
   </div>
 </template>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -220,6 +220,12 @@ const router = createRouter({
       meta: { requiresAuth: false },
     },
     {
+      path: '/link-google',
+      name: RouteNames.LINK_GOOGLE,
+      component: () => import('@/domains/auth/views/LinkGoogleView.vue'),
+      meta: { requiresAuth: false },
+    },
+    {
       path: '/forgot-password',
       name: RouteNames.FORGOT_PASSWORD,
       component: () => import('@/domains/auth/views/ForgotPasswordView.vue'),

--- a/src/router/routeNames.ts
+++ b/src/router/routeNames.ts
@@ -4,6 +4,7 @@ export const RouteNames = {
   SIGNUP: 'signup',
   VERIFY_EMAIL_NOTICE: 'verify-email-notice',
   VERIFY_EMAIL: 'verify-email',
+  LINK_GOOGLE: 'link-google',
   ONBOARDING_CREATE_CLINIC: 'onboarding-create-clinic',
   SELECT_CLINIC: 'select-clinic',
   PATIENT_LIST: 'patient-list',

--- a/src/types/google-identity.d.ts
+++ b/src/types/google-identity.d.ts
@@ -1,0 +1,28 @@
+interface GoogleCredentialResponse {
+  credential?: string
+}
+
+interface GoogleIdentityButtonOptions {
+  theme?: 'outline' | 'filled_blue' | 'filled_black'
+  size?: 'large' | 'medium' | 'small'
+  type?: 'standard' | 'icon'
+  text?: 'signin_with' | 'signup_with' | 'continue_with' | 'signin'
+  shape?: 'rectangular' | 'pill' | 'circle' | 'square'
+  width?: number
+}
+
+interface GoogleIdentity {
+  initialize(options: {
+    client_id: string
+    callback: (response: GoogleCredentialResponse) => void
+  }): void
+  renderButton(parent: HTMLElement, options: GoogleIdentityButtonOptions): void
+}
+
+interface Window {
+  google?: {
+    accounts: {
+      id: GoogleIdentity
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds the web Google sign-in/signup UI and account-linking confirmation flow.

## Changes

- Adds Google Identity Services button rendering on login and signup.
- Calls the backend Google auth endpoints and reuses the existing post-login flow for onboarding and clinic selection.
- Shows an explicit confirmation dialog before requesting a Google link email for existing MediFlow accounts.
- Adds `/link-google` to complete one-time Google account linking.
- Removes tracked `.env` from the repo and ignores it going forward.

## Validation

- `vite build`
- Touched auth/router `vue-tsc` filter showed no matching errors
- `git diff --check`
- Local browser test confirmed Google sign-in, onboarding, and avatar display work after OAuth origin configuration and `storage:link`