### PR TITLE
feat: add clinical glass design foundation

### DIFF
--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -14,7 +14,7 @@ export const test = base.extend<{}, { authenticatedContext: import('@playwright/
     await page.getByRole('textbox', { name: 'Email' }).fill(EMAIL)
     await page.locator('input[type="password"]').fill(PASSWORD)
     await page.getByRole('checkbox', { name: 'Remember me' }).check()
-    await page.getByRole('button', { name: 'Sign in' }).click()
+    await page.getByRole('button', { name: 'Sign in', exact: true }).click()
 
     // Wait for app to be ready
     await expect(page.getByRole('link', { name: /patient/i }).first()).toBeVisible({ timeout: 15000 })

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -11,7 +11,7 @@ export async function login(page: Page) {
   await page.getByRole('textbox', { name: 'Email' }).fill(EMAIL)
   await page.locator('input[type="password"]').fill(PASSWORD)
   await page.getByRole('checkbox', { name: 'Remember me' }).check()
-  await page.getByRole('button', { name: 'Sign in' }).click()
+  await page.getByRole('button', { name: 'Sign in', exact: true }).click()
 
   // Wait for app to be ready (sidebar visible = logged in + clinic selected)
   await expect(page.getByRole('link', { name: /patient/i }).first()).toBeVisible({ timeout: 15000 })

--- a/src/components/layout/DashboardLayout.vue
+++ b/src/components/layout/DashboardLayout.vue
@@ -52,7 +52,7 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <SidebarProvider style="--header-height: 3.5rem">
+  <SidebarProvider class="app-shell" style="--header-height: 3.5rem">
     <AppSidebar />
     <SidebarInset>
       <SiteHeader />

--- a/src/components/layout/SiteHeader.vue
+++ b/src/components/layout/SiteHeader.vue
@@ -130,7 +130,7 @@ function onFocus() {
 
 <template>
   <header
-    class="bg-background sticky top-0 z-50 flex w-full items-center border-b"
+    class="surface-panel sticky top-0 z-50 flex w-full items-center border-b"
     style="height: var(--header-height)"
   >
     <div class="flex h-full w-full items-center gap-2 px-4">
@@ -143,7 +143,7 @@ function onFocus() {
           type="text"
           placeholder="Search patients..."
           aria-label="Search patients"
-          class="bg-muted/50 border-input placeholder:text-muted-foreground h-9 w-full rounded-md border pl-8 pr-8 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+          class="clinical-solid placeholder:text-muted-foreground h-9 w-full rounded-md border pl-8 pr-8 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
           @blur="onBlur"
           @focus="onFocus"
           @keydown="onKeydown"
@@ -155,7 +155,7 @@ function onFocus() {
 
         <div
           v-if="showDropdown && query.trim().length >= 2"
-          class="absolute left-0 top-full z-50 mt-1 w-full rounded-md border bg-popover p-1 text-popover-foreground shadow-md"
+          class="surface-floating absolute left-0 top-full z-50 mt-1 w-full rounded-md border p-1 text-popover-foreground"
         >
           <template v-if="results.length > 0">
             <button

--- a/src/components/ui/alert-dialog/AlertDialogContent.vue
+++ b/src/components/ui/alert-dialog/AlertDialogContent.vue
@@ -26,14 +26,14 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits)
   <AlertDialogPortal>
     <AlertDialogOverlay
       data-slot="alert-dialog-overlay"
-      class="data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/80"
+      class="surface-overlay data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50"
     />
     <AlertDialogContent
       data-slot="alert-dialog-content"
       v-bind="{ ...$attrs, ...forwarded }"
       :class="
         cn(
-          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
+          'surface-floating data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 duration-200 sm:max-w-lg',
           props.class,
         )
       "

--- a/src/components/ui/badge/index.ts
+++ b/src/components/ui/badge/index.ts
@@ -15,7 +15,7 @@ export const badgeVariants = cva(
         destructive:
          "border-transparent bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
         outline:
-          "text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
+          "surface-muted text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
       },
     },
     defaultVariants: {

--- a/src/components/ui/button/index.ts
+++ b/src/components/ui/button/index.ts
@@ -13,7 +13,7 @@ export const buttonVariants = cva(
         destructive:
           "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
         outline:
-          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
+          "surface-muted border hover:bg-accent hover:text-accent-foreground dark:hover:bg-input/50",
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost:

--- a/src/components/ui/card/Card.vue
+++ b/src/components/ui/card/Card.vue
@@ -14,7 +14,7 @@ const props = defineProps<Props>()
     data-slot="card"
     :class="
       cn(
-        'bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm',
+        'surface-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6',
         props.class,
       )
     "

--- a/src/components/ui/combobox/ComboboxList.vue
+++ b/src/components/ui/combobox/ComboboxList.vue
@@ -25,7 +25,7 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits)
     <ComboboxContent
       data-slot="combobox-list"
       v-bind="{ ...$attrs, ...forwarded }"
-      :class="cn('z-50 w-[200px] rounded-md border bg-popover text-popover-foreground origin-(--reka-combobox-content-transform-origin) overflow-hidden shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2', props.class)"
+      :class="cn('surface-floating z-50 w-[200px] rounded-md border text-popover-foreground origin-(--reka-combobox-content-transform-origin) overflow-hidden outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2', props.class)"
     >
       <slot />
     </ComboboxContent>

--- a/src/components/ui/context-menu/ContextMenuContent.vue
+++ b/src/components/ui/context-menu/ContextMenuContent.vue
@@ -27,7 +27,7 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits)
       data-slot="context-menu-content"
       v-bind="{ ...$attrs, ...forwarded }"
       :class="cn(
-        'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--reka-context-menu-content-available-height) min-w-[8rem] overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md',
+        'surface-floating text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--reka-context-menu-content-available-height) min-w-[8rem] overflow-x-hidden overflow-y-auto rounded-md border p-1',
         props.class,
       )"
     >

--- a/src/components/ui/context-menu/ContextMenuSubContent.vue
+++ b/src/components/ui/context-menu/ContextMenuSubContent.vue
@@ -22,7 +22,7 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits)
     v-bind="forwarded"
     :class="
       cn(
-        'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--reka-context-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg',
+        'surface-floating text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--reka-context-menu-content-transform-origin) overflow-hidden rounded-md border p-1',
         props.class,
       )
     "

--- a/src/components/ui/dialog/DialogContent.vue
+++ b/src/components/ui/dialog/DialogContent.vue
@@ -34,7 +34,7 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits)
       v-bind="{ ...$attrs, ...forwarded }"
       :class="
         cn(
-          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
+          'surface-floating data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 duration-200 sm:max-w-lg',
           props.class,
         )"
     >
@@ -43,7 +43,7 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits)
       <DialogClose
         v-if="showCloseButton"
         data-slot="dialog-close"
