### PR TITLE
feat: refine sidebar glass surfaces

### DIFF
--- a/src/components/layout/AppSidebar.vue
+++ b/src/components/layout/AppSidebar.vue
@@ -168,10 +168,10 @@ onMounted(async () => {
     <SidebarHeader>
       <SidebarMenu>
         <SidebarMenuItem>
-          <SidebarMenuButton size="lg" as="a" href="/">
-            <Avatar class="size-8 rounded-lg">
-              <AvatarImage v-if="authStore.currentClinic?.logo_url" :src="authStore.currentClinic.logo_url" alt="Clinic logo" class="rounded-lg object-cover" />
-              <AvatarFallback class="bg-sidebar-primary text-sidebar-primary-foreground rounded-lg text-xs">
+          <SidebarMenuButton size="lg" as="a" href="/" class="rounded-2xl">
+            <Avatar class="size-10 rounded-2xl shadow-[0_12px_28px_rgba(0,41,84,0.18)] group-data-[collapsible=icon]:size-8">
+              <AvatarImage v-if="authStore.currentClinic?.logo_url" :src="authStore.currentClinic.logo_url" alt="Clinic logo" class="rounded-2xl object-cover" />
+              <AvatarFallback class="rounded-2xl bg-sidebar-primary text-sidebar-primary-foreground text-xs">
                 <Stethoscope class="size-4" />
               </AvatarFallback>
             </Avatar>
@@ -195,7 +195,7 @@ onMounted(async () => {
         @logout="handleLogout"
         @switch-clinic="openSwitchDialog"
       />
-      <p class="truncate text-xs tabular-nums text-muted-foreground/50 group-data-[collapsible=icon]:hidden">
+      <p class="px-2 text-[10px] tabular-nums text-muted-foreground/45 group-data-[collapsible=icon]:hidden">
         {{ feVersion }}|{{ apiVersion }}
       </p>
     </SidebarFooter>

--- a/src/components/layout/NavMain.vue
+++ b/src/components/layout/NavMain.vue
@@ -79,7 +79,7 @@ const emit = defineEmits<{
         >
           <SidebarMenuItem>
             <CollapsibleTrigger as-child>
-              <SidebarMenuButton :tooltip="item.title" :is-active="item.items.some(sub => isActive(sub.url))" class="h-10" @click="item.url !== '#' && router.push(item.url)">
+              <SidebarMenuButton :tooltip="item.title" :is-active="item.items.some(sub => isActive(sub.url))" @click="item.url !== '#' && router.push(item.url)">
                 <component :is="item.icon" />
                 <span>{{ item.title }}</span>
                 <ChevronRight class="ml-auto transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90" />
@@ -99,7 +99,7 @@ const emit = defineEmits<{
 
         <!-- Coming soon items: disabled appearance -->
         <SidebarMenuItem v-else-if="item.comingSoon">
-          <SidebarMenuButton :tooltip="`${item.title} — Coming soon`" class="h-10 pointer-events-none opacity-50">
+          <SidebarMenuButton :tooltip="`${item.title} — Coming soon`" class="pointer-events-none opacity-50">
             <component :is="item.icon" />
             <span>{{ item.title }}</span>
             <Badge variant="outline" class="ml-auto text-[10px] px-1.5 py-0">Soon</Badge>
@@ -108,7 +108,7 @@ const emit = defineEmits<{
 
         <!-- Locked (Pro) items -->
         <SidebarMenuItem v-else-if="item.locked">
-          <SidebarMenuButton :tooltip="`${item.title} — Pro`" class="h-10 opacity-60 hover:opacity-80" @click="emit('locked-click', item.title)">
+          <SidebarMenuButton :tooltip="`${item.title} — Pro`" class="opacity-60 hover:opacity-80" @click="emit('locked-click', item.title)">
             <component :is="item.icon" />
             <span>{{ item.title }}</span>
             <Crown class="ml-auto size-3.5 text-amber-500" />
@@ -117,7 +117,7 @@ const emit = defineEmits<{
 
         <!-- Items without sub-items: direct link -->
         <SidebarMenuItem v-else>
-          <SidebarMenuButton as="a" :href="item.url" :tooltip="item.title" :is-active="isActive(item.url)" class="h-10" @click.prevent="navigateTo(item.url)">
+          <SidebarMenuButton as="a" :href="item.url" :tooltip="item.title" :is-active="isActive(item.url)" @click.prevent="navigateTo(item.url)">
             <component :is="item.icon" />
             <span>{{ item.title }}</span>
             <Badge

--- a/src/components/layout/NavUser.vue
+++ b/src/components/layout/NavUser.vue
@@ -72,9 +72,9 @@ const initials = computed(() => {
         <DropdownMenuTrigger as-child>
           <SidebarMenuButton
             size="lg"
-            class="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
+            class="rounded-2xl data-[state=open]:border-white/55 data-[state=open]:bg-white/62 data-[state=open]:text-sidebar-accent-foreground data-[state=open]:shadow-[0_14px_32px_rgba(37,99,235,0.12)]"
           >
-            <Avatar class="h-8 w-8 rounded-full">
+            <Avatar class="h-9 w-9 rounded-full shadow-[0_10px_24px_rgba(15,23,42,0.1)] group-data-[collapsible=icon]:h-8 group-data-[collapsible=icon]:w-8">
               <AvatarImage v-if="user.avatarUrl" :src="user.avatarUrl" :alt="user.name" class="rounded-full object-cover" />
               <AvatarFallback class="rounded-full">
                 {{ initials }}

--- a/src/components/ui/sidebar/Sidebar.vue
+++ b/src/components/ui/sidebar/Sidebar.vue
@@ -24,7 +24,7 @@ const { isMobile, state, openMobile, setOpenMobile } = useSidebar()
   <div
     v-if="collapsible === 'none'"
     data-slot="sidebar"
-    :class="cn('surface-sidebar text-sidebar-foreground flex h-full w-(--sidebar-width) flex-col border-r', props.class)"
+    :class="cn('surface-sidebar text-sidebar-foreground flex h-full w-(--sidebar-width) flex-col overflow-hidden', props.class)"
     v-bind="$attrs"
   >
     <slot />
@@ -87,7 +87,7 @@ const { isMobile, state, openMobile, setOpenMobile } = useSidebar()
     >
       <div
         data-sidebar="sidebar"
-        class="surface-sidebar flex h-full w-full flex-col border group-data-[variant=floating]:rounded-lg group-data-[variant=inset]:rounded-xl"
+        class="surface-sidebar flex h-full w-full flex-col overflow-hidden group-data-[variant=floating]:rounded-2xl group-data-[variant=inset]:rounded-2xl"
       >
         <slot />
       </div>

--- a/src/components/ui/sidebar/SidebarContent.vue
+++ b/src/components/ui/sidebar/SidebarContent.vue
@@ -11,7 +11,7 @@ const props = defineProps<{
   <div
     data-slot="sidebar-content"
     data-sidebar="content"
-    :class="cn('flex min-h-0 flex-1 flex-col gap-2 overflow-auto group-data-[collapsible=icon]:overflow-hidden', props.class)"
+    :class="cn('flex min-h-0 flex-1 flex-col gap-2 overflow-auto px-3 py-2 group-data-[collapsible=icon]:overflow-hidden group-data-[collapsible=icon]:px-3', props.class)"
   >
     <slot />
   </div>

--- a/src/components/ui/sidebar/SidebarFooter.vue
+++ b/src/components/ui/sidebar/SidebarFooter.vue
@@ -11,7 +11,7 @@ const props = defineProps<{
   <div
     data-slot="sidebar-footer"
     data-sidebar="footer"
-    :class="cn('flex flex-col gap-2 p-2', props.class)"
+    :class="cn('flex flex-col gap-2 p-4 pt-2 group-data-[collapsible=icon]:p-3 group-data-[collapsible=icon]:pt-2', props.class)"
   >
     <slot />
   </div>

--- a/src/components/ui/sidebar/SidebarHeader.vue
+++ b/src/components/ui/sidebar/SidebarHeader.vue
@@ -11,7 +11,7 @@ const props = defineProps<{
   <div
     data-slot="sidebar-header"
     data-sidebar="header"
-    :class="cn('flex flex-col gap-2 p-2', props.class)"
+    :class="cn('flex flex-col gap-2 p-4 pb-2 group-data-[collapsible=icon]:p-3 group-data-[collapsible=icon]:pb-2', props.class)"
   >
     <slot />
   </div>

--- a/src/components/ui/sidebar/SidebarMenuSubButton.vue
+++ b/src/components/ui/sidebar/SidebarMenuSubButton.vue
@@ -23,8 +23,7 @@ const props = withDefaults(defineProps<PrimitiveProps & {
     :data-size="size"
     :data-active="isActive"
     :class="cn(
-      'surface-interactive text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground [&>svg]:text-sidebar-accent-foreground flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md border border-transparent px-2 outline-hidden focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0',
-      'data-[active=true]:text-sidebar-accent-foreground',
+      'surface-interactive text-sidebar-foreground ring-sidebar-ring hover:bg-white/45 hover:text-sidebar-accent-foreground active:bg-white/55 active:text-sidebar-accent-foreground dark:hover:bg-white/10 [&>svg]:text-sidebar-accent-foreground flex h-8 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-lg border border-transparent px-2.5 outline-hidden focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:text-blue-600 dark:data-[active=true]:text-blue-300 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0',
       size === 'sm' && 'text-xs',
       size === 'md' && 'text-sm',
       'group-data-[collapsible=icon]:hidden',

--- a/src/components/ui/sidebar/SidebarSeparator.vue
+++ b/src/components/ui/sidebar/SidebarSeparator.vue
@@ -12,7 +12,7 @@ const props = defineProps<{
   <Separator
     data-slot="sidebar-separator"
     data-sidebar="separator"
-    :class="cn('bg-sidebar-border mx-2 w-auto', props.class)"
+    :class="cn('mx-3 my-2 w-auto bg-white/45 dark:bg-white/10', props.class)"
   >
     <slot />
   </Separator>

--- a/src/components/ui/sidebar/index.ts
+++ b/src/components/ui/sidebar/index.ts
@@ -36,16 +36,16 @@ export { default as SidebarTrigger } from "./SidebarTrigger.vue"
 export { useSidebar } from "./utils"
 
 export const sidebarMenuButtonVariants = cva(
-  "peer/menu-button surface-interactive flex w-full items-center gap-2 overflow-hidden rounded-md border border-transparent p-2 text-left text-sm outline-hidden ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-data-[sidebar=menu-action]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
+  "peer/menu-button surface-interactive flex w-full items-center gap-3 overflow-hidden rounded-2xl border border-transparent px-3.5 py-2 text-left text-[0.95rem] outline-hidden ring-sidebar-ring transition-[width,height,padding,box-shadow,transform] hover:-translate-y-0.5 hover:bg-white/45 hover:text-sidebar-accent-foreground hover:shadow-[0_12px_28px_rgba(15,23,42,0.08)] focus-visible:ring-2 active:translate-y-0 active:bg-white/55 active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-data-[sidebar=menu-action]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:border-white/55 data-[active=true]:bg-white/62 data-[active=true]:font-semibold data-[active=true]:text-blue-600 data-[active=true]:shadow-[0_14px_32px_rgba(37,99,235,0.12)] data-[state=open]:hover:bg-white/50 data-[state=open]:hover:text-sidebar-accent-foreground dark:hover:bg-white/10 dark:data-[active=true]:border-white/10 dark:data-[active=true]:bg-white/10 dark:data-[active=true]:text-blue-300 group-data-[collapsible=icon]:size-10! group-data-[collapsible=icon]:p-2.5! [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
   {
     variants: {
       variant: {
-        default: "hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
+        default: "hover:bg-white/45 hover:text-sidebar-accent-foreground",
         outline:
-          "surface-muted hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
+          "surface-muted hover:bg-white/45 hover:text-sidebar-accent-foreground",
       },
       size: {
-        default: "h-8 text-sm",
+        default: "h-11",
         sm: "h-7 text-xs",
         lg: "h-12 text-sm group-data-[collapsible=icon]:p-0!",
       },

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -312,14 +312,16 @@
 
   [data-sidebar='menu-button'][data-active='true'],
   [data-sidebar='menu-sub-button'][data-active='true'] {
-    background: var(--surface-muted);
-    border-color: var(--surface-border-strong);
-    box-shadow: inset 0 1px 0 oklch(1 0 0 / 0.38), 0 10px 28px -24px oklch(0.22 0.045 245 / 0.4);
+    background: oklch(1 0 0 / 0.62);
+    border-color: oklch(1 0 0 / 0.55);
+    box-shadow: 0 14px 32px rgb(37 99 235 / 0.12);
   }
 
   .dark [data-sidebar='menu-button'][data-active='true'],
   .dark [data-sidebar='menu-sub-button'][data-active='true'] {
-    box-shadow: inset 0 1px 0 oklch(1 0 0 / 0.08), 0 10px 30px -24px oklch(0 0 0 / 0.75);
+    background: oklch(1 0 0 / 0.1);
+    border-color: oklch(1 0 0 / 0.12);
+    box-shadow: 0 14px 32px rgb(59 130 246 / 0.18);
   }
 }
 


### PR DESCRIPTION
## Summary
- Refines the app sidebar shell to use the shared glass surface treatment without hard container borders.
- Updates sidebar nav, nested nav, clinic header, footer user control, and separators for softer glass spacing, hover, active, and elevation states.
- Keeps collapsed sidebar icons centered and stable while preserving existing navigation behavior.

## Verification
- `git diff --check`
- `npm run build`
- Manual Chrome check on `http://127.0.0.1:5176/patients?page=1` for expanded and collapsed sidebar states.