### PR TITLE
Polish appointment glass styling

### DIFF
--- a/src/domains/appointment/components/AppointmentBoard.vue
+++ b/src/domains/appointment/components/AppointmentBoard.vue
@@ -345,9 +345,9 @@ const doctorLanes = computed<DoctorLane[]>(() => visibleDoctors.value.map((docto
 }))
 
 function appointmentCardClasses(status: AppointmentStatus): string {
-  if (status === 'checked_in') return 'border-emerald-200 bg-white shadow-sm shadow-emerald-950/5 dark:border-emerald-900 dark:bg-background'
-  if (status === 'cancelled' || status === 'no_show') return 'border-muted bg-muted/40 text-muted-foreground opacity-75'
-  return 'border-border bg-white shadow-sm dark:bg-background'
+  if (status === 'checked_in') return 'appointment-timeline-card--checked-in'
+  if (status === 'cancelled' || status === 'no_show') return 'appointment-timeline-card--quiet text-muted-foreground opacity-75'
+  return 'appointment-timeline-card--scheduled'
 }
 
 function formatStatus(status: AppointmentStatus): string {
@@ -510,9 +510,9 @@ defineExpose({ refetch: fetchBoard })
 <template>
   <div class="space-y-4">
     <div class="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
-      <div class="rounded-lg border bg-background p-4 shadow-sm">
+      <div class="appointment-board-stat surface-card rounded-2xl p-4">
         <div class="grid grid-cols-[44px_minmax(0,1fr)_auto] items-center gap-3">
-          <span class="flex size-10 items-center justify-center rounded-xl bg-gradient-to-br from-blue-500 to-blue-600 text-white shadow-sm">
+          <span class="appointment-stat-icon flex size-10 items-center justify-center rounded-2xl bg-gradient-to-br from-blue-500 to-blue-600 text-white shadow-[0_16px_32px_rgba(37,99,235,0.24)]">
             <CalendarDays class="size-6" />
           </span>
           <div>
@@ -523,9 +523,9 @@ defineExpose({ refetch: fetchBoard })
         </div>
         <p class="mt-3 text-sm text-muted-foreground">{{ stats.scheduled }} appointments</p>
       </div>
-      <div class="rounded-lg border bg-background p-4 shadow-sm">
+      <div class="appointment-board-stat surface-card rounded-2xl p-4">
         <div class="grid grid-cols-[44px_minmax(0,1fr)_auto] items-center gap-3">
-          <span class="flex size-10 items-center justify-center rounded-xl bg-gradient-to-br from-emerald-500 to-emerald-600 text-white shadow-sm">
+          <span class="appointment-stat-icon flex size-10 items-center justify-center rounded-2xl bg-gradient-to-br from-emerald-500 to-emerald-600 text-white shadow-[0_16px_32px_rgba(16,185,129,0.24)]">
             <CheckCircle2 class="size-6" />
           </span>
           <div>
@@ -536,9 +536,9 @@ defineExpose({ refetch: fetchBoard })
         </div>
         <p class="mt-3 text-sm text-muted-foreground">0 waiting</p>
       </div>
-      <div class="rounded-lg border bg-background p-4 shadow-sm">
+      <div class="appointment-board-stat surface-card rounded-2xl p-4">
         <div class="grid grid-cols-[44px_minmax(0,1fr)_auto] items-center gap-3">
-          <span class="flex size-10 items-center justify-center rounded-xl bg-gradient-to-br from-amber-500 to-amber-600 text-white shadow-sm">
+          <span class="appointment-stat-icon flex size-10 items-center justify-center rounded-2xl bg-gradient-to-br from-amber-500 to-amber-600 text-white shadow-[0_16px_32px_rgba(245,158,11,0.24)]">
             <Clock class="size-6" />
           </span>
           <div class="min-w-0">
@@ -553,9 +553,9 @@ defineExpose({ refetch: fetchBoard })
           {{ nextAppointment?.patient_name ?? 'No more scheduled visits' }}
         </p>
       </div>
-      <div class="rounded-lg border bg-background p-4 shadow-sm">
+      <div class="appointment-board-stat surface-card rounded-2xl p-4">
         <div class="grid grid-cols-[44px_minmax(0,1fr)_auto] items-center gap-3">
-          <span class="flex size-10 items-center justify-center rounded-xl bg-gradient-to-br from-violet-500 to-violet-600 text-white shadow-sm">
+          <span class="appointment-stat-icon flex size-10 items-center justify-center rounded-2xl bg-gradient-to-br from-violet-500 to-violet-600 text-white shadow-[0_16px_32px_rgba(139,92,246,0.24)]">
             <CalendarPlus class="size-6" />
           </span>
           <div>
@@ -568,23 +568,23 @@ defineExpose({ refetch: fetchBoard })
       </div>
     </div>
 
-    <div v-if="error" role="alert" class="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2.5 text-sm text-destructive">
+    <div v-if="error" role="alert" class="surface-card rounded-2xl bg-destructive/10 px-4 py-3 text-sm text-destructive">
       {{ error }}
       <Button variant="outline" size="sm" class="mt-2" @click="fetchBoard">Try again</Button>
     </div>
 
     <div class="grid gap-3 xl:grid-cols-[minmax(0,1fr)_minmax(430px,0.86fr)]">
-      <section class="overflow-hidden rounded-lg border bg-background shadow-sm">
-        <div class="flex items-center justify-between border-b px-4 py-3">
+      <section class="appointment-board-panel surface-card overflow-hidden rounded-2xl">
+        <div class="appointment-board-panel-header flex items-center justify-between px-4 py-3">
           <h2 class="text-base font-semibold">{{ selectedFlowTitle }}</h2>
         </div>
 
-        <div v-if="isLoading" class="m-5 flex items-center justify-center rounded-lg border py-16">
+        <div v-if="isLoading" class="surface-muted m-5 flex items-center justify-center rounded-2xl py-16">
           <LoaderCircle class="size-6 animate-spin text-muted-foreground" />
         </div>
 
-        <div v-else-if="appointments.length === 0 && selectedDayBlocks.length === 0" class="m-5 flex flex-col items-center justify-center rounded-lg border py-16 text-center">
-          <div class="mb-3 flex size-12 items-center justify-center rounded-full bg-primary/10">
+        <div v-else-if="appointments.length === 0 && selectedDayBlocks.length === 0" class="surface-muted m-5 flex flex-col items-center justify-center rounded-2xl py-16 text-center">
+          <div class="appointment-empty-icon mb-3 flex size-12 items-center justify-center rounded-2xl bg-primary/10">
             <CalendarDays class="size-6 text-primary" />
           </div>
           <p class="text-sm font-medium">No appointments for this day</p>
@@ -596,7 +596,7 @@ defineExpose({ refetch: fetchBoard })
         </div>
 
         <div v-else class="relative px-4 py-5">
-          <div class="absolute bottom-9 left-[102px] top-14 w-px bg-border" />
+          <div class="appointment-timeline-line absolute bottom-9 left-[102px] top-14 w-px" />
 
           <div class="space-y-4">
             <div
@@ -620,7 +620,7 @@ defineExpose({ refetch: fetchBoard })
 
               <template v-else-if="item.type === 'now'">
                 <div class="flex justify-end">
-                  <span class="whitespace-nowrap rounded-md border border-teal-300 bg-teal-50 px-2 py-0.5 text-xs font-semibold text-teal-700">
+                  <span class="appointment-now-pill whitespace-nowrap rounded-full px-2 py-0.5 text-xs font-semibold text-teal-700">
                     {{ currentTimeLabel }}
                   </span>
                 </div>
@@ -647,7 +647,7 @@ defineExpose({ refetch: fetchBoard })
                 <div
                   role="button"
                   tabindex="0"
-                  :class="['relative min-h-24 rounded-lg border p-3 text-left transition hover:-translate-y-0.5 hover:shadow-md', appointmentCardClasses(item.appointment.status)]"
+                  :class="['appointment-timeline-card relative min-h-24 rounded-2xl p-3 text-left transition-all hover:-translate-y-0.5', appointmentCardClasses(item.appointment.status)]"
                   @click="emit('appointment-click', item.appointment.id)"
                   @keydown.enter.space.prevent="emit('appointment-click', item.appointment.id)"
                 >
@@ -753,10 +753,10 @@ defineExpose({ refetch: fetchBoard })
 
                 <div
                   :class="[
-                    'relative rounded-lg border p-3 text-left',
+                    'appointment-block-card relative rounded-2xl p-3 text-left',
                     item.block.type === 'leave' || item.block.type === 'unavailable'
-                      ? 'border-dashed bg-muted/30'
-                      : 'bg-background',
+                      ? 'appointment-block-card--quiet'
+                      : '',
                   ]"
                 >
                   <div class="grid gap-3 sm:grid-cols-[40px_minmax(0,1fr)_auto] sm:items-center">