-        class="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+        class="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:bg-accent hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
       >
         <Cross2Icon />
         <span class="sr-only">Close</span>

--- a/src/components/ui/dialog/DialogOverlay.vue
+++ b/src/components/ui/dialog/DialogOverlay.vue
@@ -14,7 +14,7 @@ const delegatedProps = reactiveOmit(props, "class")
   <DialogOverlay
     data-slot="dialog-overlay"
     v-bind="delegatedProps"
-    :class="cn('data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/80', props.class)"
+    :class="cn('surface-overlay data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50', props.class)"
   >
     <slot />
   </DialogOverlay>

--- a/src/components/ui/dialog/DialogScrollContent.vue
+++ b/src/components/ui/dialog/DialogScrollContent.vue
@@ -27,12 +27,12 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits)
 <template>
   <DialogPortal>
     <DialogOverlay
-      class="fixed inset-0 z-50 grid place-items-center overflow-y-auto bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0"
+      class="surface-overlay fixed inset-0 z-50 grid place-items-center overflow-y-auto data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0"
     >
       <DialogContent
         :class="
           cn(
-            'relative z-50 grid w-full max-w-lg my-8 gap-4 border border-border bg-background p-6 shadow-lg duration-200 sm:rounded-lg md:w-full',
+            'surface-floating relative z-50 grid w-full max-w-lg my-8 gap-4 border p-6 duration-200 sm:rounded-lg md:w-full',
             props.class,
           )
         "
@@ -48,7 +48,7 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits)
         <slot />
 
         <DialogClose
-          class="absolute top-4 right-4 p-0.5 transition-colors rounded-md hover:bg-secondary"
+          class="absolute top-4 right-4 rounded-md p-0.5 transition-colors hover:bg-accent"
         >
           <Cross2Icon class="w-4 h-4" />
           <span class="sr-only">Close</span>

--- a/src/components/ui/dropdown-menu/DropdownMenuContent.vue
+++ b/src/components/ui/dropdown-menu/DropdownMenuContent.vue
@@ -31,7 +31,7 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits)
     <DropdownMenuContent
       data-slot="dropdown-menu-content"
       v-bind="{ ...$attrs, ...forwarded }"
-      :class="cn('bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--reka-dropdown-menu-content-available-height) min-w-[8rem] origin-(--reka-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md', props.class)"
+      :class="cn('surface-floating text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--reka-dropdown-menu-content-available-height) min-w-[8rem] origin-(--reka-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1', props.class)"
     >
       <slot />
     </DropdownMenuContent>

--- a/src/components/ui/dropdown-menu/DropdownMenuSubContent.vue
+++ b/src/components/ui/dropdown-menu/DropdownMenuSubContent.vue
@@ -20,7 +20,7 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits)
   <DropdownMenuSubContent
     data-slot="dropdown-menu-sub-content"
     v-bind="forwarded"
-    :class="cn('bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--reka-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg', props.class)"
+    :class="cn('surface-floating text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--reka-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border p-1', props.class)"
   >
     <slot />
   </DropdownMenuSubContent>

--- a/src/components/ui/input/Input.vue
+++ b/src/components/ui/input/Input.vue
@@ -24,7 +24,7 @@ const modelValue = useVModel(props, "modelValue", emits, {
     v-model="modelValue"
     data-slot="input"
     :class="cn(
-      'file:text-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+      'clinical-solid file:text-foreground selection:bg-primary selection:text-primary-foreground h-9 w-full min-w-0 rounded-md border px-3 py-1 text-base transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
       'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]',
       'aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive',
       props.class,

--- a/src/components/ui/input/PasswordInput.vue
+++ b/src/components/ui/input/PasswordInput.vue
@@ -30,7 +30,7 @@ const showPassword = ref(false)
       :type="showPassword ? 'text' : 'password'"
       data-slot="input"
       :class="cn(
-        'file:text-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 pr-9 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+        'clinical-solid file:text-foreground selection:bg-primary selection:text-primary-foreground h-9 w-full min-w-0 rounded-md border px-3 py-1 pr-9 text-base transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
         'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]',
         'aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive',
         props.class,

--- a/src/components/ui/native-select/NativeSelect.vue
+++ b/src/components/ui/native-select/NativeSelect.vue
@@ -33,7 +33,7 @@ const delegatedProps = reactiveOmit(props, "class")
       v-model="modelValue"
       data-slot="native-select"
       :class="cn(
-        'border-input selection:bg-primary selection:text-primary-foreground dark:bg-input/30 dark:hover:bg-input/50 h-9 w-full min-w-0 appearance-none rounded-md border bg-transparent px-3 py-2 pr-9 text-sm shadow-xs transition-[color,box-shadow] outline-none disabled:pointer-events-none disabled:cursor-not-allowed',
+        'clinical-solid selection:bg-primary selection:text-primary-foreground dark:hover:bg-input/50 h-9 w-full min-w-0 appearance-none rounded-md border px-3 py-2 pr-9 text-sm transition-[color,box-shadow] outline-none disabled:pointer-events-none disabled:cursor-not-allowed',
         'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]',
         'aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive',
         props.class,

--- a/src/components/ui/popover/PopoverContent.vue
+++ b/src/components/ui/popover/PopoverContent.vue
@@ -34,7 +34,7 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits)
       v-bind="{ ...$attrs, ...forwarded }"
       :class="
         cn(
-          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 rounded-md border p-4 shadow-md origin-(--reka-popover-content-transform-origin) outline-hidden',
+          'surface-floating text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 rounded-md border p-4 origin-(--reka-popover-content-transform-origin) outline-hidden',
           props.class,
         )
       "

--- a/src/components/ui/select/SelectContent.vue
+++ b/src/components/ui/select/SelectContent.vue
@@ -34,7 +34,7 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits)
       data-slot="select-content"
       v-bind="{ ...$attrs, ...forwarded }"
       :class="cn(
