### PR TITLE
Dental fee schedule — scope-aware tab + Vitest setup

### DIFF
--- a/e2e/dental-fee-schedule.spec.ts
+++ b/e2e/dental-fee-schedule.spec.ts
@@ -1,0 +1,113 @@
+import { test, expect } from './fixtures'
+import { waitForDataLoad } from './helpers'
+
+/**
+ * Smoke coverage for the Dental Fee Schedule scope-aware tab.
+ *
+ * Two mount points to exercise:
+ *   1. Clinic Settings → Specialties → Dental — clinic-wide defaults.
+ *   2. Dentist Account → Financial / Billing — per-dentist overrides
+ *      (with clinic prices shown as input placeholders).
+ *
+ * Both tests gate on the presence of the relevant section and skip
+ * (rather than fail) when the demo account isn't a dentist or the
+ * dental specialty isn't enabled — staging seed data isn't guaranteed.
+ * The point is to detect mount-site regressions (component import path,
+ * tab wiring, route presence) once the feature ships.
+ */
+test.describe('Dental Fee Schedule', () => {
+  test('clinic settings → Specialties → Dental tab shows the Fee Schedule card', async ({ page }) => {
+    await page.goto('/clinic/settings')
+    await waitForDataLoad(page)
+
+    const specialtiesHeading = page.getByRole('heading', { name: /specialties/i }).first()
+    if (!(await specialtiesHeading.isVisible({ timeout: 5000 }).catch(() => false))) {
+      test.skip(true, 'Specialties section not present — clinic settings may differ on this account')
+      return
+    }
+
+    const dentalTab = page.getByRole('tab', { name: /^dental$/i }).first()
+    if (!(await dentalTab.isVisible({ timeout: 5000 }).catch(() => false))) {
+      test.skip(true, 'Dental specialty tab not present on this clinic')
+      return
+    }
+
+    await dentalTab.click()
+
+    // Card title is "Dental Fee Schedule" in both clinic and doctor scopes —
+    // the description text differs. Asserting the title catches mount
+    // regressions without coupling to scope-specific copy.
+    await expect(page.getByText('Dental Fee Schedule')).toBeVisible({ timeout: 10000 })
+
+    // The clinic-scope description gives the strongest signal that the
+    // right scope is mounted. Match a stable substring.
+    await expect(
+      page.getByText(/Set the clinic-wide default prices/i),
+    ).toBeVisible({ timeout: 5000 })
+  })
+
+  test('search input filters the catalog', async ({ page }) => {
+    await page.goto('/clinic/settings')
+    await waitForDataLoad(page)
+
+    const dentalTab = page.getByRole('tab', { name: /^dental$/i }).first()
+    if (!(await dentalTab.isVisible({ timeout: 5000 }).catch(() => false))) {
+      test.skip(true, 'Dental specialty tab not present on this clinic')
+      return
+    }
+    await dentalTab.click()
+
+    const searchInput = page.getByPlaceholder(/search by name, code, or material/i)
+    if (!(await searchInput.isVisible({ timeout: 5000 }).catch(() => false))) {
+      test.skip(true, 'Catalog rows did not load — likely an unseeded test clinic')
+      return
+    }
+
+    // Search for a CDT code that won't match anything to verify the empty
+    // state renders. We avoid asserting positive matches because the seed
+    // catalog can change over time.
+    await searchInput.fill('ZZ-NO-SUCH-CODE')
+    await expect(page.getByText(/no services match your search/i)).toBeVisible({ timeout: 5000 })
+  })
+
+  test('dentist account → Financial/Billing shows the override editor when applicable', async ({ page }) => {
+    // The account-settings route varies by app version; navigate via the
+    // user menu rather than guessing a URL. Skip the test if the menu
+    // doesn't expose an "Account" / "Profile" option (e.g., role is not a
+    // doctor).
+    await page.goto('/')
+    await waitForDataLoad(page)
+
+    // Try common entry points — any one of these should work; if none do
+    // we skip rather than fail.
+    const entryPoints = ['/account', '/account/settings', '/profile', '/profile/settings']
+    let landed = false
+    for (const path of entryPoints) {
+      const res = await page.goto(path).catch(() => null)
+      if (res && res.ok()) {
+        landed = true
+        break
+      }
+    }
+    if (!landed) {
+      test.skip(true, 'No account/profile route is reachable for this user')
+      return
+    }
+    await waitForDataLoad(page)
+
+    // The Dental Fee Schedule only mounts when the user's specialty is
+    // dental. Otherwise the financial form omits it. Skip rather than
+    // fail.
+    const card = page.getByText('Dental Fee Schedule')
+    if (!(await card.isVisible({ timeout: 5000 }).catch(() => false))) {
+      test.skip(true, 'User is not a dentist — DentalBillingTab not mounted')
+      return
+    }
+
+    await expect(card).toBeVisible()
+    // Doctor-scope description signals the override semantics.
+    await expect(
+      page.getByText(/Override your clinic.{0,3}s prices for procedures you charge differently/i),
+    ).toBeVisible({ timeout: 5000 })
+  })
+})

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "build": "vue-tsc -b && vite build",
     "preview": "vite preview",
     "generate-pwa-assets": "pwa-assets-generator",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed"
@@ -50,10 +52,13 @@
     "@types/node": "^24.11.0",
     "@vite-pwa/assets-generator": "^1.0.2",
     "@vitejs/plugin-vue": "^6.0.2",
+    "@vue/test-utils": "^2.4.6",
     "@vue/tsconfig": "^0.8.1",
+    "happy-dom": "^15.11.7",
     "typescript": "~5.9.3",
     "vite": "^7.3.1",
     "vite-plugin-pwa": "^1.2.0",
+    "vitest": "^3.0.5",
     "vue-tsc": "^3.1.5"
   }
 }