@@ -803,7 +803,7 @@ defineExpose({ refetch: fetchBoard })
       </section>
 
       <aside class="space-y-3">
-        <section class="rounded-lg border bg-background p-4 shadow-sm">
+        <section class="appointment-board-side-card surface-card rounded-2xl p-4">
           <div class="mb-3 flex items-center justify-between">
             <div>
               <h2 class="text-base font-semibold">Week at a glance</h2>
@@ -816,12 +816,12 @@ defineExpose({ refetch: fetchBoard })
               v-for="day in weekDays"
               :key="day"
               :class="[
-                'rounded-lg border p-2 text-center transition-colors',
+                'appointment-week-day rounded-2xl p-2 text-center transition-all',
                 day === todayDate
-                  ? 'border-teal-300 bg-teal-50 text-teal-950 shadow-sm shadow-teal-950/10 ring-1 ring-teal-300 dark:border-teal-700 dark:bg-teal-950/30 dark:text-teal-100'
+                  ? 'is-today text-teal-950 dark:text-teal-100'
                   : day === selectedDate
-                    ? 'border-transparent bg-blue-50 text-foreground dark:bg-blue-950/30'
-                    : 'border-transparent hover:bg-muted/60',
+                    ? 'is-selected text-foreground'
+                    : 'hover:bg-white/40 dark:hover:bg-white/5',
               ]"
               @click="selectDate(day)"
             >