-        'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--reka-select-content-available-height) min-w-[8rem] overflow-x-hidden overflow-y-auto rounded-md border shadow-md',
+        'surface-floating text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--reka-select-content-available-height) min-w-[8rem] overflow-x-hidden overflow-y-auto rounded-md border',
         position === 'popper'
           && 'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
         props.class,

--- a/src/components/ui/select/SelectTrigger.vue
+++ b/src/components/ui/select/SelectTrigger.vue
@@ -21,7 +21,7 @@ const forwardedProps = useForwardProps(delegatedProps)
     :data-size="size"
     v-bind="forwardedProps"
     :class="cn(
-      'border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*=\'text-\'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-full items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*=\'size-\'])]:size-4',
+      'clinical-solid data-[placeholder]:text-muted-foreground [&_svg:not([class*=\'text-\'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:hover:bg-input/50 flex w-full items-center justify-between gap-2 rounded-md border px-3 py-2 text-sm whitespace-nowrap transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*=\'size-\'])]:size-4',
       props.class,
     )"
   >

--- a/src/components/ui/sheet/SheetContent.vue
+++ b/src/components/ui/sheet/SheetContent.vue
@@ -37,7 +37,7 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits)
     <DialogContent
       data-slot="sheet-content"
       :class="cn(
-        'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500',
+        'surface-floating data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500',
         side === 'right'
           && 'data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm',
         side === 'left'
@@ -52,7 +52,7 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits)
       <slot />
 
       <DialogClose
-        class="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none"
+        class="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:bg-accent hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none"
       >
         <Cross2Icon class="size-4" />
         <span class="sr-only">Close</span>

--- a/src/components/ui/sheet/SheetOverlay.vue
+++ b/src/components/ui/sheet/SheetOverlay.vue
@@ -13,7 +13,7 @@ const delegatedProps = reactiveOmit(props, "class")
 <template>
   <DialogOverlay
     data-slot="sheet-overlay"
-    :class="cn('data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/80', props.class)"
+    :class="cn('surface-overlay data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50', props.class)"
     v-bind="delegatedProps"
   >
     <slot />

--- a/src/components/ui/sidebar/Sidebar.vue
+++ b/src/components/ui/sidebar/Sidebar.vue
@@ -24,7 +24,7 @@ const { isMobile, state, openMobile, setOpenMobile } = useSidebar()
   <div
     v-if="collapsible === 'none'"
     data-slot="sidebar"
-    :class="cn('bg-sidebar text-sidebar-foreground flex h-full w-(--sidebar-width) flex-col', props.class)"
+    :class="cn('surface-sidebar text-sidebar-foreground flex h-full w-(--sidebar-width) flex-col border-r', props.class)"
     v-bind="$attrs"
   >
     <slot />
@@ -36,7 +36,7 @@ const { isMobile, state, openMobile, setOpenMobile } = useSidebar()
       data-slot="sidebar"
       data-mobile="true"
       :side="side"
-      class="bg-sidebar text-sidebar-foreground w-(--sidebar-width) p-0 [&>button]:hidden"
+      class="surface-sidebar text-sidebar-foreground w-(--sidebar-width) p-0 [&>button]:hidden"
       :style="{
         '--sidebar-width': SIDEBAR_WIDTH_MOBILE,
       }"
@@ -80,14 +80,14 @@ const { isMobile, state, openMobile, setOpenMobile } = useSidebar()
         // Adjust the padding for floating and inset variants.
         variant === 'floating' || variant === 'inset'
           ? 'p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]'
-          : 'group-data-[collapsible=icon]:w-(--sidebar-width-icon) group-data-[side=left]:border-r group-data-[side=right]:border-l',
+          : 'group-data-[collapsible=icon]:w-(--sidebar-width-icon)',
         props.class,
       )"
       v-bind="$attrs"
     >
       <div
         data-sidebar="sidebar"
-        class="bg-sidebar group-data-[variant=floating]:border-sidebar-border flex h-full w-full flex-col group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:shadow-sm"
+        class="surface-sidebar flex h-full w-full flex-col border group-data-[variant=floating]:rounded-lg group-data-[variant=inset]:rounded-xl"
       >
         <slot />
       </div>

--- a/src/components/ui/sidebar/SidebarInput.vue
+++ b/src/components/ui/sidebar/SidebarInput.vue
@@ -13,7 +13,7 @@ const props = defineProps<{
     data-slot="sidebar-input"
     data-sidebar="input"
     :class="cn(
-      'bg-background h-8 w-full shadow-none',
+      'h-8 w-full shadow-none',
       props.class,
     )"
   >

--- a/src/components/ui/sidebar/SidebarInset.vue
+++ b/src/components/ui/sidebar/SidebarInset.vue
@@ -11,8 +11,8 @@ const props = defineProps<{
   <main
     data-slot="sidebar-inset"
     :class="cn(
-      'bg-background relative flex min-h-0 min-w-0 w-full flex-1 flex-col overflow-hidden',
-      'md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2',
+      'relative flex min-h-0 min-w-0 w-full flex-1 flex-col overflow-hidden',
+      'md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2',
       props.class,
     )"
   >

