### PR TITLE
Refine auth recovery glass pages

### DIFF
--- a/src/domains/auth/views/ForgotPasswordView.vue
+++ b/src/domains/auth/views/ForgotPasswordView.vue
@@ -11,16 +11,19 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card'
-import { Mail, LoaderCircle, CircleCheck, ArrowLeft } from 'lucide-vue-next'
+import { ArrowLeft, CircleCheck, Clock3, LoaderCircle, Mail, MailCheck, Moon, ShieldCheck, Sun } from 'lucide-vue-next'
 import AppLogo from '@/components/AppLogo.vue'
 import { HttpError } from '@/lib/http'
 import { forgotPasswordSchema } from '@/lib/validationRules'
 import { RouteNames } from '@/router/routeNames'
+import { useTheme } from '@/composables/useTheme'
 import { useNeuralNetwork } from '@/composables/useNeuralNetwork'
 import { authApi } from '../api/authApi'
 import type { ValidationError } from '../types/auth.types'
+import AuthFeedbackAlert from '../components/AuthFeedbackAlert.vue'
 
 const { canvasRef } = useNeuralNetwork()
+const { isDark, toggleTheme } = useTheme()
 
 const { handleSubmit, setFieldError } = useForm({
   validationSchema: forgotPasswordSchema,
@@ -71,61 +74,125 @@ const onSubmit = handleSubmit(async (values) => {
 </script>
 
 <template>
-  <div class="auth-shell relative flex min-h-screen items-center justify-center overflow-hidden px-4">
-    <canvas ref="canvasRef" class="pointer-events-none absolute inset-0" />
+  <div class="auth-shell relative flex min-h-dvh items-center justify-center overflow-x-hidden overflow-y-auto px-4 py-16 sm:px-6 sm:py-6">
+    <canvas ref="canvasRef" class="pointer-events-none absolute inset-0 opacity-55" />
+    <button
+      type="button"
+      class="auth-theme-toggle"
+      :aria-label="isDark ? 'Switch to light mode' : 'Switch to dark mode'"
+      @click="toggleTheme"
+    >
+      <Sun v-if="isDark" class="size-4" />
+      <Moon v-else class="size-4" />
+    </button>
 
     <div
-      class="relative z-10 w-full max-w-sm transition-all duration-700 ease-out"
+      class="relative z-10 grid w-full max-w-5xl items-stretch gap-4 transition-all duration-700 ease-out sm:gap-6 lg:grid-cols-[0.92fr_1fr]"
       :class="ready ? 'translate-y-0 opacity-100' : 'translate-y-8 opacity-0'"
     >
-      <div
-        class="mb-4 flex justify-center transition-all delay-100 duration-700 ease-out"
-        :class="ready ? 'translate-y-0 opacity-100' : 'translate-y-6 opacity-0'"
+      <section
+        class="auth-side-panel hidden min-h-[520px] flex-col justify-between overflow-hidden rounded-3xl p-8 lg:flex"
+        aria-label="MediFlow account recovery"
       >
-        <AppLogo class="h-24 w-auto" />
-      </div>
+        <div>
+          <div class="mb-10 flex justify-center">
+            <AppLogo class="h-20 w-auto drop-shadow-[0_18px_38px_rgba(37,99,235,0.14)]" />
+          </div>
 
-      <div
-        class="transition-all delay-200 duration-700 ease-out"
-        :class="ready ? 'translate-y-0 opacity-100' : 'translate-y-6 opacity-0'"
-      >
-        <!-- Success state -->
-        <Card v-if="submitted" class="border-primary/20 shadow-[0_28px_90px_-42px_oklch(0.28_0.09_245_/_0.65)]">
-          <CardHeader class="text-center">
-            <div class="mx-auto mb-2 flex size-12 items-center justify-center rounded-full bg-green-500/10">
-              <CircleCheck class="size-6 text-green-600 dark:text-green-400" />
+          <div class="max-w-sm space-y-4">
+            <p class="text-sm font-medium uppercase tracking-[0.16em] text-blue-600/80 dark:text-blue-300/80">
+              Account recovery
+            </p>
+            <h1 class="text-4xl font-semibold leading-tight text-foreground">
+              Recover access without breaking clinic flow.
+            </h1>
+            <p class="text-base leading-7 text-muted-foreground">
+              We will send a secure reset link if the email belongs to a MediFlow account.
+            </p>
+          </div>
+        </div>
+
+        <div class="grid gap-3">
+          <div class="auth-status-row">
+            <div class="auth-status-icon text-blue-600 dark:text-blue-300">
+              <MailCheck class="size-4" />
             </div>
-            <CardTitle class="text-xl">Check your email</CardTitle>
-            <CardDescription>
-              If an account exists with that email, we've sent a password reset link.
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <RouterLink :to="{ name: RouteNames.LOGIN }">
-              <Button variant="outline" class="w-full">
-                <ArrowLeft class="size-4" />
-                Back to sign in
-              </Button>
-            </RouterLink>
-          </CardContent>
-        </Card>
+            <div>
+              <p class="text-sm font-semibold">Email check</p>
+              <p class="text-xs text-muted-foreground">No account details are exposed on this screen</p>
+            </div>
+          </div>
+          <div class="auth-status-row">
+            <div class="auth-status-icon text-emerald-600 dark:text-emerald-300">
+              <ShieldCheck class="size-4" />
+            </div>
+            <div>
+              <p class="text-sm font-semibold">Secure reset</p>
+              <p class="text-xs text-muted-foreground">Only the email link can continue the recovery</p>
+            </div>
+          </div>
+          <div class="auth-status-row">
+            <div class="auth-status-icon text-teal-600 dark:text-teal-300">
+              <Clock3 class="size-4" />
+            </div>
+            <div>
+              <p class="text-sm font-semibold">Return to work</p>
+              <p class="text-xs text-muted-foreground">Set a new password and continue sign-in</p>
+            </div>
+          </div>
+        </div>
+      </section>
 
-        <!-- Form state -->
-        <Card v-else class="border-primary/20 shadow-[0_28px_90px_-42px_oklch(0.28_0.09_245_/_0.65)]">
-          <CardHeader class="text-center">
-            <CardTitle class="text-xl">Forgot password?</CardTitle>
-            <CardDescription>Enter your email and we'll send you a reset link</CardDescription>
+      <div
+        class="flex transition-all delay-200 duration-700 ease-out"
+        :class="ready ? 'translate-y-0 opacity-100' : 'translate-y-6 opacity-0'"
+      >
+        <Card class="auth-recovery-card mx-auto flex w-full min-w-0 max-w-lg justify-center rounded-2xl border-0 py-5 shadow-[0_32px_90px_-42px_oklch(0.22_0.08_245_/_0.62)] sm:min-h-[520px] sm:rounded-3xl sm:py-8 lg:h-full">
+          <CardHeader class="px-4 pb-4 text-center sm:px-10 sm:pb-6">
+            <div
+              class="mb-2 flex justify-center transition-all delay-100 duration-700 ease-out lg:hidden"
+              :class="ready ? 'translate-y-0 opacity-100' : 'translate-y-6 opacity-0'"
+            >
+              <div class="auth-logo-mark">
+                <AppLogo class="h-11 w-auto" />
+              </div>
+            </div>
+            <template v-if="submitted">
+              <div class="mx-auto mb-3 flex size-12 items-center justify-center rounded-full bg-[var(--feedback-success-bg)] text-[var(--feedback-success-fg)]">
+                <CircleCheck class="size-6" />
+              </div>
+              <CardTitle class="text-xl sm:text-2xl">Check your email</CardTitle>
+              <CardDescription>
+                If an account exists with that email, we sent a password reset link.
+              </CardDescription>
+            </template>
+            <template v-else>
+              <CardTitle class="text-xl sm:text-2xl">Forgot password?</CardTitle>
+              <CardDescription>Enter your email and we will send you a reset link</CardDescription>
+            </template>
           </CardHeader>
 
-          <CardContent>
-            <form class="flex flex-col gap-5" novalidate @submit.prevent="onSubmit">
-              <div
+          <CardContent class="min-w-0 px-4 sm:px-10">
+            <div v-if="submitted" class="mx-auto flex w-full max-w-[400px] flex-col gap-5">
+              <AuthFeedbackAlert variant="success" role="status">
+                The link may take a minute to arrive. Check spam if it does not show in your inbox.
+              </AuthFeedbackAlert>
+              <RouterLink :to="{ name: RouteNames.LOGIN }">
+                <Button class="h-10 w-full text-base">
+                  <ArrowLeft class="size-4" />
+                  Back to sign in
+                </Button>
+              </RouterLink>
+            </div>
+
+            <form v-else class="mx-auto flex w-full max-w-[400px] flex-col gap-4 sm:gap-5" novalidate @submit.prevent="onSubmit">
+              <AuthFeedbackAlert
                 v-if="generalError"
+                variant="danger"
                 role="alert"
-                class="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2.5 text-sm text-destructive"
               >
                 {{ generalError }}
-              </div>
+              </AuthFeedbackAlert>
 
               <div
                 class="flex flex-col gap-2 transition-all delay-300 duration-500 ease-out"
@@ -143,6 +210,7 @@ const onSubmit = handleSubmit(async (values) => {
                   autocomplete="email"
                   :disabled="isLoading"
                   :aria-invalid="!!emailError"
+                  class="auth-form-input"
                   required
                 />
                 <p v-if="emailError" class="text-xs text-destructive">
@@ -154,7 +222,7 @@ const onSubmit = handleSubmit(async (values) => {
                 class="transition-all delay-[350ms] duration-500 ease-out"
                 :class="ready ? 'translate-y-0 opacity-100' : 'translate-y-4 opacity-0'"
               >
-                <Button type="submit" class="w-full" :disabled="isLoading">
+                <Button type="submit" class="h-10 w-full text-base" :disabled="isLoading">
                   <LoaderCircle v-if="isLoading" class="size-4 animate-spin" />
                   {{ isLoading ? 'Sending...' : 'Send reset link' }}
                 </Button>
@@ -179,3 +247,170 @@ const onSubmit = handleSubmit(async (values) => {
     </div>
   </div>
 </template>
+
+<style scoped>
+.auth-side-panel {
+  background:
+    linear-gradient(135deg, rgb(255 255 255 / 0.54), rgb(255 255 255 / 0.2) 54%, rgb(255 255 255 / 0.34)),
+    rgb(255 255 255 / 0.08);
+  border: 1px solid rgb(255 255 255 / 0.5);
+  box-shadow: 0 32px 90px -42px oklch(0.22 0.08 245 / 0.62);
+  backdrop-filter: blur(30px) saturate(1.22);
+  -webkit-backdrop-filter: blur(30px) saturate(1.22);
+}
+
+.auth-recovery-card {
+  background:
+    linear-gradient(145deg, rgb(255 255 255 / 0.72), rgb(255 255 255 / 0.38) 58%, rgb(255 255 255 / 0.5)),
+    rgb(255 255 255 / 0.14);
+  border: 0;
+  backdrop-filter: blur(30px) saturate(1.2);
+  -webkit-backdrop-filter: blur(30px) saturate(1.2);
+}
+
+.auth-theme-toggle {
+  position: absolute;
+  right: 0.875rem;
+  top: 0.875rem;
+  z-index: 20;
+  display: inline-flex;
+  height: 2.25rem;
+  width: 2.25rem;
+  align-items: center;
+  justify-content: center;
+  border-radius: 9999px;
+  border: 1px solid rgb(255 255 255 / 0.48);
+  background: rgb(255 255 255 / 0.42);
+  color: rgb(15 23 42 / 0.72);
+  box-shadow: 0 14px 34px rgb(15 23 42 / 0.08);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+  transition: transform 120ms ease, background 120ms ease, box-shadow 120ms ease;
+}
+
+.auth-theme-toggle:hover {
+  transform: translateY(-1px);
+  background: rgb(255 255 255 / 0.58);
+  box-shadow: 0 18px 42px rgb(15 23 42 / 0.12);
+}
+
+.auth-theme-toggle:active {
+  transform: translateY(0);
+}
+
+.auth-theme-toggle:focus-visible {
+  outline: 2px solid rgb(37 99 235 / 0.45);
+  outline-offset: 3px;
+}
+
+.auth-logo-mark {
+  display: inline-flex;
+  min-height: 3.25rem;
+  min-width: 3.25rem;
+  align-items: center;
+  justify-content: center;
+  border-radius: 1.5rem;
+  border: 1px solid rgb(255 255 255 / 0.5);
+  background: rgb(255 255 255 / 0.58);
+  box-shadow: 0 18px 45px rgb(37 99 235 / 0.12);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+}
+
+@media (min-width: 640px) {
+  .auth-theme-toggle {
+    right: 1.5rem;
+    top: 1.5rem;
+    height: 2.5rem;
+    width: 2.5rem;
+  }
+
+  .auth-logo-mark {
+    min-height: 4rem;
+    min-width: 4rem;
+  }
+}
+
+.auth-status-row {
+  display: flex;
+  align-items: center;
+  gap: 0.875rem;
+  border-radius: 1.25rem;
+  border: 1px solid rgb(255 255 255 / 0.45);
+  background: rgb(255 255 255 / 0.36);
+  padding: 0.875rem;
+  box-shadow: 0 14px 34px rgb(15 23 42 / 0.06);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+}
+
+.auth-status-icon {
+  display: inline-flex;
+  height: 2.5rem;
+  width: 2.5rem;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  border-radius: 9999px;
+  border: 1px solid rgb(255 255 255 / 0.5);
+  background: rgb(255 255 255 / 0.58);
+  box-shadow: 0 10px 24px rgb(15 23 42 / 0.06);
+}
+
+:deep(.auth-form-input) {
+  height: 2.75rem;
+  border-radius: 1rem;
+  border-color: rgb(255 255 255 / 0.55);
+  background: rgb(255 255 255 / 0.62);
+  box-shadow: 0 10px 26px rgb(15 23 42 / 0.06);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+}
+
+:deep(.auth-form-input:focus-visible) {
+  border-color: rgb(255 255 255 / 0.75);
+  background: rgb(255 255 255 / 0.75);
+}
+
+:global(.dark) .auth-side-panel {
+  background:
+    linear-gradient(135deg, rgb(15 23 42 / 0.58), rgb(15 23 42 / 0.28) 54%, rgb(15 23 42 / 0.42)),
+    rgb(15 23 42 / 0.12);
+  border-color: rgb(255 255 255 / 0.1);
+  box-shadow: 0 24px 80px -38px rgb(0 0 0 / 0.82);
+}
+
+:global(.dark) .auth-recovery-card {
+  background:
+    linear-gradient(145deg, rgb(15 23 42 / 0.66), rgb(15 23 42 / 0.42) 58%, rgb(15 23 42 / 0.52)),
+    rgb(15 23 42 / 0.16);
+}
+
+:global(.dark) .auth-theme-toggle {
+  border-color: rgb(255 255 255 / 0.1);
+  background: rgb(255 255 255 / 0.08);
+  color: rgb(226 232 240 / 0.86);
+  box-shadow: 0 16px 38px rgb(0 0 0 / 0.28);
+}
+
+:global(.dark) .auth-theme-toggle:hover {
+  background: rgb(255 255 255 / 0.12);
+}
+
+:global(.dark) .auth-logo-mark,
+:global(.dark) .auth-status-row,
+:global(.dark) .auth-status-icon {
+  border-color: rgb(255 255 255 / 0.1);
+  background: rgb(255 255 255 / 0.08);
+}
+
+:global(.dark) :deep(.auth-form-input) {
+  border-color: rgb(255 255 255 / 0.12);
+  background: rgb(15 23 42 / 0.52);
+  box-shadow: 0 12px 28px rgb(0 0 0 / 0.24);
+}
+
+:global(.dark) :deep(.auth-form-input:focus-visible) {
+  background: rgb(15 23 42 / 0.66);
+}
+</style>

--- a/src/domains/auth/views/LoginView.vue
+++ b/src/domains/auth/views/LoginView.vue
@@ -167,7 +167,7 @@ async function requestGoogleLink(): Promise<void> {
 </script>
 
 <template>
-  <div class="auth-shell relative flex min-h-dvh items-start justify-center overflow-x-hidden overflow-y-auto px-4 pb-5 pt-16 sm:items-center sm:px-6 sm:py-6">
+  <div class="auth-shell relative flex min-h-dvh items-center justify-center overflow-x-hidden overflow-y-auto px-4 py-16 sm:px-6 sm:py-6">
     <canvas ref="canvasRef" class="pointer-events-none absolute inset-0 opacity-55" />
     <button
       type="button"

--- a/src/domains/auth/views/ResetPasswordView.vue
+++ b/src/domains/auth/views/ResetPasswordView.vue
@@ -12,18 +12,21 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card'
-import { Lock, LoaderCircle, CircleCheck, CircleX, ArrowRight } from 'lucide-vue-next'
+import { ArrowRight, CircleCheck, CircleX, KeyRound, LoaderCircle, Lock, Moon, ShieldCheck, Sun, TimerReset } from 'lucide-vue-next'
 import AppLogo from '@/components/AppLogo.vue'
 import { HttpError } from '@/lib/http'
 import { resetPasswordSchema } from '@/lib/validationRules'
 import { RouteNames } from '@/router/routeNames'
+import { useTheme } from '@/composables/useTheme'
 import { useNeuralNetwork } from '@/composables/useNeuralNetwork'
 import { authApi } from '../api/authApi'
 import type { ValidationError } from '../types/auth.types'
 import PasswordStrengthBar from '../components/PasswordStrengthBar.vue'
+import AuthFeedbackAlert from '../components/AuthFeedbackAlert.vue'
 
 const route = useRoute()
 const { canvasRef } = useNeuralNetwork()
+const { isDark, toggleTheme } = useTheme()
 
 const token = typeof route.query.token === 'string' ? route.query.token : null
 const encodedEmail = typeof route.query.email === 'string' ? route.query.email : null
@@ -93,81 +96,145 @@ const onSubmit = handleSubmit(async (values) => {
 </script>
 
 <template>
-  <div class="auth-shell relative flex min-h-screen items-center justify-center overflow-hidden px-4">
-    <canvas ref="canvasRef" class="pointer-events-none absolute inset-0" />
+  <div class="auth-shell relative flex min-h-dvh items-center justify-center overflow-x-hidden overflow-y-auto px-4 py-16 sm:px-6 sm:py-6">
+    <canvas ref="canvasRef" class="pointer-events-none absolute inset-0 opacity-55" />
+    <button
+      type="button"
+      class="auth-theme-toggle"
+      :aria-label="isDark ? 'Switch to light mode' : 'Switch to dark mode'"
+      @click="toggleTheme"
+    >
+      <Sun v-if="isDark" class="size-4" />
+      <Moon v-else class="size-4" />
+    </button>
 
     <div
-      class="relative z-10 w-full max-w-sm transition-all duration-700 ease-out"
+      class="relative z-10 grid w-full max-w-5xl items-stretch gap-4 transition-all duration-700 ease-out sm:gap-6 lg:grid-cols-[0.92fr_1fr]"
       :class="ready ? 'translate-y-0 opacity-100' : 'translate-y-8 opacity-0'"
     >
+      <section
+        class="auth-side-panel hidden min-h-[560px] flex-col justify-between overflow-hidden rounded-3xl p-8 lg:flex"
+        aria-label="MediFlow password reset"
+      >
+        <div>
+          <div class="mb-10 flex justify-center">
+            <AppLogo class="h-20 w-auto drop-shadow-[0_18px_38px_rgba(37,99,235,0.14)]" />
+          </div>
+
+          <div class="max-w-sm space-y-4">
+            <p class="text-sm font-medium uppercase tracking-[0.16em] text-blue-600/80 dark:text-blue-300/80">
+              Password reset
+            </p>
+            <h1 class="text-4xl font-semibold leading-tight text-foreground">
+              Set a fresh password for your clinic account.
+            </h1>
+            <p class="text-base leading-7 text-muted-foreground">
+              Choose a strong password, then sign in again to continue clinic operations.
+            </p>
+          </div>
+        </div>
+
+        <div class="grid gap-3">
+          <div class="auth-status-row">
+            <div class="auth-status-icon text-blue-600 dark:text-blue-300">
+              <KeyRound class="size-4" />
+            </div>
+            <div>
+              <p class="text-sm font-semibold">New credential</p>
+              <p class="text-xs text-muted-foreground">Use a password you do not share elsewhere</p>
+            </div>
+          </div>
+          <div class="auth-status-row">
+            <div class="auth-status-icon text-emerald-600 dark:text-emerald-300">
+              <ShieldCheck class="size-4" />
+            </div>
+            <div>
+              <p class="text-sm font-semibold">Protected session</p>
+              <p class="text-xs text-muted-foreground">The reset link is checked before saving</p>
+            </div>
+          </div>
+          <div class="auth-status-row">
+            <div class="auth-status-icon text-teal-600 dark:text-teal-300">
+              <TimerReset class="size-4" />
+            </div>
+            <div>
+              <p class="text-sm font-semibold">Clean sign-in</p>
+              <p class="text-xs text-muted-foreground">Return to the login page after reset</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
       <div
-        class="mb-4 flex justify-center transition-all delay-100 duration-700 ease-out"
+        class="flex transition-all delay-200 duration-700 ease-out"
         :class="ready ? 'translate-y-0 opacity-100' : 'translate-y-6 opacity-0'"
       >
-        <AppLogo class="h-24 w-auto" />
-      </div>
-
-      <div
-        class="transition-all delay-200 duration-700 ease-out"
-        :class="ready ? 'translate-y-0 opacity-100' : 'translate-y-6 opacity-0'"
-      >
-        <!-- Invalid params state -->
-        <Card v-if="!hasValidParams" class="border-primary/20 shadow-[0_28px_90px_-42px_oklch(0.28_0.09_245_/_0.65)]">
-          <CardHeader class="text-center">
-            <div class="mx-auto mb-2 flex size-12 items-center justify-center rounded-full bg-destructive/10">
-              <CircleX class="size-6 text-destructive" />
+        <Card class="auth-recovery-card mx-auto flex w-full min-w-0 max-w-lg justify-center rounded-2xl border-0 py-5 shadow-[0_32px_90px_-42px_oklch(0.22_0.08_245_/_0.62)] sm:min-h-[560px] sm:rounded-3xl sm:py-8 lg:h-full">
+          <CardHeader class="px-4 pb-4 text-center sm:px-10 sm:pb-6">
+            <div
+              class="mb-2 flex justify-center transition-all delay-100 duration-700 ease-out lg:hidden"
+              :class="ready ? 'translate-y-0 opacity-100' : 'translate-y-6 opacity-0'"
+            >
+              <div class="auth-logo-mark">
+                <AppLogo class="h-11 w-auto" />
+              </div>
             </div>
-            <CardTitle class="text-xl">Invalid reset link</CardTitle>
-            <CardDescription>
-              This password reset link is missing required parameters. Please request a new one.
-            </CardDescription>
+            <template v-if="!hasValidParams">
+              <div class="mx-auto mb-3 flex size-12 items-center justify-center rounded-full bg-[var(--feedback-danger-bg)] text-[var(--feedback-danger-fg)]">
+                <CircleX class="size-6" />
+              </div>
+              <CardTitle class="text-xl sm:text-2xl">Invalid reset link</CardTitle>
+              <CardDescription>
+                This password reset link is missing required parameters. Please request a new one.
+              </CardDescription>
+            </template>
+            <template v-else-if="succeeded">
+              <div class="mx-auto mb-3 flex size-12 items-center justify-center rounded-full bg-[var(--feedback-success-bg)] text-[var(--feedback-success-fg)]">
+                <CircleCheck class="size-6" />
+              </div>
+              <CardTitle class="text-xl sm:text-2xl">Password reset</CardTitle>
+              <CardDescription>
+                Your password has been updated successfully. You can now sign in with your new password.
+              </CardDescription>
+            </template>
+            <template v-else>
+              <CardTitle class="text-xl sm:text-2xl">Set new password</CardTitle>
+              <CardDescription>Enter your new password below</CardDescription>
+            </template>
           </CardHeader>
-          <CardContent>
-            <RouterLink :to="{ name: RouteNames.FORGOT_PASSWORD }">
-              <Button class="w-full">
-                Request a new link
-              </Button>
-            </RouterLink>
-          </CardContent>
-        </Card>
 
-        <!-- Success state -->
-        <Card v-else-if="succeeded" class="border-primary/20 shadow-[0_28px_90px_-42px_oklch(0.28_0.09_245_/_0.65)]">
-          <CardHeader class="text-center">
-            <div class="mx-auto mb-2 flex size-12 items-center justify-center rounded-full bg-green-500/10">
-              <CircleCheck class="size-6 text-green-600 dark:text-green-400" />
+          <CardContent class="min-w-0 px-4 sm:px-10">
+            <div v-if="!hasValidParams" class="mx-auto flex w-full max-w-[400px] flex-col gap-5">
+              <AuthFeedbackAlert variant="danger" role="alert">
+                The link cannot be used as-is. Send yourself a new recovery email.
+              </AuthFeedbackAlert>
+              <RouterLink :to="{ name: RouteNames.FORGOT_PASSWORD }">
+                <Button class="h-10 w-full text-base">
+                  Request a new link
+                </Button>
+              </RouterLink>
             </div>
-            <CardTitle class="text-xl">Password reset!</CardTitle>
-            <CardDescription>
-              Your password has been updated successfully. You can now sign in with your new password.
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <RouterLink :to="{ name: RouteNames.LOGIN }">
-              <Button class="w-full">
-                Continue to sign in
-                <ArrowRight class="size-4" />
-              </Button>
-            </RouterLink>
-          </CardContent>
-        </Card>
 
-        <!-- Form state -->
-        <Card v-else class="border-primary/20 shadow-[0_28px_90px_-42px_oklch(0.28_0.09_245_/_0.65)]">
-          <CardHeader class="text-center">
-            <CardTitle class="text-xl">Set new password</CardTitle>
-            <CardDescription>Enter your new password below</CardDescription>
-          </CardHeader>
+            <div v-else-if="succeeded" class="mx-auto flex w-full max-w-[400px] flex-col gap-5">
+              <AuthFeedbackAlert variant="success" role="status">
+                Your new password is active for the next sign-in.
+              </AuthFeedbackAlert>
+              <RouterLink :to="{ name: RouteNames.LOGIN }">
+                <Button class="h-10 w-full text-base">
+                  Continue to sign in
+                  <ArrowRight class="size-4" />
+                </Button>
+              </RouterLink>
+            </div>
 
-          <CardContent>
-            <form class="flex flex-col gap-5" novalidate @submit.prevent="onSubmit">
-              <div
+            <form v-else class="mx-auto flex w-full max-w-[400px] flex-col gap-4 sm:gap-5" novalidate @submit.prevent="onSubmit">
+              <AuthFeedbackAlert
                 v-if="generalError"
+                variant="danger"
                 role="alert"
-                class="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2.5 text-sm text-destructive"
               >
                 {{ generalError }}
-              </div>
+              </AuthFeedbackAlert>
 
               <div
                 class="flex flex-col gap-2 transition-all delay-300 duration-500 ease-out"
@@ -184,6 +251,7 @@ const onSubmit = handleSubmit(async (values) => {
                   autocomplete="new-password"
                   :disabled="isLoading"
                   :aria-invalid="!!passwordError"
+                  class="auth-form-input"
                   required
                 />
                 <p v-if="passwordError" class="text-xs text-destructive">
@@ -207,6 +275,7 @@ const onSubmit = handleSubmit(async (values) => {
                   autocomplete="new-password"
                   :disabled="isLoading"
                   :aria-invalid="!!passwordConfirmationError"
+                  class="auth-form-input"
                   required
                 />
                 <p v-if="passwordConfirmationError" class="text-xs text-destructive">
@@ -218,11 +287,24 @@ const onSubmit = handleSubmit(async (values) => {
                 class="transition-all delay-[400ms] duration-500 ease-out"
                 :class="ready ? 'translate-y-0 opacity-100' : 'translate-y-4 opacity-0'"
               >
-                <Button type="submit" class="w-full" :disabled="isLoading">
+                <Button type="submit" class="h-10 w-full text-base" :disabled="isLoading">
                   <LoaderCircle v-if="isLoading" class="size-4 animate-spin" />
                   {{ isLoading ? 'Resetting...' : 'Reset password' }}
                 </Button>
               </div>
+
+              <p
+                class="text-center text-sm text-muted-foreground transition-all delay-[450ms] duration-500 ease-out"
+                :class="ready ? 'translate-y-0 opacity-100' : 'translate-y-4 opacity-0'"
+              >
+                Need a different link?
+                <RouterLink
+                  :to="{ name: RouteNames.FORGOT_PASSWORD }"
+                  class="font-medium text-primary underline-offset-4 hover:underline"
+                >
+                  Start again
+                </RouterLink>
+              </p>
             </form>
           </CardContent>
         </Card>
@@ -230,3 +312,170 @@ const onSubmit = handleSubmit(async (values) => {
     </div>
   </div>
 </template>
+
+<style scoped>
+.auth-side-panel {
+  background:
+    linear-gradient(135deg, rgb(255 255 255 / 0.54), rgb(255 255 255 / 0.2) 54%, rgb(255 255 255 / 0.34)),
+    rgb(255 255 255 / 0.08);
+  border: 1px solid rgb(255 255 255 / 0.5);
+  box-shadow: 0 32px 90px -42px oklch(0.22 0.08 245 / 0.62);
+  backdrop-filter: blur(30px) saturate(1.22);
+  -webkit-backdrop-filter: blur(30px) saturate(1.22);
+}
+
+.auth-recovery-card {
+  background:
+    linear-gradient(145deg, rgb(255 255 255 / 0.72), rgb(255 255 255 / 0.38) 58%, rgb(255 255 255 / 0.5)),
+    rgb(255 255 255 / 0.14);
+  border: 0;
+  backdrop-filter: blur(30px) saturate(1.2);
+  -webkit-backdrop-filter: blur(30px) saturate(1.2);
+}
+
+.auth-theme-toggle {
+  position: absolute;
+  right: 0.875rem;
+  top: 0.875rem;
+  z-index: 20;
+  display: inline-flex;
+  height: 2.25rem;
+  width: 2.25rem;
+  align-items: center;
+  justify-content: center;
+  border-radius: 9999px;
+  border: 1px solid rgb(255 255 255 / 0.48);
+  background: rgb(255 255 255 / 0.42);
+  color: rgb(15 23 42 / 0.72);
+  box-shadow: 0 14px 34px rgb(15 23 42 / 0.08);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+  transition: transform 120ms ease, background 120ms ease, box-shadow 120ms ease;
+}
+
+.auth-theme-toggle:hover {
+  transform: translateY(-1px);
+  background: rgb(255 255 255 / 0.58);
+  box-shadow: 0 18px 42px rgb(15 23 42 / 0.12);
+}
+
+.auth-theme-toggle:active {
+  transform: translateY(0);
+}
+
+.auth-theme-toggle:focus-visible {
+  outline: 2px solid rgb(37 99 235 / 0.45);
+  outline-offset: 3px;
+}
+
+.auth-logo-mark {
+  display: inline-flex;
+  min-height: 3.25rem;
+  min-width: 3.25rem;
+  align-items: center;
+  justify-content: center;
+  border-radius: 1.5rem;
+  border: 1px solid rgb(255 255 255 / 0.5);
+  background: rgb(255 255 255 / 0.58);
+  box-shadow: 0 18px 45px rgb(37 99 235 / 0.12);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+}
+
+@media (min-width: 640px) {
+  .auth-theme-toggle {
+    right: 1.5rem;
+    top: 1.5rem;
+    height: 2.5rem;
+    width: 2.5rem;
+  }
+
+  .auth-logo-mark {
+    min-height: 4rem;
+    min-width: 4rem;
+  }
+}
+
+.auth-status-row {
+  display: flex;
+  align-items: center;
+  gap: 0.875rem;
+  border-radius: 1.25rem;
+  border: 1px solid rgb(255 255 255 / 0.45);
+  background: rgb(255 255 255 / 0.36);
+  padding: 0.875rem;
+  box-shadow: 0 14px 34px rgb(15 23 42 / 0.06);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+}
+
+.auth-status-icon {
+  display: inline-flex;
+  height: 2.5rem;
+  width: 2.5rem;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  border-radius: 9999px;
+  border: 1px solid rgb(255 255 255 / 0.5);
+  background: rgb(255 255 255 / 0.58);
+  box-shadow: 0 10px 24px rgb(15 23 42 / 0.06);
+}
+
+:deep(.auth-form-input) {
+  height: 2.75rem;
+  border-radius: 1rem;
+  border-color: rgb(255 255 255 / 0.55);
+  background: rgb(255 255 255 / 0.62);
+  box-shadow: 0 10px 26px rgb(15 23 42 / 0.06);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+}
+
+:deep(.auth-form-input:focus-visible) {
+  border-color: rgb(255 255 255 / 0.75);
+  background: rgb(255 255 255 / 0.75);
+}
+
+:global(.dark) .auth-side-panel {
+  background:
+    linear-gradient(135deg, rgb(15 23 42 / 0.58), rgb(15 23 42 / 0.28) 54%, rgb(15 23 42 / 0.42)),
+    rgb(15 23 42 / 0.12);
+  border-color: rgb(255 255 255 / 0.1);
+  box-shadow: 0 24px 80px -38px rgb(0 0 0 / 0.82);
+}
+
+:global(.dark) .auth-recovery-card {
+  background:
+    linear-gradient(145deg, rgb(15 23 42 / 0.66), rgb(15 23 42 / 0.42) 58%, rgb(15 23 42 / 0.52)),
+    rgb(15 23 42 / 0.16);
+}
+
+:global(.dark) .auth-theme-toggle {
+  border-color: rgb(255 255 255 / 0.1);
+  background: rgb(255 255 255 / 0.08);
+  color: rgb(226 232 240 / 0.86);
+  box-shadow: 0 16px 38px rgb(0 0 0 / 0.28);
+}
+
+:global(.dark) .auth-theme-toggle:hover {
+  background: rgb(255 255 255 / 0.12);
+}
+
+:global(.dark) .auth-logo-mark,
+:global(.dark) .auth-status-row,
+:global(.dark) .auth-status-icon {
+  border-color: rgb(255 255 255 / 0.1);
+  background: rgb(255 255 255 / 0.08);
+}
+
+:global(.dark) :deep(.auth-form-input) {
+  border-color: rgb(255 255 255 / 0.12);
+  background: rgb(15 23 42 / 0.52);
+  box-shadow: 0 12px 28px rgb(0 0 0 / 0.24);
+}
+
+:global(.dark) :deep(.auth-form-input:focus-visible) {
+  background: rgb(15 23 42 / 0.66);
+}
+</style>

--- a/src/domains/auth/views/SignupView.vue
+++ b/src/domains/auth/views/SignupView.vue
@@ -169,7 +169,7 @@ async function requestGoogleLink(): Promise<void> {
 </script>
 
 <template>
-  <div class="auth-shell relative flex min-h-dvh items-start justify-center overflow-x-hidden overflow-y-auto px-4 pb-5 pt-16 sm:items-center sm:px-6 sm:py-6">
+  <div class="auth-shell relative flex min-h-dvh items-center justify-center overflow-x-hidden overflow-y-auto px-4 py-16 sm:px-6 sm:py-6">
     <canvas ref="canvasRef" class="pointer-events-none absolute inset-0 opacity-55" />
     <button
       type="button"

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -346,6 +346,93 @@
     border-color: oklch(1 0 0 / 0.12);
     box-shadow: 0 14px 32px rgb(59 130 246 / 0.18);
   }
+
+  .dark .auth-side-panel,
+  .dark .auth-login-card,
+  .dark .auth-signup-card,
+  .dark .auth-recovery-card {
+    color: rgb(248 250 252 / 0.96);
+    box-shadow: 0 32px 90px -42px rgb(0 0 0 / 0.86) !important;
+  }
+
+  .dark .auth-side-panel {
+    background:
+      radial-gradient(circle at 22% 14%, rgb(59 130 246 / 0.18), transparent 32%),
+      radial-gradient(circle at 82% 88%, rgb(20 184 166 / 0.12), transparent 34%),
+      linear-gradient(135deg, rgb(15 23 42 / 0.9), rgb(2 6 23 / 0.78) 56%, rgb(15 23 42 / 0.84)),
+      rgb(2 6 23 / 0.72) !important;
+    border-color: rgb(148 163 184 / 0.18) !important;
+  }
+
+  .dark .auth-login-card,
+  .dark .auth-signup-card,
+  .dark .auth-recovery-card {
+    background:
+      radial-gradient(circle at 50% 0%, rgb(59 130 246 / 0.12), transparent 34%),
+      linear-gradient(145deg, rgb(15 23 42 / 0.88), rgb(2 6 23 / 0.74) 58%, rgb(15 23 42 / 0.82)),
+      rgb(2 6 23 / 0.68) !important;
+  }
+
+  .dark .auth-side-panel .text-muted-foreground,
+  .dark .auth-login-card .text-muted-foreground,
+  .dark .auth-signup-card .text-muted-foreground,
+  .dark .auth-recovery-card .text-muted-foreground {
+    color: rgb(203 213 225 / 0.78) !important;
+  }
+
+  .dark .auth-status-row {
+    background: rgb(15 23 42 / 0.56) !important;
+    border-color: rgb(148 163 184 / 0.14) !important;
+    box-shadow: 0 16px 38px rgb(0 0 0 / 0.24) !important;
+  }
+
+  .dark .auth-logo-mark,
+  .dark .auth-status-icon {
+    background: rgb(15 23 42 / 0.72) !important;
+    border-color: rgb(148 163 184 / 0.14) !important;
+    box-shadow: 0 14px 30px rgb(0 0 0 / 0.24) !important;
+  }
+
+  .dark .auth-theme-toggle {
+    background: rgb(15 23 42 / 0.76) !important;
+    border-color: rgb(148 163 184 / 0.16) !important;
+    color: rgb(226 232 240 / 0.92) !important;
+    box-shadow: 0 18px 42px rgb(0 0 0 / 0.3) !important;
+  }
+
+  .dark .auth-theme-toggle:hover {
+    background: rgb(30 41 59 / 0.82) !important;
+  }
+
+  .dark .auth-form-input {
+    background: rgb(15 23 42 / 0.72) !important;
+    border-color: rgb(148 163 184 / 0.14) !important;
+    color: rgb(248 250 252 / 0.92) !important;
+    box-shadow: 0 14px 32px rgb(0 0 0 / 0.22) !important;
+  }
+
+  .dark .auth-form-input::placeholder {
+    color: rgb(148 163 184 / 0.78) !important;
+  }
+
+  .dark .auth-form-input:focus-visible {
+    background: rgb(15 23 42 / 0.84) !important;
+    border-color: rgb(125 211 252 / 0.34) !important;
+  }
+
+  .dark .auth-feedback-alert-success {
+    background:
+      linear-gradient(135deg, rgb(20 184 166 / 0.2), rgb(15 23 42 / 0.58)),
+      rgb(15 23 42 / 0.48) !important;
+    color: rgb(125 245 228) !important;
+  }
+
+  .dark .auth-feedback-alert-danger {
+    background:
+      linear-gradient(135deg, rgb(244 63 94 / 0.2), rgb(15 23 42 / 0.58)),
+      rgb(15 23 42 / 0.48) !important;
+    color: rgb(253 164 175) !important;
+  }
 }
 
 @supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {


### PR DESCRIPTION
## Summary

- Restyle forgot password and reset password with the same glass auth layout used by login and signup.
- Improve dark-mode glass contrast across the auth pages so cards, alerts, inputs, and status rows stay readable.
- Vertically center auth forms on mobile while keeping taller signup/reset flows scroll-safe.

## Validation

- `npm run build`
- `git diff --check`
- Local visual checks for mobile login, signup, forgot password, and dark-mode auth states.