@@ -857,12 +857,12 @@ defineExpose({ refetch: fetchBoard })
           </div>
         </section>
 
-        <section class="rounded-lg border bg-background p-4 shadow-sm">
+        <section class="appointment-board-side-card surface-card rounded-2xl p-4">
           <div class="mb-3 flex items-center justify-between">
             <h2 class="text-base font-semibold">Doctor lanes</h2>
             <Button variant="link" size="sm" class="h-auto p-0 text-xs">View all</Button>
           </div>
-          <div class="divide-y">
+          <div class="appointment-doctor-lanes divide-y">
             <div v-for="lane in doctorLanes.slice(0, 3)" :key="lane.doctor.id" class="py-3 first:pt-0 last:pb-0">
               <div class="grid grid-cols-[44px_minmax(0,1fr)_92px_120px] items-center gap-3">
                 <img
@@ -903,3 +903,146 @@ defineExpose({ refetch: fetchBoard })
     </div>
   </div>
 </template>
+
+<style scoped>
+.appointment-board-stat,
+.appointment-board-panel,
+.appointment-board-side-card,
+.appointment-timeline-card,
+.appointment-block-card {
+  position: relative;
+}
+
+.appointment-board-stat,
+.appointment-board-panel,
+.appointment-board-side-card,
+.appointment-timeline-card,
+.appointment-block-card {
+  border: 0;
+  background:
+    radial-gradient(circle at 18% 0%, rgb(59 130 246 / 0.08), transparent 32%),
+    radial-gradient(circle at 82% 18%, rgb(20 184 166 / 0.08), transparent 30%),
+    var(--surface-panel-strong);
+}
+
+.appointment-board-panel-header {
+  box-shadow: inset 0 -1px 0 rgb(255 255 255 / 0.32);
+}
+
+.appointment-stat-icon,
+.appointment-empty-icon {
+  transform: translateZ(0);
+}
+
+.appointment-timeline-line {
+  background: rgb(148 163 184 / 0.28);
+}
+
+.appointment-now-pill {
+  border: 1px solid rgb(94 234 212 / 0.42);
+  background: rgb(240 253 250 / 0.72);
+  box-shadow: 0 10px 24px rgb(15 118 110 / 0.1);
+}
+
+.appointment-timeline-card:hover,
+.appointment-block-card:hover,
+.appointment-board-side-card:hover {
+  box-shadow: var(--surface-shadow-strong);
+}
+
+.appointment-timeline-card--checked-in {
+  background:
+    linear-gradient(135deg, rgb(16 185 129 / 0.1), rgb(255 255 255 / 0.38)),
+    var(--surface-panel-strong);
+}
+
+.appointment-timeline-card--quiet {
+  background: rgb(148 163 184 / 0.12);
+}
+
+.appointment-block-card--quiet {
+  border: 1px dashed rgb(148 163 184 / 0.28);
+}
+
+.appointment-week-day {
+  border: 0;
+}
+
+.appointment-week-day.is-today {
+  background: rgb(204 251 241 / 0.78);
+  box-shadow:
+    0 12px 26px rgb(15 118 110 / 0.12),
+    inset 0 0 0 1px rgb(45 212 191 / 0.46);
+}
+
+.appointment-week-day.is-selected {
+  background: rgb(219 234 254 / 0.72);
+  box-shadow: inset 0 0 0 1px rgb(96 165 250 / 0.34);
+}
+
+.appointment-doctor-lanes {
+  border-color: rgb(255 255 255 / 0.28);
+}
+
+:global(.dark .appointment-board-stat),
+:global(.dark .appointment-board-panel),
+:global(.dark .appointment-board-side-card),
+:global(.dark .appointment-timeline-card),
+:global(.dark .appointment-block-card) {
+  background:
+    radial-gradient(circle at 86% 88%, rgb(20 184 166 / 0.12), transparent 34%),
+    radial-gradient(circle at 18% 10%, rgb(59 130 246 / 0.12), transparent 30%),
+    linear-gradient(135deg, rgb(15 23 42 / 0.58), rgb(15 23 42 / 0.28) 54%, rgb(15 23 42 / 0.42)),
+    rgb(15 23 42 / 0.12);
+  border: 1px solid rgb(255 255 255 / 0.1) !important;
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 0.06),
+    inset 1px 0 0 rgb(255 255 255 / 0.035),
+    0 24px 80px -38px rgb(0 0 0 / 0.82);
+}
+
+:global(.dark .appointment-board-panel-header) {
+  box-shadow:
+    inset 0 -1px 0 rgb(148 163 184 / 0.12),
+    inset 0 1px 0 rgb(255 255 255 / 0.03);
+}
+
+:global(.dark .appointment-timeline-line) {
+  background: rgb(148 163 184 / 0.14);
+}
+
+:global(.dark .appointment-now-pill) {
+  color: rgb(94 234 212);
+  border-color: rgb(94 234 212 / 0.22);
+  background: rgb(20 184 166 / 0.12);
+  box-shadow: 0 14px 34px rgb(0 0 0 / 0.22);
+}
+
+:global(.dark .appointment-timeline-card:hover),
+:global(.dark .appointment-block-card:hover) {
+  background:
+    linear-gradient(90deg, rgb(59 130 246 / 0.12), rgb(20 184 166 / 0.08)),
+    rgb(15 23 42 / 0.38);
+  box-shadow:
+    inset 3px 0 0 rgb(56 189 248 / 0.42),
+    inset 0 1px 0 rgb(255 255 255 / 0.04),
+    inset 0 -1px 0 rgb(255 255 255 / 0.04),
+    0 24px 80px -38px rgb(0 0 0 / 0.82);
+}
+
+:global(.dark .appointment-week-day.is-today) {
+  background: rgb(20 184 166 / 0.14);
+  box-shadow:
+    0 0 0 1px rgb(94 234 212 / 0.22),
+    0 14px 34px rgb(20 184 166 / 0.1);
+}
+
+:global(.dark .appointment-week-day.is-selected) {
+  background: rgb(59 130 246 / 0.14);
+  box-shadow: inset 0 0 0 1px rgb(96 165 250 / 0.2);
+}
+
+:global(.dark .appointment-doctor-lanes) {
+  border-color: rgb(148 163 184 / 0.1);
+}
+</style>