--- a/src/components/ui/sidebar/SidebarMenuSubButton.vue
+++ b/src/components/ui/sidebar/SidebarMenuSubButton.vue
@@ -23,8 +23,8 @@ const props = withDefaults(defineProps<PrimitiveProps & {
     :data-size="size"
     :data-active="isActive"
     :class="cn(
-      'text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground [&>svg]:text-sidebar-accent-foreground flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 outline-hidden focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0',
-      'data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground',
+      'surface-interactive text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground [&>svg]:text-sidebar-accent-foreground flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md border border-transparent px-2 outline-hidden focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0',
+      'data-[active=true]:text-sidebar-accent-foreground',
       size === 'sm' && 'text-xs',
       size === 'md' && 'text-sm',
       'group-data-[collapsible=icon]:hidden',

--- a/src/components/ui/sidebar/SidebarProvider.vue
+++ b/src/components/ui/sidebar/SidebarProvider.vue
@@ -72,7 +72,7 @@ provideSidebarContext({
         '--sidebar-width': SIDEBAR_WIDTH,
         '--sidebar-width-icon': SIDEBAR_WIDTH_ICON,
       }"
-      :class="cn('group/sidebar-wrapper has-data-[variant=inset]:bg-sidebar flex h-svh w-full overflow-hidden', props.class)"
+      :class="cn('app-shell group/sidebar-wrapper flex h-svh w-full overflow-hidden', props.class)"
       v-bind="$attrs"
     >
       <slot />

--- a/src/components/ui/sidebar/index.ts
+++ b/src/components/ui/sidebar/index.ts
@@ -36,13 +36,13 @@ export { default as SidebarTrigger } from "./SidebarTrigger.vue"
 export { useSidebar } from "./utils"
 
 export const sidebarMenuButtonVariants = cva(
-  "peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-hidden ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-data-[sidebar=menu-action]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
+  "peer/menu-button surface-interactive flex w-full items-center gap-2 overflow-hidden rounded-md border border-transparent p-2 text-left text-sm outline-hidden ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-data-[sidebar=menu-action]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
   {
     variants: {
       variant: {
         default: "hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
         outline:
-          "bg-background shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))]",
+          "surface-muted hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
       },
       size: {
         default: "h-8 text-sm",

--- a/src/components/ui/tabs/TabsList.vue
+++ b/src/components/ui/tabs/TabsList.vue
@@ -25,7 +25,7 @@ const sizeClasses: Record<string, string> = {
     data-slot="tabs-list"
     v-bind="delegatedProps"
     :class="cn(
-      'bg-muted text-muted-foreground inline-flex w-fit items-center justify-center rounded-lg',
+      'surface-muted text-muted-foreground inline-flex w-fit items-center justify-center rounded-lg border',
       sizeClasses[size],
       props.class,
     )"

--- a/src/components/ui/tabs/TabsTrigger.vue
+++ b/src/components/ui/tabs/TabsTrigger.vue
@@ -26,7 +26,7 @@ const sizeClasses: Record<string, string> = {
   <TabsTrigger
     data-slot="tabs-trigger"
     :class="cn(
-      'data-[state=active]:bg-background dark:data-[state=active]:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 text-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center rounded-md border border-transparent font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*=\'size-\'])]:size-4',
+      'data-[state=active]:bg-[var(--surface-solid)] dark:data-[state=active]:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring dark:data-[state=active]:border-input text-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center rounded-md border border-transparent font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*=\'size-\'])]:size-4',
       sizeClasses[size],
       props.class,
     )"

--- a/src/components/ui/textarea/Textarea.vue
+++ b/src/components/ui/textarea/Textarea.vue
@@ -23,6 +23,6 @@ const modelValue = useVModel(props, "modelValue", emits, {
   <textarea
     v-model="modelValue"
     data-slot="textarea"
-    :class="cn('border-input focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm', props.class)"
+    :class="cn('clinical-solid focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive flex field-sizing-content min-h-16 w-full rounded-md border px-3 py-2 text-base transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm', props.class)"
   />
 </template>

--- a/src/components/ui/tooltip/TooltipContent.vue
+++ b/src/components/ui/tooltip/TooltipContent.vue
@@ -24,11 +24,11 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits)
     <TooltipContent
       data-slot="tooltip-content"
       v-bind="{ ...forwarded, ...$attrs }"
-      :class="cn('bg-popover text-popover-foreground border shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit rounded-md px-3 py-1.5 text-xs text-balance', props.class)"
+      :class="cn('surface-floating text-popover-foreground border animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit rounded-md px-3 py-1.5 text-xs text-balance', props.class)"
     >
       <slot />
 
-      <TooltipArrow class="bg-popover fill-popover z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px] border-r border-b" />
+      <TooltipArrow class="z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px] border-r border-b bg-[var(--surface-floating)] fill-[var(--surface-floating)]" />
     </TooltipContent>
   </TooltipPortal>
 </template>

--- a/src/domains/auth/views/ForgotPasswordView.vue
+++ b/src/domains/auth/views/ForgotPasswordView.vue
@@ -71,7 +71,7 @@ const onSubmit = handleSubmit(async (values) => {
 </script>
 
 <template>
-  <div class="relative flex min-h-screen items-center justify-center overflow-hidden bg-background px-4">
+  <div class="auth-shell relative flex min-h-screen items-center justify-center overflow-hidden px-4">
     <canvas ref="canvasRef" class="pointer-events-none absolute inset-0" />
 
     <div
@@ -90,7 +90,7 @@ const onSubmit = handleSubmit(async (values) => {
         :class="ready ? 'translate-y-0 opacity-100' : 'translate-y-6 opacity-0'"
       >
         <!-- Success state -->
-        <Card v-if="submitted" class="backdrop-blur-sm bg-card/90">
+        <Card v-if="submitted" class="border-primary/20 shadow-[0_28px_90px_-42px_oklch(0.28_0.09_245_/_0.65)]">
           <CardHeader class="text-center">
             <div class="mx-auto mb-2 flex size-12 items-center justify-center rounded-full bg-green-500/10">
               <CircleCheck class="size-6 text-green-600 dark:text-green-400" />
@@ -111,7 +111,7 @@ const onSubmit = handleSubmit(async (values) => {
         </Card>
 
         <!-- Form state -->
-        <Card v-else class="backdrop-blur-sm bg-card/90">
+        <Card v-else class="border-primary/20 shadow-[0_28px_90px_-42px_oklch(0.28_0.09_245_/_0.65)]">
           <CardHeader class="text-center">
             <CardTitle class="text-xl">Forgot password?</CardTitle>
             <CardDescription>Enter your email and we'll send you a reset link</CardDescription>

--- a/src/domains/auth/views/LinkGoogleView.vue
+++ b/src/domains/auth/views/LinkGoogleView.vue
@@ -54,13 +54,13 @@ onMounted(() => {
 </script>
 
 <template>
-  <div class="flex min-h-screen items-center justify-center bg-background px-4">
+  <div class="auth-shell flex min-h-screen items-center justify-center px-4">
     <div class="w-full max-w-sm">
       <div class="mb-4 flex justify-center">
         <AppLogo class="h-24 w-auto" />
       </div>
 
-      <Card class="backdrop-blur-sm bg-card/90">
+      <Card class="border-primary/20 shadow-[0_28px_90px_-42px_oklch(0.28_0.09_245_/_0.65)]">
         <CardHeader class="text-center">
           <div class="mb-2 flex justify-center">
             <LoaderCircle v-if="isLoading" class="size-8 animate-spin text-primary" />

--- a/src/domains/auth/views/LoginView.vue
+++ b/src/domains/auth/views/LoginView.vue
@@ -164,7 +164,7 @@ async function requestGoogleLink(): Promise<void> {
 </script>
 
 <template>
-  <div class="relative flex min-h-screen items-center justify-center overflow-hidden bg-background px-4">
+  <div class="auth-shell relative flex min-h-screen items-center justify-center overflow-hidden px-4">
     <canvas ref="canvasRef" class="pointer-events-none absolute inset-0" />
 
     <div
@@ -182,7 +182,7 @@ async function requestGoogleLink(): Promise<void> {
         class="transition-all delay-200 duration-700 ease-out"
         :class="ready ? 'translate-y-0 opacity-100' : 'translate-y-6 opacity-0'"
       >
-        <Card class="backdrop-blur-sm bg-card/90">
+        <Card class="border-primary/20 shadow-[0_28px_90px_-42px_oklch(0.28_0.09_245_/_0.65)]">
           <CardHeader class="text-center">
             <CardTitle class="text-xl">Welcome back!</CardTitle>
             <CardDescription>Sign in to your account</CardDescription>

--- a/src/domains/auth/views/ResetPasswordView.vue
+++ b/src/domains/auth/views/ResetPasswordView.vue
@@ -93,7 +93,7 @@ const onSubmit = handleSubmit(async (values) => {
 </script>
 
 <template>
-  <div class="relative flex min-h-screen items-center justify-center overflow-hidden bg-background px-4">
+  <div class="auth-shell relative flex min-h-screen items-center justify-center overflow-hidden px-4">
     <canvas ref="canvasRef" class="pointer-events-none absolute inset-0" />
 
     <div
@@ -112,7 +112,7 @@ const onSubmit = handleSubmit(async (values) => {
         :class="ready ? 'translate-y-0 opacity-100' : 'translate-y-6 opacity-0'"
       >
         <!-- Invalid params state -->
-        <Card v-if="!hasValidParams" class="backdrop-blur-sm bg-card/90">
+        <Card v-if="!hasValidParams" class="border-primary/20 shadow-[0_28px_90px_-42px_oklch(0.28_0.09_245_/_0.65)]">
           <CardHeader class="text-center">
             <div class="mx-auto mb-2 flex size-12 items-center justify-center rounded-full bg-destructive/10">
               <CircleX class="size-6 text-destructive" />
@@ -132,7 +132,7 @@ const onSubmit = handleSubmit(async (values) => {
         </Card>
 
         <!-- Success state -->
-        <Card v-else-if="succeeded" class="backdrop-blur-sm bg-card/90">
+        <Card v-else-if="succeeded" class="border-primary/20 shadow-[0_28px_90px_-42px_oklch(0.28_0.09_245_/_0.65)]">
           <CardHeader class="text-center">
             <div class="mx-auto mb-2 flex size-12 items-center justify-center rounded-full bg-green-500/10">
               <CircleCheck class="size-6 text-green-600 dark:text-green-400" />
@@ -153,7 +153,7 @@ const onSubmit = handleSubmit(async (values) => {
         </Card>
 
         <!-- Form state -->
-        <Card v-else class="backdrop-blur-sm bg-card/90">
+        <Card v-else class="border-primary/20 shadow-[0_28px_90px_-42px_oklch(0.28_0.09_245_/_0.65)]">
           <CardHeader class="text-center">
             <CardTitle class="text-xl">Set new password</CardTitle>
             <CardDescription>Enter your new password below</CardDescription>

--- a/src/domains/auth/views/SelectClinicView.vue
+++ b/src/domains/auth/views/SelectClinicView.vue
@@ -54,7 +54,7 @@ async function handleSelectClinic(clinicId: string) {
 </script>
 
 <template>
-  <div class="relative flex min-h-screen items-center justify-center overflow-hidden bg-background px-4 py-8">
+  <div class="auth-shell relative flex min-h-screen items-center justify-center overflow-hidden px-4 py-8">
     <canvas ref="canvasRef" class="pointer-events-none absolute inset-0" />
 
     <div
@@ -97,7 +97,7 @@ async function handleSelectClinic(clinicId: string) {
         <button
           v-for="(membership, i) in authStore.memberships"
           :key="membership.id"
-          class="group relative flex items-center gap-4 rounded-xl border bg-card/90 p-4 backdrop-blur-sm transition-all duration-500 ease-out hover:shadow-lg hover:border-primary/30 hover:-translate-y-1 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50"
+          class="surface-card group relative flex items-center gap-4 rounded-xl border p-4 transition-all duration-500 ease-out hover:-translate-y-1 hover:border-primary/30 hover:shadow-lg focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50"
           :class="ready ? 'translate-y-0 opacity-100' : 'translate-y-6 opacity-0'"
           :style="{ transitionDelay: `${300 + i * 100}ms` }"
           :disabled="isLoading !== null"

--- a/src/domains/auth/views/SignupView.vue
+++ b/src/domains/auth/views/SignupView.vue
@@ -166,7 +166,7 @@ async function requestGoogleLink(): Promise<void> {
 </script>
 
 <template>
-  <div class="relative flex min-h-screen items-center justify-center overflow-hidden bg-background px-4">
+  <div class="auth-shell relative flex min-h-screen items-center justify-center overflow-hidden px-4">
     <canvas ref="canvasRef" class="pointer-events-none absolute inset-0" />
 
     <div
@@ -184,7 +184,7 @@ async function requestGoogleLink(): Promise<void> {
         class="transition-all delay-200 duration-700 ease-out"
         :class="ready ? 'translate-y-0 opacity-100' : 'translate-y-6 opacity-0'"
       >
-        <Card class="backdrop-blur-sm bg-card/90">
+        <Card class="border-primary/20 shadow-[0_28px_90px_-42px_oklch(0.28_0.09_245_/_0.65)]">
           <CardHeader class="text-center">
             <CardTitle class="text-xl">Create an account</CardTitle>
             <CardDescription>Get started with MediFlow</CardDescription>

--- a/src/domains/auth/views/VerifyEmailNoticeView.vue
+++ b/src/domains/auth/views/VerifyEmailNoticeView.vue
@@ -58,7 +58,7 @@ async function resend() {
 </script>
 
 <template>
-  <div class="relative flex min-h-screen items-center justify-center overflow-hidden bg-background px-4">
+  <div class="auth-shell relative flex min-h-screen items-center justify-center overflow-hidden px-4">
     <canvas ref="canvasRef" class="pointer-events-none absolute inset-0" />
 
     <div
@@ -76,7 +76,7 @@ async function resend() {
         class="transition-all delay-200 duration-700 ease-out"
         :class="ready ? 'translate-y-0 opacity-100' : 'translate-y-6 opacity-0'"
       >
-        <Card class="backdrop-blur-sm bg-card/90">
+        <Card class="border-primary/20 shadow-[0_28px_90px_-42px_oklch(0.28_0.09_245_/_0.65)]">
           <CardHeader class="text-center">
             <div class="mx-auto mb-2 flex size-12 items-center justify-center rounded-full bg-primary/10">
               <MailCheck class="size-6 text-primary" />

--- a/src/domains/auth/views/VerifyEmailView.vue
+++ b/src/domains/auth/views/VerifyEmailView.vue
@@ -61,7 +61,7 @@ onMounted(async () => {
 </script>
 
 <template>
-  <div class="relative flex min-h-screen items-center justify-center overflow-hidden bg-background px-4">
+  <div class="auth-shell relative flex min-h-screen items-center justify-center overflow-hidden px-4">
     <canvas ref="canvasRef" class="pointer-events-none absolute inset-0" />
 
     <div
@@ -79,7 +79,7 @@ onMounted(async () => {
         class="transition-all delay-200 duration-700 ease-out"
         :class="ready ? 'translate-y-0 opacity-100' : 'translate-y-6 opacity-0'"
       >
-        <Card class="backdrop-blur-sm bg-card/90">
+        <Card class="border-primary/20 shadow-[0_28px_90px_-42px_oklch(0.28_0.09_245_/_0.65)]">
           <!-- Verifying state -->
           <template v-if="status === 'verifying'">
             <CardHeader class="text-center">

--- a/src/domains/dashboard/components/OwnerRevenueChart.vue
+++ b/src/domains/dashboard/components/OwnerRevenueChart.vue
@@ -82,7 +82,7 @@ onMounted(fetchData)
 </script>
 
 <template>
-  <div class="rounded-xl border bg-card p-6 text-card-foreground shadow-sm">
+  <div class="surface-card rounded-xl border p-6 text-card-foreground">
     <div class="mb-4 flex items-center justify-between">
       <div>
         <h2 class="text-sm font-semibold">Clinic Revenue</h2>

--- a/src/domains/dashboard/components/PatientDistributionChart.vue
+++ b/src/domains/dashboard/components/PatientDistributionChart.vue
@@ -100,7 +100,7 @@ const localCount = computed(() => total.value - other.value)
 </script>
 
 <template>
-  <div class="rounded-xl border bg-card p-6 text-card-foreground shadow-sm">
+  <div class="surface-card rounded-xl border p-6 text-card-foreground">
     <div class="mb-4">
       <h2 class="text-sm font-semibold">Patient Distribution</h2>
       <p v-if="city && !loading" class="text-xs text-muted-foreground">

--- a/src/domains/dashboard/components/RevenueChart.vue
+++ b/src/domains/dashboard/components/RevenueChart.vue
@@ -44,7 +44,7 @@ onMounted(async () => {
 </script>
 
 <template>
-  <div class="relative overflow-hidden rounded-xl border bg-card p-6 text-card-foreground shadow-sm">
+  <div class="surface-card relative overflow-hidden rounded-xl border p-6 text-card-foreground">
     <!-- Sparkline behind content -->
     <div
       v-if="!loading && data.length"

--- a/src/domains/dashboard/components/StatCard.vue
+++ b/src/domains/dashboard/components/StatCard.vue
@@ -26,7 +26,7 @@ const iconColorClass: Record<typeof props.colorClass, string> = {
 </script>
 
 <template>
-  <div class="h-full rounded-xl border bg-card p-6 text-card-foreground shadow-sm">
+  <div class="surface-card h-full rounded-xl border p-6 text-card-foreground">
     <div class="flex items-start justify-between">
       <div class="flex flex-col gap-3">
         <span class="text-sm font-medium text-muted-foreground">{{ label }}</span>

--- a/src/domains/dashboard/views/DoctorDashboardView.vue
+++ b/src/domains/dashboard/views/DoctorDashboardView.vue
@@ -216,7 +216,7 @@ onUnmounted(() => {
       <!-- Widgets grid -->
       <div class="grid gap-4 lg:grid-cols-2 [&>*]:min-w-0">
         <!-- Upcoming Schedule -->
-        <div v-if="hasAppointments && (loading || groupedAppointments.length)" class="rounded-xl border bg-card p-6 text-card-foreground shadow-sm overflow-hidden">
+        <div v-if="hasAppointments && (loading || groupedAppointments.length)" class="surface-card overflow-hidden rounded-xl border p-6 text-card-foreground">
           <div class="mb-4 flex items-center justify-between">
             <h2 class="text-sm font-semibold">Upcoming Schedule</h2>
             <Button variant="ghost" size="sm" class="h-7 text-xs" @click="router.push({ name: RouteNames.APPOINTMENT_LIST })">
@@ -277,7 +277,7 @@ onUnmounted(() => {
         </div>
 
         <!-- Queue Preview -->
-        <div v-if="hasAppointments && (loading || stats?.queue_list.length)" class="rounded-xl border bg-card p-6 text-card-foreground shadow-sm">
+        <div v-if="hasAppointments && (loading || stats?.queue_list.length)" class="surface-card rounded-xl border p-6 text-card-foreground">
           <div class="mb-4 flex items-center justify-between">
             <h2 class="text-sm font-semibold">Queue</h2>
             <Button variant="ghost" size="sm" class="h-7 text-xs" @click="router.push({ name: RouteNames.QUEUE })">
@@ -341,7 +341,7 @@ onUnmounted(() => {
         </div>
 
         <!-- Draft Consultations -->
-        <div v-if="loading || stats?.draft_consultations_list.length" class="rounded-xl border bg-card p-6 text-card-foreground shadow-sm">
+        <div v-if="loading || stats?.draft_consultations_list.length" class="surface-card rounded-xl border p-6 text-card-foreground">
           <div class="mb-4 flex items-center justify-between">
             <div class="flex items-center gap-2">
               <h2 class="text-sm font-semibold">Draft Consultations</h2>
@@ -396,7 +396,7 @@ onUnmounted(() => {
         </div>
 
         <!-- Recent Patients -->
-        <div v-if="loading || stats?.recent_patients.length" class="rounded-xl border bg-card p-6 text-card-foreground shadow-sm">
+        <div v-if="loading || stats?.recent_patients.length" class="surface-card rounded-xl border p-6 text-card-foreground">
           <h2 class="mb-4 text-sm font-semibold">Recent Patients</h2>
 
           <div v-if="loading" class="flex flex-col gap-3">

--- a/src/domains/dashboard/views/OwnerDashboardView.vue
+++ b/src/domains/dashboard/views/OwnerDashboardView.vue
@@ -216,7 +216,7 @@ onUnmounted(() => {
       <!-- Stat cards -->
       <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
         <button class="text-left h-full" @click="router.push({ name: RouteNames.PATIENT_LIST })">
-          <div class="h-full rounded-xl border bg-card p-6 text-card-foreground shadow-sm">
+          <div class="surface-card h-full rounded-xl border p-6 text-card-foreground">
             <div class="flex items-start justify-between">
               <div class="flex flex-col gap-1">
                 <span class="text-sm font-medium text-muted-foreground">Total Patients</span>
@@ -246,7 +246,7 @@ onUnmounted(() => {
           />
         </button>
         <button class="text-left h-full" @click="router.push({ name: RouteNames.TEAM })">
-          <div class="rounded-xl border bg-card p-6 text-card-foreground shadow-sm">
+          <div class="surface-card rounded-xl border p-6 text-card-foreground">
             <div class="flex items-start justify-between">
               <div class="flex flex-col gap-3">
                 <span class="text-sm font-medium text-muted-foreground">Team Members</span>
@@ -300,7 +300,7 @@ onUnmounted(() => {
         <OwnerRevenueChart />
 
         <!-- Your Upcoming Appointments -->
-        <div v-if="hasAppointments && (loading || stats?.my_upcoming_appointments.length)" class="rounded-xl border bg-card p-6 text-card-foreground shadow-sm overflow-hidden">
+        <div v-if="hasAppointments && (loading || stats?.my_upcoming_appointments.length)" class="surface-card overflow-hidden rounded-xl border p-6 text-card-foreground">
           <div class="mb-4 flex items-center justify-between">
             <h2 class="text-sm font-semibold">
               Your Upcoming Appointments
@@ -361,7 +361,7 @@ onUnmounted(() => {
         </div>
 
         <!-- Today's Clinic Appointments -->
-        <div v-if="hasAppointments && (loading || stats?.todays_appointments.length)" class="rounded-xl border bg-card p-6 text-card-foreground shadow-sm overflow-hidden">
+        <div v-if="hasAppointments && (loading || stats?.todays_appointments.length)" class="surface-card overflow-hidden rounded-xl border p-6 text-card-foreground">
           <div class="mb-4 flex items-center justify-between">
             <h2 class="text-sm font-semibold">Today's Clinic Appointments</h2>
             <Button variant="ghost" size="sm" class="h-7 text-xs" @click="router.push({ name: RouteNames.APPOINTMENT_LIST })">
@@ -413,7 +413,7 @@ onUnmounted(() => {
         </div>
 
         <!-- Queue -->
-        <div v-if="hasAppointments && (loading || stats?.queue_list.length)" class="rounded-xl border bg-card p-6 text-card-foreground shadow-sm">
+        <div v-if="hasAppointments && (loading || stats?.queue_list.length)" class="surface-card rounded-xl border p-6 text-card-foreground">
           <div class="mb-4 flex items-center justify-between">
             <h2 class="flex flex-wrap items-center gap-1.5 text-sm font-semibold">
               Queue
@@ -468,7 +468,7 @@ onUnmounted(() => {
         </div>
 
         <!-- Recent Consultations -->
-        <div v-if="loading || stats?.recent_consultations.length" class="rounded-xl border bg-card p-6 text-card-foreground shadow-sm">
+        <div v-if="loading || stats?.recent_consultations.length" class="surface-card rounded-xl border p-6 text-card-foreground">
           <h2 class="mb-4 text-sm font-semibold">Recent Consultations</h2>
 
           <div v-if="loading" class="flex flex-col gap-3">
@@ -504,7 +504,7 @@ onUnmounted(() => {
         </div>
 
         <!-- Medicines Widget -->
-        <div v-if="loading || stats?.top_medicines.length || stats?.low_stock_medicines.length" class="rounded-xl border bg-card p-6 text-card-foreground shadow-sm">
+        <div v-if="loading || stats?.top_medicines.length || stats?.low_stock_medicines.length" class="surface-card rounded-xl border p-6 text-card-foreground">
           <div class="mb-4 flex items-center justify-between">
             <h2 class="text-sm font-semibold">Medicines</h2>
             <Button variant="ghost" size="sm" class="h-7 text-xs" @click="router.push({ name: RouteNames.CLINIC_MEDICINES })">

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -63,6 +63,23 @@
   --stat-green: oklch(0.723 0.191 149.58);
   --stat-purple: oklch(0.283 0.090 253.827);
   --stat-orange: oklch(0.705 0.213 47.604);
+
+  /* Clinical glass surfaces */
+  --app-background: linear-gradient(135deg, oklch(0.985 0.026 205) 0%, oklch(0.965 0.04 250) 48%, oklch(0.982 0.03 165) 100%);
+  --auth-background: linear-gradient(120deg, oklch(0.985 0.026 205) 0%, oklch(0.968 0.055 250) 42%, oklch(0.984 0.04 170) 100%);
+  --surface-panel: oklch(1 0 0 / 0.62);
+  --surface-panel-strong: oklch(1 0 0 / 0.68);
+  --surface-floating: oklch(1 0 0 / 0.78);
+  --surface-sidebar: oklch(1 0 0 / 0.56);
+  --surface-solid: oklch(1 0 0 / 0.96);
+  --surface-muted: oklch(0.985 0.006 235 / 0.7);
+  --surface-border: oklch(0.8 0.035 235 / 0.9);
+  --surface-border-strong: oklch(0.67 0.055 235 / 0.88);
+  --surface-shadow: 0 22px 65px -36px oklch(0.25 0.065 245 / 0.55);
+  --surface-shadow-strong: 0 32px 90px -42px oklch(0.22 0.08 245 / 0.62);
+  --surface-blur: blur(22px) saturate(1.18);
+  --surface-blur-strong: blur(30px) saturate(1.22);
+  --surface-overlay: oklch(0.18 0.035 245 / 0.42);
 }
 
 .dark {
@@ -102,6 +119,20 @@
   --sidebar-accent-foreground: oklch(0.925 0 0);
   --sidebar-border: oklch(0.278 0 0);
   --sidebar-ring: oklch(0.45 0.090 253.827);
+
+  --app-background: linear-gradient(135deg, oklch(0.16 0.035 245) 0%, oklch(0.12 0.028 268) 52%, oklch(0.17 0.032 185) 100%);
+  --auth-background: linear-gradient(120deg, oklch(0.16 0.035 245) 0%, oklch(0.125 0.035 268) 46%, oklch(0.17 0.035 185) 100%);
+  --surface-panel: oklch(0.21 0.022 245 / 0.64);
+  --surface-panel-strong: oklch(0.2 0.02 245 / 0.72);
+  --surface-floating: oklch(0.2 0.02 245 / 0.86);
+  --surface-sidebar: oklch(0.18 0.018 245 / 0.7);
+  --surface-solid: oklch(0.178 0 0 / 0.97);
+  --surface-muted: oklch(0.24 0.014 245 / 0.62);
+  --surface-border: oklch(0.38 0.025 245 / 0.65);
+  --surface-border-strong: oklch(0.5 0.035 245 / 0.7);
+  --surface-shadow: 0 18px 50px -30px oklch(0 0 0 / 0.72);
+  --surface-shadow-strong: 0 24px 80px -38px oklch(0 0 0 / 0.82);
+  --surface-overlay: oklch(0 0 0 / 0.58);
 }
 
 @theme inline {
@@ -153,6 +184,7 @@
   }
   body {
     @apply bg-background text-foreground;
+    background: var(--app-background);
     font-feature-settings: 'ss01' 1, 'cv01' 1;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
@@ -172,6 +204,103 @@
   select,
   summary {
     cursor: pointer;
+  }
+}
+
+@layer utilities {
+  .app-shell {
+    background: var(--app-background);
+  }
+
+  .auth-shell {
+    background: var(--auth-background);
+  }
+
+  .surface-panel {
+    background: var(--surface-panel);
+    border-color: var(--surface-border);
+    box-shadow: var(--surface-shadow);
+    backdrop-filter: var(--surface-blur);
+    -webkit-backdrop-filter: var(--surface-blur);
+  }
+
+  .surface-card {
+    background: var(--surface-panel-strong);
+    border-color: var(--surface-border);
+    box-shadow: var(--surface-shadow);
+    backdrop-filter: var(--surface-blur);
+    -webkit-backdrop-filter: var(--surface-blur);
+  }
+
+  .surface-floating {
+    background: var(--surface-floating);
+    border-color: var(--surface-border-strong);
+    box-shadow: var(--surface-shadow-strong);
+    backdrop-filter: var(--surface-blur-strong);
+    -webkit-backdrop-filter: var(--surface-blur-strong);
+  }
+
+  .surface-sidebar {
+    background: var(--surface-sidebar);
+    border-color: var(--surface-border);
+    box-shadow: var(--surface-shadow);
+    backdrop-filter: var(--surface-blur);
+    -webkit-backdrop-filter: var(--surface-blur);
+  }
+
+  .surface-solid {
+    background: var(--surface-solid);
+    border-color: var(--surface-border);
+  }
+
+  .surface-muted {
+    background: var(--surface-muted);
+    border-color: var(--surface-border);
+  }
+
+  .surface-overlay {
+    background: var(--surface-overlay);
+    backdrop-filter: blur(4px);
+    -webkit-backdrop-filter: blur(4px);
+  }
+
+  .surface-interactive {
+    transition-property: background-color, border-color, box-shadow, transform;
+    transition-duration: 150ms;
+  }
+
+  .surface-interactive:hover {
+    border-color: var(--surface-border-strong);
+    box-shadow: var(--surface-shadow-strong);
+  }
+
+  .clinical-solid {
+    background: var(--surface-solid);
+    border-color: var(--surface-border);
+    box-shadow: 0 1px 2px oklch(0 0 0 / 0.04);
+  }
+
+  [data-sidebar='menu-button'][data-active='true'],
+  [data-sidebar='menu-sub-button'][data-active='true'] {
+    background: var(--surface-muted);
+    border-color: var(--surface-border-strong);
+    box-shadow: inset 0 1px 0 oklch(1 0 0 / 0.38), 0 10px 28px -24px oklch(0.22 0.045 245 / 0.4);
+  }
+
+  .dark [data-sidebar='menu-button'][data-active='true'],
+  .dark [data-sidebar='menu-sub-button'][data-active='true'] {
+    box-shadow: inset 0 1px 0 oklch(1 0 0 / 0.08), 0 10px 30px -24px oklch(0 0 0 / 0.75);
+  }
+}
+
+@supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
+  @layer utilities {
+    .surface-panel,
+    .surface-card,
+    .surface-floating,
+    .surface-sidebar {
+      background: var(--surface-solid);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

- Adds the first clinical glass design foundation: shared surface tokens, app/auth shells, floating overlays, solid clinical inputs, and interactive surface utilities.
- Applies the foundation through shared shadcn-vue wrappers, sidebar/layout chrome, auth screens, and dashboard cards/charts.
- Tightens E2E login helpers to target the exact password sign-in button now that Google sign-in is also present.

## Impact

This keeps the app functional while moving the visual baseline toward the new restrained glass design system. Dense clinical inputs remain solid for readability; glass is applied to shells, cards, overlays, and navigation surfaces.

## Validation

- `npm run build` passed.
- `git diff --check` passed.
- Local preview `/login` and authenticated dashboard render were smoke checked on `http://127.0.0.1:4174`.
- `npx playwright test e2e/dashboard.spec.ts --project=chromium` was attempted. Login/dashboard render passed, but the existing sidebar navigation assertions did not pass in the local preview: the rendered sidebar anchors had correct `href`s, but Playwright clicks stayed on `/`. I did not treat that as part of this visual foundation change without deeper router investigation.