--- a/src/domains/auth/components/ConsultationFeeForm.vue
+++ b/src/domains/auth/components/ConsultationFeeForm.vue
@@ -206,7 +206,7 @@ async function onSubmit() {
 
     <!-- Dental fee schedule (dental only) -->
     <CardContent v-if="isDental" class="pt-6">
-      <DentalBillingTab />
+      <DentalBillingTab scope="doctor" />
     </CardContent>
 
     <Separator v-if="isDental" />

--- a/src/domains/clinic/views/ClinicSettingsView.vue
+++ b/src/domains/clinic/views/ClinicSettingsView.vue
@@ -11,6 +11,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { clinicApi } from '@/domains/clinic/api/clinicApi'
 import { useAuthStore } from '@/domains/auth/stores/authStore'
 import type { ToothNumberingPreference } from '@/domains/auth/types/auth.types'
+import DentalBillingTab from '@/domains/dental/components/DentalBillingTab.vue'
 
 const authStore = useAuthStore()
 const isFetching = ref(true)
@@ -308,6 +309,8 @@ function saveFeeSetting(key: string, value: string) {
                   >{{ opt.label }}</button>
                 </div>
               </div>
+
+              <DentalBillingTab scope="clinic" />
             </TabsContent>
           </Tabs>
         </CardContent>

--- a/src/domains/dental/api/dentalApi.ts
+++ b/src/domains/dental/api/dentalApi.ts
@@ -9,6 +9,7 @@ import type {
   CreateTreatmentPlanPayload,
   UpdateTreatmentPlanPayload,
   UpdateDentalServicePayload,
+  UpdateDoctorDentalServicePayload,
   UpdateDentalVisitPayload,
 } from '../types/dental.types'
 
@@ -53,12 +54,22 @@ export const dentalApi = {
     return http.delete(`/patients/${patientId}/dental-visits/${visitId}`) as Promise<void>
   },
 
-  // Service catalog / fee schedule
+  // Service catalog / fee schedule (clinic-wide defaults)
   listServices(): Promise<{ data: DentalServiceCatalogEntry[] }> {
     return http.get('/dental/services') as Promise<{ data: DentalServiceCatalogEntry[] }>
   },
   updateService(clinicServiceUuid: string, payload: UpdateDentalServicePayload): Promise<{ data: DentalServiceCatalogEntry }> {
     return http.patch(`/dental/services/${clinicServiceUuid}`, payload) as Promise<{ data: DentalServiceCatalogEntry }>
+  },
+
+  // Per-doctor overrides on the active clinic's catalog. Returns the same
+  // catalog rows but with `override_price` / `override_is_active` populated
+  // from the dentist's `DoctorService` rows and `effective_*` computed.
+  listMyServices(): Promise<{ data: DentalServiceCatalogEntry[] }> {
+    return http.get('/me/dental/services') as Promise<{ data: DentalServiceCatalogEntry[] }>
+  },
+  updateMyService(clinicServiceUuid: string, payload: UpdateDoctorDentalServicePayload): Promise<{ data: DentalServiceCatalogEntry }> {
+    return http.patch(`/me/dental/services/${clinicServiceUuid}`, payload) as Promise<{ data: DentalServiceCatalogEntry }>
   },
 
   // Per-tooth history (aggregated across profile, visits, and treatment plans)

--- a/src/domains/dental/components/DentalBillingTab.vue
+++ b/src/domains/dental/components/DentalBillingTab.vue
@@ -8,9 +8,15 @@ import { LoaderCircle, Search, Stethoscope } from 'lucide-vue-next'
 import { toast } from 'vue-sonner'
 import { HttpError } from '@/lib/http'
 import { useDentalServices } from '../composables/useDentalServices'
-import type { DentalServiceCategory } from '../types/dental.types'
+import type { DentalServiceCatalogEntry, DentalServiceCategory } from '../types/dental.types'
 
-const { services, groupedByCategory, loaded, loading, error, ensureLoaded, updateService } = useDentalServices()
+const props = withDefaults(defineProps<{
+  scope?: 'clinic' | 'doctor'
+}>(), {
+  scope: 'doctor',
+})
+
+const { services, groupedByCategory, loaded, loading, error, ensureLoaded, updateService } = useDentalServices({ scope: props.scope })
 
 const search = ref('')
 const openCategories = ref<Set<DentalServiceCategory>>(new Set(['preventive', 'restorative', 'endodontic']))
@@ -25,12 +31,45 @@ onMounted(async () => {
   }
 })
 
-// Sync drafts whenever catalog arrives/refreshes
-watch(services, (next) => {
-  const drafts: Record<string, string> = {}
-  for (const s of next) {
-    if (s.clinic_service_uuid) drafts[s.clinic_service_uuid] = String(s.clinic_price)
+// Drafts seed differently per scope:
+// - clinic: prefill the editable clinic price
+// - doctor: prefill ONLY the override (blank when no override exists)
+//   so the input shows clinic price as a placeholder until the dentist
+//   types something. Submitting a blank value sends `null`, which the
+//   backend reads as "use clinic default" and clears the override.
+//
+// Preserve in-flight typing: when a sibling row mutates (toggle, save),
+// the cache is replaced and this watcher refires with the same `services`
+// reference but new entries. We rebuild drafts from the current rows but
+// keep any draft the user has already typed for a row we've shown
+// before — otherwise the user loses unsaved keystrokes whenever any row
+// changes elsewhere in the list.
+function seedDraft(s: DentalServiceCatalogEntry, scope: 'clinic' | 'doctor'): string {
+  if (scope === 'doctor') {
+    return s.override_price != null ? String(s.override_price) : ''
   }
+  return s.clinic_price != null ? String(s.clinic_price) : ''
+}
+
+watch([services, () => props.scope], ([next, scope], oldVal) => {
+  const previousScope = Array.isArray(oldVal) ? oldVal[1] : undefined
+  const isScopeChange = previousScope !== undefined && previousScope !== scope
+  const previous = priceDrafts.value
+  const drafts: Record<string, string> = {}
+
+  for (const s of next) {
+    const uuid = s.clinic_service_uuid
+    if (!uuid) continue
+    // Preserve user typing across sibling-row updates. On scope change we
+    // re-seed everything because the values mean different things
+    // (override vs clinic).
+    if (!isScopeChange && uuid in previous) {
+      drafts[uuid] = previous[uuid] ?? ''
+      continue
+    }
+    drafts[uuid] = seedDraft(s, scope)
+  }
+
   priceDrafts.value = drafts
 }, { immediate: true })
 
@@ -52,6 +91,12 @@ const CATEGORY_LABELS: Record<DentalServiceCategory, string> = {
   other: 'Other',
 }
 
+const description = computed(() =>
+  props.scope === 'clinic'
+    ? "Set the clinic-wide default prices. Individual dentists can override these on their own profile."
+    : "Override your clinic's prices for procedures you charge differently. Leave a price blank to use the clinic default.",
+)
+
 const filteredGroups = computed(() => {
   const q = search.value.trim().toLowerCase()
   const out: { category: DentalServiceCategory; label: string; items: typeof services.value }[] = []
@@ -69,7 +114,18 @@ const filteredGroups = computed(() => {
   return out
 })
 
-const activeCount = computed(() => services.value.filter((s) => s.is_active).length)
+// Activation flag the row's UI should reflect — clinic_is_active when the
+// clinic admin is editing, effective_is_active for the dentist (so a
+// per-doctor opt-out shows as off even when the clinic still offers it).
+function rowIsActive(item: DentalServiceCatalogEntry): boolean {
+  return props.scope === 'doctor' ? item.effective_is_active : item.clinic_is_active
+}
+
+function rowUsesClinicDefault(item: DentalServiceCatalogEntry): boolean {
+  return props.scope === 'doctor' && item.override_price == null
+}
+
+const activeCount = computed(() => services.value.filter((s) => rowIsActive(s)).length)
 
 function toggleCategory(cat: DentalServiceCategory) {
   const next = new Set(openCategories.value)
@@ -84,10 +140,16 @@ async function savePrice(clinicServiceUuid: string) {
     toast.error('Enter a valid non-negative amount.')
     return
   }
+  // Clinic price is required (the catalog row must have a price); doctor
+  // override is allowed to clear back to null.
+  if (props.scope === 'clinic' && parsed === null) {
+    toast.error('Clinic price is required. Enter a non-negative amount.')
+    return
+  }
   saving.value.add(clinicServiceUuid)
   try {
     await updateService(clinicServiceUuid, { price: parsed })
-    toast.success('Price updated.')
+    toast.success(props.scope === 'doctor' && parsed === null ? 'Override cleared.' : 'Price updated.')
   } catch (err) {
     const msg = err instanceof HttpError ? err.message : 'Failed to save price.'
     toast.error(msg)
@@ -97,14 +159,25 @@ async function savePrice(clinicServiceUuid: string) {
   }
 }
 
-async function toggleActive(clinicServiceUuid: string, next: boolean) {
-  saving.value.add(clinicServiceUuid)
+async function toggleActive(item: DentalServiceCatalogEntry, next: boolean) {
+  const uuid = item.clinic_service_uuid
+  if (!uuid) return
+  saving.value.add(uuid)
   try {
-    await updateService(clinicServiceUuid, { is_active: next })
+    if (props.scope === 'doctor') {
+      // Doctor toggle writes to override_is_active. Setting it to match
+      // the clinic flag again would still leave a sparse override row;
+      // pass `null` so the backend clears the activation override (and
+      // deletes the row when both fields revert to defaults).
+      const overrideValue: boolean | null = next === item.clinic_is_active ? null : next
+      await updateService(uuid, { is_active: overrideValue })
+    } else {
+      await updateService(uuid, { is_active: next })
+    }
   } catch {
     toast.error('Failed to update service.')
   } finally {
-    saving.value.delete(clinicServiceUuid)
+    saving.value.delete(uuid)
     saving.value = new Set(saving.value)
   }
 }
@@ -118,7 +191,7 @@ async function toggleActive(clinicServiceUuid: string, next: boolean) {
         <CardTitle class="text-base">Dental Fee Schedule</CardTitle>
       </div>
       <CardDescription>
-        Enable or disable the procedures you offer, and set your price per service. CDT-aligned codes with Philippine-market defaults.
+        {{ description }}
         <span v-if="loaded" class="text-foreground">{{ activeCount }} of {{ services.length }} active.</span>
       </CardDescription>
     </CardHeader>
@@ -131,6 +204,10 @@ async function toggleActive(clinicServiceUuid: string, next: boolean) {
 
       <div v-else-if="error" role="alert" class="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2.5 text-sm text-destructive">
         {{ error }}
+      </div>
+
+      <div v-else-if="services.length === 0" class="py-8 text-center text-sm text-muted-foreground">
+        No dental services configured yet.
       </div>
 
       <div v-else>
@@ -183,6 +260,9 @@ async function toggleActive(clinicServiceUuid: string, next: boolean) {
                     <span v-if="item.material && item.description"> · </span>
                     <span>{{ item.description ?? '' }}</span>
                   </div>
+                  <p v-if="rowUsesClinicDefault(item)" class="mt-0.5 text-[11px] text-muted-foreground">
+                    Uses clinic default
+                  </p>
                 </div>
 
                 <div class="text-right text-xs text-muted-foreground">
@@ -199,16 +279,17 @@ async function toggleActive(clinicServiceUuid: string, next: boolean) {
                     step="0.01"
                     min="0"
                     class="h-8"
-                    :disabled="!item.is_active || saving.has(item.clinic_service_uuid ?? '')"
+                    :placeholder="props.scope === 'doctor' && item.clinic_price != null ? String(item.clinic_price) : undefined"
+                    :disabled="!rowIsActive(item) || saving.has(item.clinic_service_uuid ?? '')"
                     @blur="item.clinic_service_uuid && savePrice(item.clinic_service_uuid)"
                     @keyup.enter="item.clinic_service_uuid && savePrice(item.clinic_service_uuid)"
                   />
                 </div>
 
                 <Switch
-                  :model-value="item.is_active"
+                  :model-value="rowIsActive(item)"
                   :disabled="saving.has(item.clinic_service_uuid ?? '')"
-                  @update:model-value="item.clinic_service_uuid && toggleActive(item.clinic_service_uuid, $event)"
+                  @update:model-value="toggleActive(item, $event)"
                 />
               </div>
             </div>

--- a/src/domains/dental/composables/useDentalServices.spec.ts
+++ b/src/domains/dental/composables/useDentalServices.spec.ts
@@ -1,0 +1,383 @@
+/**
+ * Tests for the `useDentalServices` composable.
+ *
+ * Why these tests exist:
+ *   - Module-level caches (one per scope) make this composable look simple
+ *     but the lifetime is full of races: clinic-switch invalidation,
+ *     window-focus refetch, in-flight ensureLoaded across two consumers,
+ *     clinic-side invalidation while doctor-side is mid-fetch. The
+ *     generation counter that gates each fetch's commit is the load-bearing
+ *     piece — silently breaking it would re-introduce the stale-cache bug.
+ *   - The clinic-update endpoint echoes the raw ClinicService model (no
+ *     `clinic_*`/`effective_*` fields) so the cache update path has to
+ *     map raw → typed and refresh `effective_*` even when the response
+ *     omits them. A regression here is invisible in the type system.
+ *
+ * Each test imports the composable dynamically after `vi.resetModules()`
+ * so its module-level cache state is fresh.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { nextTick } from 'vue'
+import type { DentalServiceCatalogEntry } from '../types/dental.types'
+
+// ---- helpers -----------------------------------------------------------
+
+function makeRow(uuid: string, opts: Partial<DentalServiceCatalogEntry> = {}): DentalServiceCatalogEntry {
+  return {
+    uuid: `sys-${uuid}`,
+    clinic_service_uuid: `clinic-${uuid}`,
+    cdt_code: `D${uuid}`,
+    name: `Service ${uuid}`,
+    description: null,
+    category: 'preventive',
+    treatment_area: 'tooth',
+    surfaces_required: null,
+    material: null,
+    is_anterior: null,
+    is_posterior: null,
+    default_price: 100,
+    price_min: null,
+    price_max: null,
+    clinic_price: 100,
+    clinic_is_active: true,
+    override_price: null,
+    override_is_active: null,
+    effective_price: 100,
+    effective_is_active: true,
+    is_active: true,
+    ...opts,
+  }
+}
+
+interface MockApi {
+  listServices: ReturnType<typeof vi.fn>
+  listMyServices: ReturnType<typeof vi.fn>
+  updateService: ReturnType<typeof vi.fn>
+  updateMyService: ReturnType<typeof vi.fn>
+}
+
+function mockApi(overrides: Partial<MockApi> = {}): MockApi {
+  return {
+    listServices: vi.fn().mockResolvedValue({ data: [] }),
+    listMyServices: vi.fn().mockResolvedValue({ data: [] }),
+    updateService: vi.fn().mockResolvedValue({ data: {} }),
+    updateMyService: vi.fn().mockResolvedValue({ data: {} }),
+    ...overrides,
+  }
+}
+
+/**
+ * Wire up the API + auth-store mocks and return a fresh import of the
+ * composable. The dynamic import + `vi.resetModules()` in beforeEach
+ * means each test gets virgin module-level cache state.
+ */
+async function loadComposable(api: MockApi) {
+  vi.doMock('../api/dentalApi', () => ({ dentalApi: api }))
+  vi.doMock('@/domains/auth/stores/authStore', () => ({
+    // Composable's `bindCacheBusters` calls `useAuthStore()` to wire the
+    // clinic-switch watcher. A plain object satisfies the access pattern;
+    // none of these tests trigger an actual clinic switch.
+    useAuthStore: () => ({ currentClinic: { id: 'clinic-fixture' } }),
+  }))
+  return await import('./useDentalServices')
+}
+
+// ---- setup --------------------------------------------------------------
+
+beforeEach(() => {
+  vi.resetModules()
+  setActivePinia(createPinia())
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.doUnmock('../api/dentalApi')
+  vi.doUnmock('@/domains/auth/stores/authStore')
+})
+
+// ---- tests --------------------------------------------------------------
+
+describe('useDentalServices — scope dispatch', () => {
+  it('clinic scope hits listServices', async () => {
+    const api = mockApi({
+      listServices: vi.fn().mockResolvedValue({ data: [makeRow('A')] }),
+    })
+    const { useDentalServices } = await loadComposable(api)
+
+    const { ensureLoaded, services } = useDentalServices({ scope: 'clinic' })
+    await ensureLoaded()
+
+    expect(api.listServices).toHaveBeenCalledOnce()
+    expect(api.listMyServices).not.toHaveBeenCalled()
+    expect(services.value).toHaveLength(1)
+  })
+
+  it('doctor scope hits listMyServices', async () => {
+    const api = mockApi({
+      listMyServices: vi.fn().mockResolvedValue({ data: [makeRow('B')] }),
+    })
+    const { useDentalServices } = await loadComposable(api)
+
+    const { ensureLoaded, services } = useDentalServices({ scope: 'doctor' })
+    await ensureLoaded()
+
+    expect(api.listMyServices).toHaveBeenCalledOnce()
+    expect(api.listServices).not.toHaveBeenCalled()
+    expect(services.value).toHaveLength(1)
+  })
+
+  it('clinic and doctor caches are independent', async () => {
+    const api = mockApi({
+      listServices: vi.fn().mockResolvedValue({ data: [makeRow('A', { clinic_price: 100 })] }),
+      listMyServices: vi.fn().mockResolvedValue({ data: [makeRow('A', { clinic_price: 100, override_price: 200, effective_price: 200 })] }),
+    })
+    const { useDentalServices } = await loadComposable(api)
+
+    const clinic = useDentalServices({ scope: 'clinic' })
+    const doctor = useDentalServices({ scope: 'doctor' })
+    await Promise.all([clinic.ensureLoaded(), doctor.ensureLoaded()])
+
+    expect(clinic.services.value[0]?.clinic_price).toBe(100)
+    expect(doctor.services.value[0]?.effective_price).toBe(200)
+  })
+})
+
+describe('useDentalServices — ensureLoaded', () => {
+  it('de-duplicates concurrent calls within a scope', async () => {
+    const api = mockApi({
+      listServices: vi.fn().mockResolvedValue({ data: [makeRow('A')] }),
+    })
+    const { useDentalServices } = await loadComposable(api)
+
+    const a = useDentalServices({ scope: 'clinic' })
+    const b = useDentalServices({ scope: 'clinic' })
+
+    await Promise.all([a.ensureLoaded(), b.ensureLoaded(), b.ensureLoaded()])
+
+    expect(api.listServices).toHaveBeenCalledOnce()
+  })
+
+  it('refetches on force=true', async () => {
+    const api = mockApi({
+      listServices: vi.fn().mockResolvedValue({ data: [makeRow('A')] }),
+    })
+    const { useDentalServices } = await loadComposable(api)
+
+    const c = useDentalServices({ scope: 'clinic' })
+    await c.ensureLoaded()
+    await c.ensureLoaded() // no force — should hit cache
+    await c.ensureLoaded(true) // force
+
+    expect(api.listServices).toHaveBeenCalledTimes(2)
+  })
+
+  it('exposes loaded=true after a successful fetch', async () => {
+    const api = mockApi({
+      listServices: vi.fn().mockResolvedValue({ data: [makeRow('A')] }),
+    })
+    const { useDentalServices } = await loadComposable(api)
+
+    const c = useDentalServices({ scope: 'clinic' })
+    expect(c.loaded.value).toBe(false)
+    await c.ensureLoaded()
+    expect(c.loaded.value).toBe(true)
+  })
+
+  it('surfaces fetch failures via the error ref', async () => {
+    const api = mockApi({
+      listServices: vi.fn().mockRejectedValue(new Error('boom')),
+    })
+    const { useDentalServices } = await loadComposable(api)
+
+    const c = useDentalServices({ scope: 'clinic' })
+    await c.ensureLoaded().catch(() => {})
+
+    expect(c.error.value).toBe('boom')
+    expect(c.loaded.value).toBe(false)
+  })
+})
+
+describe('useDentalServices — race-safety: invalidation during in-flight fetch', () => {
+  // The load-bearing test. Without the generation counter (pass 4 fix), an
+  // in-flight doctor fetch that arrives AFTER an invalidation would
+  // silently repopulate the just-cleared cache and re-mark it `loaded`.
+  it('drops a stale doctor-fetch result that arrives after a clinic-update invalidation', async () => {
+    let releaseDoctorFetch!: (value: { data: DentalServiceCatalogEntry[] }) => void
+    const doctorFetchPromise = new Promise<{ data: DentalServiceCatalogEntry[] }>((resolve) => {
+      releaseDoctorFetch = resolve
+    })
+
+    const api = mockApi({
+      listServices: vi.fn().mockResolvedValue({ data: [makeRow('A')] }),
+      listMyServices: vi.fn(() => doctorFetchPromise),
+      updateService: vi.fn().mockResolvedValue({
+        data: { uuid: 'sys-A', price: 200, is_active: true },
+      }),
+    })
+    const { useDentalServices } = await loadComposable(api)
+
+    const clinic = useDentalServices({ scope: 'clinic' })
+    const doctor = useDentalServices({ scope: 'doctor' })
+
+    // Start the doctor fetch but DON'T await it — it's our dangling
+    // in-flight fetch.
+    const doctorEnsure = doctor.ensureLoaded()
+    expect(doctor.loading.value).toBe(true)
+
+    // Pre-populate the clinic cache and run the update — this fires
+    // `invalidateScope('doctor')` mid-flight on the doctor cache.
+    await clinic.ensureLoaded()
+    await clinic.updateService('clinic-A', { price: 200 })
+
+    // After invalidation, doctor cache is reset. loaded=false, services empty.
+    expect(doctor.loaded.value).toBe(false)
+    expect(doctor.services.value).toEqual([])
+
+    // NOW release the dangling doctor fetch with stale data. The fetch's
+    // generation snapshot no longer matches the cache's bumped
+    // generation, so its result is dropped silently.
+    releaseDoctorFetch({ data: [makeRow('A', { override_price: 999 })] })
+    await doctorEnsure
+
+    expect(doctor.services.value).toEqual([]) // STILL empty — stale write rejected
+    expect(doctor.loaded.value).toBe(false)
+  })
+})
+
+describe('useDentalServices — updateClinicService', () => {
+  it('refreshes effective_* alongside clinic_* after a toggle', async () => {
+    // The clinic-update endpoint returns the raw ClinicService model
+    // (price + is_active, no clinic_* / effective_*). The composable has
+    // to map raw → typed AND refresh effective_* (clinic-scope rows have
+    // no override, so effective_* mirror clinic_*).
+    const api = mockApi({
+      listServices: vi.fn().mockResolvedValue({
+        data: [makeRow('A', {
+          clinic_is_active: true,
+          effective_is_active: true,
+          is_active: true,
+        })],
+      }),
+      updateService: vi.fn().mockResolvedValue({
+        data: { uuid: 'sys-A', price: 100, is_active: false },
+      }),
+    })
+    const { useDentalServices } = await loadComposable(api)
+
+    const clinic = useDentalServices({ scope: 'clinic' })
+    await clinic.ensureLoaded()
+    await clinic.updateService('clinic-A', { is_active: false })
+
+    const row = clinic.services.value[0]
+    expect(row).toBeDefined()
+    expect(row?.clinic_is_active).toBe(false)
+    expect(row?.is_active).toBe(false) // back-compat alias
+    expect(row?.effective_is_active).toBe(false) // pass 3 fix
+  })
+
+  it('updates clinic_price from the payload (raw response would lack it)', async () => {
+    const api = mockApi({
+      listServices: vi.fn().mockResolvedValue({ data: [makeRow('A', { clinic_price: 100 })] }),
+      updateService: vi.fn().mockResolvedValue({
+        data: { uuid: 'sys-A', price: 250, is_active: true },
+      }),
+    })
+    const { useDentalServices } = await loadComposable(api)
+
+    const clinic = useDentalServices({ scope: 'clinic' })
+    await clinic.ensureLoaded()
+    await clinic.updateService('clinic-A', { price: 250 })
+
+    const row = clinic.services.value[0]
+    expect(row?.clinic_price).toBe(250)
+    expect(row?.effective_price).toBe(250)
+  })
+
+  it('drops the doctor cache when a clinic update happens', async () => {
+    const api = mockApi({
+      listServices: vi.fn().mockResolvedValue({ data: [makeRow('A')] }),
+      listMyServices: vi.fn().mockResolvedValue({ data: [makeRow('A')] }),
+      updateService: vi.fn().mockResolvedValue({
+        data: { uuid: 'sys-A', price: 250, is_active: true },
+      }),
+    })
+    const { useDentalServices } = await loadComposable(api)
+
+    const clinic = useDentalServices({ scope: 'clinic' })
+    const doctor = useDentalServices({ scope: 'doctor' })
+    await clinic.ensureLoaded()
+    await doctor.ensureLoaded()
+    expect(doctor.loaded.value).toBe(true)
+    expect(doctor.services.value).toHaveLength(1)
+
+    await clinic.updateService('clinic-A', { price: 250 })
+
+    expect(doctor.loaded.value).toBe(false)
+    expect(doctor.services.value).toEqual([])
+  })
+})
+
+describe('useDentalServices — updateDoctorService', () => {
+  it('merges the patch into the doctor cache row', async () => {
+    const api = mockApi({
+      listMyServices: vi.fn().mockResolvedValue({ data: [makeRow('A', { effective_price: 100 })] }),
+      updateMyService: vi.fn().mockResolvedValue({
+        data: makeRow('A', {
+          override_price: 700,
+          override_is_active: null,
+          effective_price: 700,
+          effective_is_active: true,
+          is_active: true,
+        }),
+      }),
+    })
+    const { useDentalServices } = await loadComposable(api)
+
+    const doctor = useDentalServices({ scope: 'doctor' })
+    await doctor.ensureLoaded()
+    await doctor.updateService('clinic-A', { price: 700 })
+
+    const row = doctor.services.value[0]
+    expect(row?.override_price).toBe(700)
+    expect(row?.effective_price).toBe(700)
+  })
+})
+
+describe('useDentalServices — derived state', () => {
+  it('groupedByCategory partitions rows by category', async () => {
+    const api = mockApi({
+      listServices: vi.fn().mockResolvedValue({
+        data: [
+          makeRow('A', { category: 'preventive' }),
+          makeRow('B', { category: 'preventive' }),
+          makeRow('C', { category: 'restorative' }),
+        ],
+      }),
+    })
+    const { useDentalServices } = await loadComposable(api)
+
+    const c = useDentalServices({ scope: 'clinic' })
+    await c.ensureLoaded()
+    await nextTick()
+
+    expect(c.groupedByCategory.value.preventive).toHaveLength(2)
+    expect(c.groupedByCategory.value.restorative).toHaveLength(1)
+  })
+
+  it('findByCode returns the row matching cdt_code', async () => {
+    const api = mockApi({
+      listServices: vi.fn().mockResolvedValue({
+        data: [makeRow('A'), makeRow('B')],
+      }),
+    })
+    const { useDentalServices } = await loadComposable(api)
+
+    const c = useDentalServices({ scope: 'clinic' })
+    await c.ensureLoaded()
+
+    expect(c.findByCode('DA')?.cdt_code).toBe('DA')
+    expect(c.findByCode('DZ')).toBeUndefined()
+  })
+})

--- a/src/domains/dental/composables/useDentalServices.ts
+++ b/src/domains/dental/composables/useDentalServices.ts
@@ -1,38 +1,87 @@
-import { computed, effectScope, ref, watch } from 'vue'
+import { computed, effectScope, ref, watch, type Ref, type ComputedRef } from 'vue'
 import { useAuthStore } from '@/domains/auth/stores/authStore'
 import { dentalApi } from '../api/dentalApi'
 import type {
   DentalServiceCatalogEntry,
   DentalServiceCategory,
   UpdateDentalServicePayload,
+  UpdateDoctorDentalServicePayload,
 } from '../types/dental.types'
 
 /**
- * Central access point for a clinic's dental fee schedule.
+ * Central access point for the dental fee schedule.
  *
- * - Fetched lazily on first consumer.
- * - Cache invalidates when the active clinic changes (clinic switch /
- *   logout / re-login) so a dentist who moves between clinics doesn't
- *   bill with the prior clinic's prices. The cache also invalidates
- *   on `window.focus` so a price change made by the clinic admin in
- *   another tab is picked up the next time the dentist looks at the
- *   chart.
- * - `updateService` patches the backend and refreshes cache for the
- *   originating tab.
+ * Two scopes share the same surface:
+ *
+ * - `'clinic'` (default, back-compat): clinic-wide catalog. Edits hit
+ *   `PATCH /dental/services/{uuid}`. Used by the auto-coder, odontogram
+ *   display, visit view, and the clinic-settings fee schedule editor.
+ * - `'doctor'`: the same catalog rows merged with the signed-in dentist's
+ *   `DoctorService` overrides. Edits hit `PATCH /me/dental/services/{uuid}`
+ *   and clearing the price (or toggling activation) sends `null`, which
+ *   the backend interprets as "use clinic default" (and deletes the
+ *   override row when both fields revert to defaults).
+ *
+ * Each scope keeps its own cache so flipping between the two views in the
+ * same session doesn't cross-contaminate. Both caches invalidate on
+ * clinic switch and on `window.focus` so a price change in another tab
+ * is picked up the next time the user looks.
  */
 
-const services = ref<DentalServiceCatalogEntry[]>([])
-const loaded = ref(false)
-const loading = ref(false)
-const error = ref<string | null>(null)
+export type DentalServiceScope = 'clinic' | 'doctor'
 
-let pendingLoad: Promise<void> | null = null
+interface ScopeCache {
+  services: Ref<DentalServiceCatalogEntry[]>
+  loaded: Ref<boolean>
+  loading: Ref<boolean>
+  error: Ref<string | null>
+  pendingLoad: Promise<void> | null
+  /**
+   * Bumped on every invalidation. Each in-flight `ensureLoaded` snapshots
+   * the value at fetch start and only commits its result if the snapshot
+   * still matches — protects against a race where an invalidation happens
+   * mid-fetch and the dangling response would otherwise repopulate the
+   * just-cleared cache (and silently re-mark it `loaded`).
+   */
+  generation: number
+}
+
+function createCache(): ScopeCache {
+  return {
+    services: ref<DentalServiceCatalogEntry[]>([]),
+    loaded: ref(false),
+    loading: ref(false),
+    error: ref<string | null>(null),
+    pendingLoad: null,
+    generation: 0,
+  }
+}
+
+const caches: Record<DentalServiceScope, ScopeCache> = {
+  clinic: createCache(),
+  doctor: createCache(),
+}
+
 let initialised = false
 
-function invalidate(): void {
-  services.value = []
-  loaded.value = false
-  pendingLoad = null
+function invalidateScope(scope: DentalServiceScope): void {
+  const c = caches[scope]
+  c.services.value = []
+  c.loaded.value = false
+  // Reset transient state too: a fetch dangling from before this
+  // invalidation is now disowned (its `finally` is gated on the
+  // generation match), so it won't reset `loading` itself. Without this
+  // line a stale spinner would persist until something else re-fetches.
+  c.loading.value = false
+  c.error.value = null
+  c.pendingLoad = null
+  c.generation++
+}
+
+function invalidateAll(): void {
+  for (const scope of ['clinic', 'doctor'] as const) {
+    invalidateScope(scope)
+  }
 }
 
 // Detached scope so the watcher gets a stop handle (Vite HMR can call
@@ -48,11 +97,13 @@ function bindCacheBusters(): void {
 
   cacheBusterScope.run(() => {
     const auth = useAuthStore()
-    // Clinic switch / logout — pricing belongs to the active clinic.
+    // Clinic switch / logout — both clinic prices and doctor overrides
+    // are clinic-scoped on the backend (a multi-clinic dentist keeps
+    // separate override sets per clinic), so both caches drop together.
     watch(
       () => auth.currentClinic?.id ?? null,
-      (next, prev) => {
-        if (prev != null && prev !== next) invalidate()
+      (next: string | null, prev: string | null) => {
+        if (prev != null && prev !== next) invalidateAll()
       },
     )
   })
@@ -61,8 +112,10 @@ function bindCacheBusters(): void {
   // dentist's tab refetches on next focus instead of running stale
   // until full reload.
   cacheBusterFocusHandler = () => {
-    if (loaded.value) {
-      void ensureLoaded(true)
+    for (const scope of ['clinic', 'doctor'] as const) {
+      if (caches[scope].loaded.value) {
+        void ensureLoaded(scope, true)
+      }
     }
   }
   window.addEventListener('focus', cacheBusterFocusHandler)
@@ -80,59 +133,168 @@ if (typeof import.meta !== 'undefined' && import.meta.hot) {
     initialised = false
     // Reset module-scoped state too. Without this, the next hot-reload
     // re-initialises with stale `loaded === true` and skips the fetch
-    // that would have rebuilt `services`.
-    services.value = []
-    loaded.value = false
-    loading.value = false
-    error.value = null
-    pendingLoad = null
+    // that would have rebuilt `services`. Bump generation alongside the
+    // reset so any in-flight fetch on the dying module discards its
+    // dangling response on completion.
+    for (const scope of ['clinic', 'doctor'] as const) {
+      invalidateScope(scope)
+    }
   })
 }
 
-async function ensureLoaded(force = false): Promise<void> {
-  if (loaded.value && !force) return
-  if (pendingLoad && !force) return pendingLoad
+async function fetchByScope(scope: DentalServiceScope): Promise<DentalServiceCatalogEntry[]> {
+  const res = scope === 'doctor' ? await dentalApi.listMyServices() : await dentalApi.listServices()
+  return res.data
+}
 
-  loading.value = true
-  error.value = null
-  pendingLoad = (async () => {
+async function ensureLoaded(scope: DentalServiceScope, force = false): Promise<void> {
+  const cache = caches[scope]
+  if (cache.loaded.value && !force) return
+  if (cache.pendingLoad && !force) return cache.pendingLoad
+
+  cache.loading.value = true
+  cache.error.value = null
+  // Snapshot the generation at fetch start. If the cache is invalidated
+  // mid-fetch, generation will advance and we drop the stale response on
+  // arrival rather than letting it overwrite the just-cleared cache.
+  const fetchGen = cache.generation
+  cache.pendingLoad = (async () => {
     try {
-      const res = await dentalApi.listServices()
-      services.value = res.data
-      loaded.value = true
+      const data = await fetchByScope(scope)
+      if (cache.generation !== fetchGen) {
+        // Invalidated mid-fetch — drop the result silently.
+        return
+      }
+      cache.services.value = data
+      cache.loaded.value = true
     } catch (err) {
-      error.value = err instanceof Error ? err.message : 'Failed to load dental services.'
+      if (cache.generation === fetchGen) {
+        cache.error.value = err instanceof Error ? err.message : 'Failed to load dental services.'
+      }
       throw err
     } finally {
-      loading.value = false
-      pendingLoad = null
+      if (cache.generation === fetchGen) {
+        cache.loading.value = false
+        cache.pendingLoad = null
+      }
     }
   })()
 
-  return pendingLoad
+  return cache.pendingLoad
 }
 
-async function updateService(clinicServiceUuid: string, payload: UpdateDentalServicePayload): Promise<void> {
-  const res = await dentalApi.updateService(clinicServiceUuid, payload)
-  const idx = services.value.findIndex((s) => s.clinic_service_uuid === clinicServiceUuid)
-  if (idx >= 0) {
-    const existing = services.value[idx]
-    if (existing) {
-      services.value[idx] = {
-        ...existing,
-        clinic_price: res.data.clinic_price ?? existing.clinic_price,
-        is_active: res.data.is_active ?? existing.is_active,
-      }
-    }
+/**
+ * Merge a server response back into the cache row, preserving fields the
+ * server might not echo. The doctor endpoint may return only override
+ * fields and the clinic endpoint may return only clinic fields; falling
+ * back to the existing row keeps `clinic_price` / `clinic_is_active`
+ * stable for non-billing consumers (auto-coder, odontogram display) that
+ * read those directly.
+ */
+function mergeRow(
+  existing: DentalServiceCatalogEntry,
+  patch: DentalServiceCatalogEntry,
+): DentalServiceCatalogEntry {
+  return {
+    ...existing,
+    ...patch,
+    clinic_price: patch.clinic_price ?? existing.clinic_price,
+    clinic_is_active: patch.clinic_is_active ?? existing.clinic_is_active,
   }
 }
 
-export function useDentalServices() {
+async function updateClinicService(
+  clinicServiceUuid: string,
+  payload: UpdateDentalServicePayload,
+): Promise<void> {
+  // The clinic update endpoint echoes the raw ClinicService model — it ships
+  // `price` and `is_active` but NOT the typed `clinic_*` / `effective_*` /
+  // back-compat `is_active` fields the cache expects. mergeRow's null-safe
+  // fallback would leave `clinic_is_active` stale after a toggle and the
+  // Switch would visually bounce back. Instead, apply the payload directly:
+  // the API call has already succeeded by the time we run, and the payload
+  // is canonical for what we asked the server to set.
+  const raw = (await dentalApi.updateService(clinicServiceUuid, payload)).data as
+    & Partial<DentalServiceCatalogEntry>
+    & { price?: number | null; is_active?: boolean | null }
+  const cache = caches.clinic
+  const idx = cache.services.value.findIndex((s) => s.clinic_service_uuid === clinicServiceUuid)
+  if (idx >= 0) {
+    const existing = cache.services.value[idx]
+    if (existing) {
+      const nextClinicPrice = payload.price ?? (typeof raw.price === 'number' ? raw.price : existing.clinic_price)
+      const nextClinicIsActive = payload.is_active ?? (typeof raw.is_active === 'boolean' ? raw.is_active : existing.clinic_is_active)
+      cache.services.value[idx] = {
+        ...existing,
+        clinic_price: nextClinicPrice,
+        clinic_is_active: nextClinicIsActive,
+        // No override exists in clinic-scope rows, so effective_* always
+        // mirrors clinic_*. Refresh both so any consumer that reads
+        // effective_* (auto-coder, billing display) sees the new value
+        // without waiting for a refetch.
+        effective_price: nextClinicPrice,
+        effective_is_active: nextClinicIsActive,
+        is_active: nextClinicIsActive,
+      }
+    }
+  }
+  // Doctor cache derives `effective_*` from the same clinic baseline. A
+  // clinic-side change made while the doctor view is also loaded would
+  // otherwise show stale fallbacks, so drop the doctor cache; next
+  // consumer re-fetches. Bumping the generation in `invalidateScope`
+  // guarantees that any in-flight doctor `ensureLoaded()` will discard
+  // its dangling response when it arrives — preventing the silent
+  // re-loaded race.
+  if (caches.doctor.loaded.value || caches.doctor.pendingLoad) {
+    invalidateScope('doctor')
+  }
+}
+
+async function updateDoctorService(
+  clinicServiceUuid: string,
+  payload: UpdateDoctorDentalServicePayload,
+): Promise<void> {
+  const res = await dentalApi.updateMyService(clinicServiceUuid, payload)
+  const cache = caches.doctor
+  const idx = cache.services.value.findIndex((s) => s.clinic_service_uuid === clinicServiceUuid)
+  if (idx >= 0) {
+    const existing = cache.services.value[idx]
+    if (existing) cache.services.value[idx] = mergeRow(existing, res.data)
+  }
+}
+
+interface UseDentalServicesOptions {
+  scope?: DentalServiceScope
+}
+
+interface UseDentalServicesReturn {
+  services: Ref<DentalServiceCatalogEntry[]>
+  groupedByCategory: ComputedRef<Record<DentalServiceCategory, DentalServiceCatalogEntry[]>>
+  loaded: Ref<boolean>
+  loading: Ref<boolean>
+  error: Ref<string | null>
+  scope: DentalServiceScope
+  ensureLoaded: (force?: boolean) => Promise<void>
+  /**
+   * Save a price/activation change. The payload shape narrows with scope:
+   * doctor scope accepts `is_active: null` (clears the override); clinic
+   * scope does not.
+   */
+  updateService: (
+    clinicServiceUuid: string,
+    payload: UpdateDentalServicePayload | UpdateDoctorDentalServicePayload,
+  ) => Promise<void>
+  findByCode: (code: string) => DentalServiceCatalogEntry | undefined
+}
+
+export function useDentalServices(options: UseDentalServicesOptions = {}): UseDentalServicesReturn {
   bindCacheBusters()
+  const scope: DentalServiceScope = options.scope ?? 'clinic'
+  const cache = caches[scope]
 
   const groupedByCategory = computed<Record<DentalServiceCategory, DentalServiceCatalogEntry[]>>(() => {
     const groups: Partial<Record<DentalServiceCategory, DentalServiceCatalogEntry[]>> = {}
-    for (const s of services.value) {
+    for (const s of cache.services.value) {
       const key = s.category
       ;(groups[key] ??= []).push(s)
     }
@@ -140,16 +302,30 @@ export function useDentalServices() {
   })
 
   function findByCode(code: string): DentalServiceCatalogEntry | undefined {
-    return services.value.find((s) => s.cdt_code === code)
+    return cache.services.value.find((s) => s.cdt_code === code)
+  }
+
+  function ensureLoadedBound(force = false): Promise<void> {
+    return ensureLoaded(scope, force)
+  }
+
+  function updateService(
+    clinicServiceUuid: string,
+    payload: UpdateDentalServicePayload | UpdateDoctorDentalServicePayload,
+  ): Promise<void> {
+    return scope === 'doctor'
+      ? updateDoctorService(clinicServiceUuid, payload)
+      : updateClinicService(clinicServiceUuid, payload as UpdateDentalServicePayload)
   }
 
   return {
-    services,
+    services: cache.services,
     groupedByCategory,
-    loaded,
-    loading,
-    error,
-    ensureLoaded,
+    loaded: cache.loaded,
+    loading: cache.loading,
+    error: cache.error,
+    scope,
+    ensureLoaded: ensureLoadedBound,
     updateService,
     findByCode,
   }

--- a/src/domains/dental/types/dental.types.ts
+++ b/src/domains/dental/types/dental.types.ts
@@ -385,13 +385,53 @@ export interface DentalServiceCatalogEntry {
   default_price: number
   price_min: number | null
   price_max: number | null
-  clinic_price: number
+  /**
+   * Clinic-wide price. Nullable — can be `null` when neither the clinic has
+   * set a price nor the SystemService row has a default. Consumers should
+   * guard before formatting (placeholder, range hint, etc.).
+   * In doctor scope this is the fallback shown as a placeholder.
+   * In clinic scope this is the editable value.
+   */
+  clinic_price: number | null
+  /** Clinic-level activation flag. Always present. */
+  clinic_is_active: boolean
+  /**
+   * Doctor's per-procedure price override. `null` means the doctor uses
+   * the clinic price. Only meaningful in doctor scope; in clinic scope
+   * the backend sets this to `null`.
+   */
+  override_price: number | null
+  /**
+   * Doctor's per-procedure activation override. `null` means the doctor
+   * inherits `clinic_is_active`. Only meaningful in doctor scope.
+   */
+  override_is_active: boolean | null
+  /** Backend-computed: `override_price ?? clinic_price`. */
+  effective_price: number | null
+  /** Backend-computed: `override_is_active ?? clinic_is_active`. */
+  effective_is_active: boolean
+  /**
+   * Back-compat alias. In clinic scope == `clinic_is_active`.
+   * In doctor scope == `effective_is_active`. Existing consumers
+   * (auto-coder, odontogram display, visit view) read this.
+   */
   is_active: boolean
 }
 
 export interface UpdateDentalServicePayload {
   price?: number | null
   is_active?: boolean
+}
+
+/**
+ * Doctor-override upsert payload. `price === null` clears the price
+ * override (falls back to clinic price). `is_active === null` clears
+ * the activation override (falls back to clinic activation). When both
+ * are null, the backend deletes the override row entirely.
+ */
+export interface UpdateDoctorDentalServicePayload {
+  price?: number | null
+  is_active?: boolean | null
 }
 
 // ---- Per-tooth history ----

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -22,5 +22,5 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "vitest.config.ts"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,35 @@
+import path from 'node:path'
+import vue from '@vitejs/plugin-vue'
+import { defineConfig } from 'vitest/config'
+
+// Standalone Vitest config — intentionally NOT extending vite.config.ts so
+// the PWA plugin (which spawns a service-worker build pipeline and pulls
+// in workbox) doesn't run on every test invocation. We only need Vue +
+// path aliases here.
+export default defineConfig({
+  plugins: [vue()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+  define: {
+    // Match the production `define` in vite.config.ts so any source code
+    // that references this token type-checks under the test runner.
+    __COMMIT_HASH__: JSON.stringify('test'),
+  },
+  test: {
+    environment: 'happy-dom',
+    globals: false,
+    include: ['src/**/*.{test,spec}.ts'],
+    // Speed: a single thread keeps module-mocked tests deterministic
+    // (vi.doMock + dynamic imports don't always survive cross-thread
+    // pool serialization in Vitest 3 yet).
+    pool: 'forks',
+    poolOptions: {
+      forks: {
+        singleFork: true,
+      },
+    },
+  },
+})


### PR DESCRIPTION
## Summary

Mounts the dental fee schedule editor in **two places** via a `scope` prop on `DentalBillingTab`:

- **Clinic Settings → Specialties → Dental** (`scope="clinic"`) — clinic-wide defaults.
- **Account → Financial / Billing** (`scope="doctor"`) — per-dentist overrides shown on top of clinic prices (clinic price renders as the input placeholder; clearing the input clears the override).

Pairs with the backend PR (`feat/dental-fee-doctor-overrides`) which adds the `/me/dental/services` endpoints and the resolver-side fallback.

Also stands up Vitest in this repo (no unit-test runner before this PR) and adds a Playwright smoke spec.

## Composable refactor (`useDentalServices`)

- Per-scope caches, scope dispatched via `useDentalServices({ scope })`. Default is `'clinic'` so existing consumers (auto-coder, odontogram display, visit view) stay on the clinic catalog.
- **Generation counter** on each cache: an in-flight fetch that resolves AFTER an invalidation drops its stale result instead of repopulating the just-cleared cache.
- `updateClinicService` maps the raw `ClinicService` PATCH response onto the typed `clinic_*` / `effective_*` / `is_active` fields (the endpoint returns the raw model, not the merged shape).
- `updateClinicService` invalidates the doctor cache (its `effective_*` derives from clinic prices).

## Type contract

- `DentalServiceCatalogEntry` gains `clinic_is_active`, `override_price`, `override_is_active`, `effective_price`, `effective_is_active`.
- `clinic_price` relaxed to `number | null` — the backend may legitimately return null when neither clinic nor system has a price.
- `is_active` kept as a back-compat alias.

## Tooling

- New `vitest.config.ts` (deliberately separate from `vite.config.ts` so the PWA plugin doesn't run on every test invocation).
- `vitest`, `@vue/test-utils`, `happy-dom` in devDependencies.
- New `test` and `test:watch` scripts.
- **14 unit tests** across scope dispatch, ensureLoaded, race-safety, update flows, derived state.
- Playwright smoke spec covering both mount points (skips gracefully when staging seed isn't a dentist).

## Test plan

- [ ] `make npm cmd="install"` to pick up the new devDeps.
- [ ] `make npm cmd="run test"` — all Vitest specs pass.
- [ ] `make npm cmd="run build"` — type check + production build pass.
- [ ] Smoke: open Clinic Settings → Specialties → Dental, verify Tooth Numbering shows above the Fee Schedule card and prices render.
- [ ] Smoke: as a dentist, open Account → Financial / Billing, verify the Fee Schedule shows clinic prices as placeholders, override-then-save persists, clearing the input clears the override.
- [ ] Smoke: clinic admin tweaks a price in another tab → on `window.focus`, the dentist's view picks up the new clinic baseline (re-fetch fires).