--- a/src/domains/appointment/components/AppointmentCalendar.vue
+++ b/src/domains/appointment/components/AppointmentCalendar.vue
@@ -372,10 +372,10 @@ const calendarOptions: CalendarOptions = {
 </script>
 
 <template>
-  <div class="appointment-calendar">
+  <div class="appointment-calendar appointment-calendar-shell surface-card rounded-2xl p-4">
     <!-- Doctor legend -->
     <div v-if="doctorLegend.length" class="mb-3 flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
-      <div v-for="doc in doctorLegend" :key="doc.name" class="flex items-center gap-1.5">
+      <div v-for="doc in doctorLegend" :key="doc.name" class="appointment-calendar-legend-pill flex items-center gap-1.5 rounded-full px-2.5 py-1">
         <div class="relative flex items-center">
           <div class="h-4 w-1 rounded-full" :style="{ backgroundColor: doc.color }" />
           <img v-if="doc.avatarUrl" :src="doc.avatarUrl" alt="" class="ml-1 size-5 rounded-full object-cover" />
@@ -389,12 +389,12 @@ const calendarOptions: CalendarOptions = {
 
     <!-- Status legend -->
     <div class="mb-3 flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
-      <div v-for="(colors, status) in STATUS_COLORS" :key="status" class="flex items-center gap-1.5">
+      <div v-for="(colors, status) in STATUS_COLORS" :key="status" class="appointment-calendar-legend-pill flex items-center gap-1.5 rounded-full px-2.5 py-1">
         <div class="size-2.5 rounded-sm border" :style="{ backgroundColor: colors.bg, borderColor: colors.border }" />
         {{ status === 'checked_in' ? 'Checked In' : status === 'no_show' ? 'No Show' : status.charAt(0).toUpperCase() + status.slice(1) }}
       </div>
       <span class="text-border">|</span>
-      <div v-for="(colors, btype) in BLOCK_TYPE_COLORS" :key="btype" class="flex items-center gap-1.5">
+      <div v-for="(colors, btype) in BLOCK_TYPE_COLORS" :key="btype" class="appointment-calendar-legend-pill flex items-center gap-1.5 rounded-full px-2.5 py-1">
         <div class="size-2.5 rounded-sm border" :style="{ backgroundColor: colors.bg, borderColor: colors.border }" />
         {{ BLOCK_TYPE_LABELS[btype] ?? btype }}
       </div>
@@ -405,6 +405,19 @@ const calendarOptions: CalendarOptions = {
 </template>
 
 <style>
+.appointment-calendar-shell {
+  border: 0;
+  background:
+    radial-gradient(circle at 18% 0%, rgb(59 130 246 / 0.08), transparent 32%),
+    radial-gradient(circle at 82% 18%, rgb(20 184 166 / 0.08), transparent 30%),
+    var(--surface-panel-strong);
+}
+
+.appointment-calendar-legend-pill {
+  background: rgb(255 255 255 / 0.36);
+  box-shadow: inset 0 0 0 1px rgb(255 255 255 / 0.28);
+}
+
 .appointment-calendar .fc {
   --fc-border-color: var(--border);
   --fc-today-bg-color: oklch(0.97 0.005 253.827 / 0.3);
@@ -423,12 +436,14 @@ const calendarOptions: CalendarOptions = {
   padding: 0.3rem 0.7rem;
   font-size: 0.8rem;
   font-weight: 500;
-  border-radius: 0.375rem;
-  border: 1px solid var(--border);
-  background: var(--background);
+  border-radius: 9999px;
+  border: 1px solid rgb(255 255 255 / 0.5);
+  background: var(--surface-muted);
   color: var(--foreground);
   text-transform: capitalize;
-  box-shadow: none;
+  box-shadow: 0 12px 28px rgb(15 23 42 / 0.06);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
 }
 
 .appointment-calendar .fc .fc-button:hover {
@@ -437,9 +452,12 @@ const calendarOptions: CalendarOptions = {
 
 .appointment-calendar .fc .fc-button-active,
 .appointment-calendar .fc .fc-button:active {
-  background: var(--primary) !important;
-  color: var(--primary-foreground) !important;
-  border-color: var(--primary) !important;
+  background: linear-gradient(135deg, rgb(37 99 235), rgb(20 184 166)) !important;
+  color: white !important;
+  border-color: rgb(255 255 255 / 0.28) !important;
+  box-shadow:
+    0 12px 26px rgb(37 99 235 / 0.16),
+    inset 0 1px 0 rgb(255 255 255 / 0.26);
 }
 
 .appointment-calendar .fc .fc-button:focus {
@@ -451,7 +469,7 @@ const calendarOptions: CalendarOptions = {
   font-size: 0.8rem;
   font-weight: 500;
   color: var(--muted-foreground);
-  background: var(--muted);
+  background: rgb(255 255 255 / 0.28);
 }
 
 .appointment-calendar .fc .fc-timegrid-slot {
@@ -502,8 +520,26 @@ const calendarOptions: CalendarOptions = {
 }
 
 .appointment-calendar .fc .fc-scrollgrid {
-  border-radius: 0.5rem;
+  border-radius: 1rem;
   overflow: hidden;
+}
+
+.dark .appointment-calendar-shell {
+  background:
+    radial-gradient(circle at 86% 88%, rgb(20 184 166 / 0.12), transparent 34%),
+    radial-gradient(circle at 18% 10%, rgb(59 130 246 / 0.12), transparent 30%),
+    linear-gradient(135deg, rgb(15 23 42 / 0.58), rgb(15 23 42 / 0.28) 54%, rgb(15 23 42 / 0.42)),
+    rgb(15 23 42 / 0.12);
+  border: 1px solid rgb(255 255 255 / 0.1) !important;
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 0.06),
+    inset 1px 0 0 rgb(255 255 255 / 0.035),
+    0 24px 80px -38px rgb(0 0 0 / 0.82);
+}
+
+.dark .appointment-calendar-legend-pill {
+  background: rgb(15 23 42 / 0.46);
+  box-shadow: inset 0 0 0 1px rgb(255 255 255 / 0.08);
 }
 
 .dark .appointment-calendar .fc .fc-day-past {
@@ -515,12 +551,19 @@ const calendarOptions: CalendarOptions = {
 }
 
 .dark .appointment-calendar .fc .fc-button {
-  background: var(--background);
+  background: rgb(15 23 42 / 0.58);
   color: var(--foreground);
-  border-color: var(--border);
+  border-color: rgb(255 255 255 / 0.1);
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 0.04),
+    0 14px 32px rgb(0 0 0 / 0.22);
 }
 
 .dark .appointment-calendar .fc .fc-button:hover {
-  background: var(--accent);
+  background: rgb(255 255 255 / 0.1);
+}
+
+.dark .appointment-calendar .fc .fc-col-header-cell {
+  background: rgb(15 23 42 / 0.38);
 }
 </style>

--- a/src/domains/appointment/components/AppointmentCard.vue
+++ b/src/domains/appointment/components/AppointmentCard.vue
@@ -64,11 +64,11 @@ const relativeTime = computed(() => {
 
 <template>
   <div
-    class="flex cursor-pointer flex-col gap-3 rounded-lg border p-3 transition-colors hover:bg-muted/50 sm:flex-row sm:items-center sm:justify-between"
+    class="appointment-list-card surface-card surface-interactive flex cursor-pointer flex-col gap-3 rounded-2xl p-4 transition-all hover:-translate-y-0.5 sm:flex-row sm:items-center sm:justify-between"
     @click="emit('click', appointment.id)"
   >
     <div class="flex min-w-0 items-center gap-3">
-      <div class="flex size-9 shrink-0 items-center justify-center rounded-full bg-primary/10">
+      <div class="appointment-list-icon flex size-10 shrink-0 items-center justify-center rounded-2xl bg-primary/10">
         <CalendarCheck class="size-4 text-primary" />
       </div>
       <div class="min-w-0">
@@ -149,3 +149,52 @@ const relativeTime = computed(() => {
     </div>
   </div>
 </template>
+
+<style scoped>
+.appointment-list-card {
+  position: relative;
+  border: 0;
+  background:
+    radial-gradient(circle at 18% 0%, rgb(59 130 246 / 0.08), transparent 32%),
+    radial-gradient(circle at 82% 18%, rgb(20 184 166 / 0.08), transparent 30%),
+    var(--surface-panel-strong);
+}
+
+.appointment-list-card:hover {
+  box-shadow: var(--surface-shadow-strong);
+}
+
+.appointment-list-icon {
+  box-shadow: 0 12px 28px rgb(15 23 42 / 0.08);
+}
+
+:global(.dark .appointment-list-card) {
+  background:
+    radial-gradient(circle at 86% 88%, rgb(20 184 166 / 0.12), transparent 34%),
+    radial-gradient(circle at 18% 10%, rgb(59 130 246 / 0.12), transparent 30%),
+    linear-gradient(135deg, rgb(15 23 42 / 0.58), rgb(15 23 42 / 0.28) 54%, rgb(15 23 42 / 0.42)),
+    rgb(15 23 42 / 0.12);
+  border: 1px solid rgb(255 255 255 / 0.1) !important;
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 0.06),
+    inset 1px 0 0 rgb(255 255 255 / 0.035),
+    0 24px 80px -38px rgb(0 0 0 / 0.82);
+}
+
+:global(.dark .appointment-list-card:hover) {
+  background:
+    linear-gradient(90deg, rgb(59 130 246 / 0.12), rgb(20 184 166 / 0.08)),
+    rgb(15 23 42 / 0.38);
+  box-shadow:
+    inset 3px 0 0 rgb(56 189 248 / 0.42),
+    inset 0 1px 0 rgb(255 255 255 / 0.04),
+    inset 0 -1px 0 rgb(255 255 255 / 0.04),
+    0 24px 80px -38px rgb(0 0 0 / 0.82);
+}
+
+:global(.dark .appointment-list-icon) {
+  border: 1px solid rgb(148 163 184 / 0.14);
+  background: rgb(15 23 42 / 0.58);
+  box-shadow: 0 14px 34px rgb(0 0 0 / 0.24);
+}
+</style>

--- a/src/domains/appointment/views/AppointmentListView.vue
+++ b/src/domains/appointment/views/AppointmentListView.vue
@@ -443,16 +443,16 @@ onUnmounted(() => {
 
 <template>
   <FeatureGate feature="appointments" label="Appointments">
-  <div class="flex flex-1 flex-col gap-4 pt-4">
+  <div class="appointment-list-shell flex flex-1 flex-col gap-4 pt-4">
     <!-- Header -->
     <div class="flex flex-col gap-3">
-      <div class="flex items-center gap-3">
+      <div class="flex flex-col gap-3 sm:flex-row sm:items-center">
         <div class="flex min-w-0 flex-1 items-center gap-3">
-          <h1 class="text-2xl font-semibold">Appointments</h1>
-          <Badge variant="secondary" class="rounded-full text-xs">{{ appointmentTotal }}</Badge>
+          <h1 class="text-2xl font-semibold tracking-normal">Appointments</h1>
+          <Badge variant="secondary" class="rounded-full px-2.5 text-sm tabular-nums">{{ appointmentTotal }}</Badge>
         </div>
 
-        <Button class="h-10 gap-2 px-4" @click="openBookingWizard()">
+        <Button class="h-10 w-full gap-2 px-5 text-sm sm:w-auto" @click="openBookingWizard()">
           <Plus class="size-4" />
           <span>Book appointment</span>
         </Button>
@@ -460,23 +460,23 @@ onUnmounted(() => {
 
       <div class="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
         <!-- View toggle -->
-        <div class="flex h-10 w-fit items-center rounded-md border bg-background">
+        <div class="appointment-view-tabs surface-muted flex h-10 w-full items-center rounded-full p-1 sm:w-fit">
           <button
-            :class="['flex h-full items-center gap-2 rounded-l-md px-4 text-sm font-medium transition-colors', viewMode === 'board' ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:text-foreground']"
+            :class="['appointment-view-tab flex h-full flex-1 items-center justify-center gap-2 rounded-full px-4 text-sm font-medium transition-all sm:flex-none', viewMode === 'board' ? 'is-active' : 'text-muted-foreground hover:text-foreground']"
             @click="viewMode = 'board'"
           >
             <LayoutDashboard class="size-4" />
-            Today Board
+            <span><span class="hidden sm:inline">Today </span>Board</span>
           </button>
           <button
-            :class="['flex h-full items-center gap-2 border-l px-4 text-sm font-medium transition-colors', viewMode === 'calendar' ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:text-foreground']"
+            :class="['appointment-view-tab flex h-full flex-1 items-center justify-center gap-2 rounded-full px-4 text-sm font-medium transition-all sm:flex-none', viewMode === 'calendar' ? 'is-active' : 'text-muted-foreground hover:text-foreground']"
             @click="viewMode = 'calendar'"
           >
             <CalendarCheck class="size-4" />
             Calendar
           </button>
           <button
-            :class="['flex h-full items-center gap-2 rounded-r-md border-l px-4 text-sm font-medium transition-colors', viewMode === 'list' ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:text-foreground']"
+            :class="['appointment-view-tab flex h-full flex-1 items-center justify-center gap-2 rounded-full px-4 text-sm font-medium transition-all sm:flex-none', viewMode === 'list' ? 'is-active' : 'text-muted-foreground hover:text-foreground']"
             @click="viewMode = 'list'"
           >
             <List class="size-4" />
@@ -486,7 +486,7 @@ onUnmounted(() => {
 
         <div class="flex flex-wrap items-center gap-2 lg:justify-end">
           <Select v-model="doctorFilter" @update:model-value="onFilterChange">
-            <SelectTrigger class="h-10 w-[170px]">
+            <SelectTrigger class="appointment-select-trigger h-10 w-full sm:w-[170px]">
               <span class="flex min-w-0 flex-1 items-center gap-2 overflow-hidden">
                 <UserRound class="size-4 shrink-0" />
                 <SelectValue class="min-w-0 flex-1 truncate" placeholder="All doctors" />
@@ -506,7 +506,7 @@ onUnmounted(() => {
 
           <!-- Status filter -->
           <Select v-model="statusFilter" @update:model-value="onFilterChange">
-            <SelectTrigger class="h-10 w-[170px]">
+            <SelectTrigger class="appointment-select-trigger h-10 w-full sm:w-[170px]">
               <SelectValue placeholder="All statuses" />
             </SelectTrigger>
             <SelectContent>
@@ -523,7 +523,7 @@ onUnmounted(() => {
 
       <div v-if="viewMode === 'list'" class="flex flex-wrap items-center gap-2">
         <!-- Range quick filters (list view only) -->
-        <div class="flex h-8 items-center rounded-md border text-xs">
+        <div class="appointment-range-tabs surface-muted flex h-9 w-full items-center overflow-x-auto rounded-full p-1 text-xs sm:w-fit">
           <button
             v-for="opt in [
               { value: 'today', label: 'Today' },
@@ -535,9 +535,9 @@ onUnmounted(() => {
             ]"
             :key="opt.value"
             :class="[
-              'h-full px-2.5 font-medium transition-colors first:rounded-l-md last:rounded-r-md',
+              'h-full shrink-0 rounded-full px-3 font-medium transition-all',
               activeRange === opt.value
-                ? 'bg-primary text-primary-foreground'
+                ? 'is-active'
                 : 'text-muted-foreground hover:text-foreground',
             ]"
             @click="onRangeChange(opt.value)"
@@ -553,7 +553,7 @@ onUnmounted(() => {
               <Button
                 variant="outline"
                 size="sm"
-                class="h-8 w-[160px] justify-start text-left font-normal"
+                class="appointment-date-trigger h-9 w-[160px] justify-start text-left font-normal"
                 :class="{ 'text-muted-foreground': !dateFilter }"
               >
                 <CalendarIcon class="mr-1.5 size-3.5" />
@@ -620,7 +620,7 @@ onUnmounted(() => {
       <div
         v-else-if="error"
         role="alert"
-        class="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2.5 text-sm text-destructive"
+        class="surface-card rounded-2xl bg-destructive/10 px-4 py-3 text-sm text-destructive"
       >
         {{ error }}
         <Button variant="outline" size="sm" class="mt-2" @click="fetchData">
@@ -631,9 +631,9 @@ onUnmounted(() => {
       <!-- Empty state -->
       <div
         v-else-if="store.appointments.length === 0"
-        class="flex flex-col items-center justify-center py-16 text-center"
+        class="surface-card flex flex-col items-center justify-center rounded-2xl py-16 text-center"
       >
-        <div class="mb-3 flex size-12 items-center justify-center rounded-full bg-primary/10">
+        <div class="appointment-empty-icon mb-3 flex size-12 items-center justify-center rounded-2xl bg-primary/10">
           <CalendarCheck class="size-6 text-primary" />
         </div>
         <p class="text-sm font-medium">No appointments found</p>
@@ -647,7 +647,7 @@ onUnmounted(() => {
       </div>
 
       <!-- List -->
-      <div v-else class="flex flex-col gap-2">
+      <div v-else class="appointment-list-stack flex flex-col gap-3">
         <AppointmentCard
           v-for="appt in store.appointments"
           :key="appt.id"
@@ -787,3 +787,48 @@ onUnmounted(() => {
   </div>
   </FeatureGate>
 </template>
+
+<style scoped>
+.appointment-view-tabs,
+.appointment-range-tabs {
+  border: 0;
+  box-shadow: 0 12px 28px rgb(15 23 42 / 0.06);
+}
+
+.appointment-view-tab.is-active,
+.appointment-range-tabs .is-active {
+  color: white;
+  background: linear-gradient(135deg, rgb(37 99 235), rgb(20 184 166));
+  box-shadow:
+    0 12px 26px rgb(37 99 235 / 0.16),
+    inset 0 1px 0 rgb(255 255 255 / 0.26);
+}
+
+.appointment-select-trigger,
+.appointment-date-trigger {
+  box-shadow: 0 12px 28px rgb(15 23 42 / 0.06);
+}
+
+.appointment-empty-icon {
+  box-shadow: 0 14px 34px rgb(37 99 235 / 0.12);
+}
+
+:global(.dark .appointment-view-tabs),
+:global(.dark .appointment-range-tabs) {
+  border: 1px solid rgb(255 255 255 / 0.1) !important;
+  background:
+    linear-gradient(135deg, rgb(15 23 42 / 0.62), rgb(15 23 42 / 0.28)),
+    rgb(15 23 42 / 0.2);
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 0.05),
+    0 16px 38px rgb(0 0 0 / 0.26);
+}
+
+:global(.dark .appointment-view-tab.is-active),
+:global(.dark .appointment-range-tabs .is-active) {
+  box-shadow:
+    0 0 0 1px rgb(125 211 252 / 0.14),
+    0 14px 34px rgb(56 189 248 / 0.16),
+    inset 0 1px 0 rgb(255 255 255 / 0.2);
+}
+</style>


### PR DESCRIPTION
## Summary
- Restyle the appointments page header controls, view tabs, filters, and empty/error states for the glass design direction.
- Update the appointment board stats, flow panel, week overview, doctor lanes, appointment cards, and calendar shell to match the patient list glass treatment.
- Improve mobile layout so the page title and primary action stack cleanly.

## Validation
- `git diff --check`
- `npm run build`
- Local visual check on `http://clinic.test/appointments` in light, dark, mobile dark, and calendar mode.