### PR TITLE
Add phase 3 appointment coverage

### DIFF
--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -1,7 +1,8 @@
 import { test as base, expect } from '@playwright/test'
 
-const EMAIL = process.env.E2E_EMAIL || 'demo@mail.com'
-const PASSWORD = process.env.E2E_PASSWORD || 'password'
+const EMAIL = process.env.E2E_EMAIL
+const PASSWORD = process.env.E2E_PASSWORD
+const HAS_E2E_CREDENTIALS = Boolean(EMAIL && PASSWORD)
 
 // Custom fixture that provides a pre-authenticated page
 // Login happens once per worker, shared across all tests
@@ -30,6 +31,10 @@ export const test = base.extend<{}, { authenticatedContext: import('@playwright/
     await use(page)
     await page.close()
   },
+})
+
+test.beforeEach(({}, testInfo) => {
+  testInfo.skip(!HAS_E2E_CREDENTIALS, 'Set E2E_EMAIL and E2E_PASSWORD to run authenticated staging tests.')
 })
 
 export { expect }

--- a/src/domains/appointment/components/AppointmentCard.spec.ts
+++ b/src/domains/appointment/components/AppointmentCard.spec.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mountWithDeps } from '@/__tests__/helpers/mountWithDeps'
+import AppointmentCard from './AppointmentCard.vue'
+import type { AppointmentResponse } from '../types/appointment.types'
+
+function makeAppointment(overrides: Partial<AppointmentResponse> = {}): AppointmentResponse {
+  return {
+    id: 'appt-1',
+    clinic_id: 'clinic-1',
+    patient_id: 'patient-1',
+    patient_name: 'Juan Dela Cruz',
+    patient_avatar_url: null,
+    doctor_id: 'doctor-1',
+    doctor_name: 'Maria Santos',
+    doctor_avatar_url: null,
+    created_by: 'user-1',
+    status: 'scheduled',
+    scheduled_at: '2026-05-06T02:30:00.000Z',
+    duration: 30,
+    reason: 'Follow-up',
+    cancellation_reason: null,
+    cancelled_by: null,
+    checked_in_at: null,
+    completed_at: null,
+    notes: null,
+    created_at: '2026-05-01T00:00:00.000Z',
+    updated_at: '2026-05-01T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+const STUBS = {
+  AppointmentStatusBadge: {
+    props: ['status'],
+    template: '<span data-testid="status">{{ status }}</span>',
+  },
+  Button: {
+    emits: ['click'],
+    template: '<button v-bind="$attrs" @click="$emit(`click`, $event)"><slot /></button>',
+  },
+  TooltipProvider: { template: '<div><slot /></div>' },
+  Tooltip: { template: '<div><slot /></div>' },
+  TooltipTrigger: { template: '<div><slot /></div>' },
+  TooltipContent: { template: '<div><slot /></div>' },
+  DropdownMenu: { template: '<div><slot /></div>' },
+  DropdownMenuTrigger: { template: '<div><slot /></div>' },
+  DropdownMenuContent: { template: '<div><slot /></div>' },
+  DropdownMenuItem: {
+    emits: ['click'],
+    template: '<button type="button" @click="$emit(`click`, $event)"><slot /></button>',
+  },
+  DropdownMenuSeparator: { template: '<hr />' },
+}
+
+function mountCard(appointment = makeAppointment(), canManage = true) {
+  return mountWithDeps(AppointmentCard, {
+    props: { appointment, canManage },
+    global: { stubs: STUBS },
+  })
+}
+
+describe('AppointmentCard', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-06T01:30:00.000Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('renders patient, doctor, reason, date, time, and relative time', () => {
+    const wrapper = mountCard()
+
+    expect(wrapper.text()).toContain('Juan Dela Cruz')
+    expect(wrapper.text()).toContain('Dr. Maria Santos')
+    expect(wrapper.text()).toContain('Follow-up')
+    expect(wrapper.text()).toContain('May 6, 2026')
+    expect(wrapper.text()).toContain('2:30 AM')
+    expect(wrapper.text()).toContain('in 1h')
+  })
+
+  it('falls back to Unknown Patient when patient_name is missing', () => {
+    const wrapper = mountCard(makeAppointment({ patient_name: null }))
+
+    expect(wrapper.text()).toContain('Unknown Patient')
+  })
+
+  it('emits click when the card body is selected', async () => {
+    const wrapper = mountCard()
+
+    await wrapper.find('.appointment-list-card').trigger('click')
+
+    expect(wrapper.emitted('click')).toEqual([['appt-1']])
+  })
+
+  it('emits scheduled management actions without triggering the card click', async () => {
+    const wrapper = mountCard()
+
+    await wrapper.findAll('button').find((button) => button.text().includes('Check In'))?.trigger('click')
+    await wrapper.findAll('button').find((button) => button.text().includes('Mark No-Show'))?.trigger('click')
+    await wrapper.findAll('button').find((button) => button.text().includes('Cancel Appointment'))?.trigger('click')
+
+    expect(wrapper.emitted('check-in')).toEqual([['appt-1']])
+    expect(wrapper.emitted('no-show')).toEqual([['appt-1']])
+    expect(wrapper.emitted('cancel')).toEqual([['appt-1']])
+    expect(wrapper.emitted('click')).toBeUndefined()
+  })
+
+  it('hides management actions when appointment is not scheduled or user cannot manage', () => {
+    const completed = mountCard(makeAppointment({ status: 'completed' }))
+    const readOnly = mountCard(makeAppointment(), false)
+
+    expect(completed.text()).not.toContain('Check In')
+    expect(readOnly.text()).not.toContain('Check In')
+  })
+})

--- a/src/domains/appointment/components/AppointmentStatusBadge.spec.ts
+++ b/src/domains/appointment/components/AppointmentStatusBadge.spec.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { mountWithDeps } from '@/__tests__/helpers/mountWithDeps'
+import AppointmentStatusBadge from './AppointmentStatusBadge.vue'
+import type { AppointmentStatus } from '../types/appointment.types'
+
+const STUBS = {
+  Badge: { template: '<span data-testid="badge" :class="$attrs.class"><slot /></span>' },
+}
+
+describe('AppointmentStatusBadge', () => {
+  it.each([
+    ['scheduled', 'Scheduled'],
+    ['checked_in', 'Checked In'],
+    ['completed', 'Completed'],
+    ['cancelled', 'Cancelled'],
+    ['no_show', 'No Show'],
+  ] satisfies [AppointmentStatus, string][])('renders the %s label', (status, label) => {
+    const wrapper = mountWithDeps(AppointmentStatusBadge, {
+      props: { status },
+      global: { stubs: STUBS },
+    })
+
+    expect(wrapper.text()).toContain(label)
+  })
+})

--- a/src/domains/appointment/stores/appointmentStore.spec.ts
+++ b/src/domains/appointment/stores/appointmentStore.spec.ts
@@ -1,0 +1,319 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type {
+  AppointmentListResponse,
+  AppointmentResponse,
+  ClinicDoctor,
+} from '../types/appointment.types'
+import type { CalendarBlock, Slot } from '@/domains/schedule/types/schedule.types'
+
+interface MockAppointmentApi {
+  list: ReturnType<typeof vi.fn>
+  get: ReturnType<typeof vi.fn>
+  create: ReturnType<typeof vi.fn>
+  cancel: ReturnType<typeof vi.fn>
+  checkIn: ReturnType<typeof vi.fn>
+  noShow: ReturnType<typeof vi.fn>
+  getDoctors: ReturnType<typeof vi.fn>
+}
+
+interface MockScheduleApi {
+  getAvailability: ReturnType<typeof vi.fn>
+}
+
+function makeAppointment(overrides: Partial<AppointmentResponse> = {}): AppointmentResponse {
+  return {
+    id: 'appt-1',
+    clinic_id: 'clinic-1',
+    patient_id: 'patient-1',
+    patient_name: 'Juan Dela Cruz',
+    patient_avatar_url: null,
+    doctor_id: 'doctor-1',
+    doctor_name: 'Maria Santos',
+    doctor_avatar_url: null,
+    created_by: 'user-1',
+    status: 'scheduled',
+    scheduled_at: '2026-05-06T01:00:00.000Z',
+    duration: 30,
+    reason: 'Consultation',
+    cancellation_reason: null,
+    cancelled_by: null,
+    checked_in_at: null,
+    completed_at: null,
+    notes: null,
+    created_at: '2026-05-01T00:00:00.000Z',
+    updated_at: '2026-05-01T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+function makeDoctor(overrides: Partial<ClinicDoctor> = {}): ClinicDoctor {
+  return {
+    id: 'doctor-1',
+    name: 'Maria Santos',
+    email: 'doctor@example.com',
+    role: 'doctor',
+    avatar_url: null,
+    ...overrides,
+  }
+}
+
+function makeListResponse(data: AppointmentResponse[] = []): AppointmentListResponse {
+  return {
+    data,
+    meta: { pagination: { page: 1, per_page: 15, total: data.length, last_page: 1 } },
+  }
+}
+
+function makeSlot(overrides: Partial<Slot> = {}): Slot {
+  return {
+    start_at: '2026-05-06T01:00:00.000Z',
+    end_at: '2026-05-06T01:30:00.000Z',
+    is_available: true,
+    ...overrides,
+  } as Slot
+}
+
+function makeBlock(overrides: Partial<CalendarBlock> = {}): CalendarBlock {
+  return {
+    id: 'block-1',
+    doctor_id: 'doctor-1',
+    start_at: '2026-05-06T04:00:00.000Z',
+    end_at: '2026-05-06T05:00:00.000Z',
+    type: 'break',
+    reason: 'Lunch',
+    ...overrides,
+  } as CalendarBlock
+}
+
+function makeAppointmentApi(overrides: Partial<MockAppointmentApi> = {}): MockAppointmentApi {
+  return {
+    list: vi.fn().mockResolvedValue(makeListResponse()),
+    get: vi.fn().mockResolvedValue({ data: makeAppointment() }),
+    create: vi.fn().mockResolvedValue({ data: makeAppointment() }),
+    cancel: vi.fn().mockResolvedValue({ data: makeAppointment({ status: 'cancelled' }) }),
+    checkIn: vi.fn().mockResolvedValue({ data: { appointment: makeAppointment({ status: 'checked_in' }) } }),
+    noShow: vi.fn().mockResolvedValue({ data: makeAppointment({ status: 'no_show' }) }),
+    getDoctors: vi.fn().mockResolvedValue({ data: [makeDoctor()] }),
+    ...overrides,
+  }
+}
+
+function makeScheduleApi(overrides: Partial<MockScheduleApi> = {}): MockScheduleApi {
+  return {
+    getAvailability: vi.fn().mockResolvedValue({
+      data: { slots: [makeSlot()], blocks: [makeBlock()] },
+    }),
+    ...overrides,
+  }
+}
+
+async function loadStore(appointmentApi: MockAppointmentApi, scheduleApi: MockScheduleApi = makeScheduleApi()) {
+  vi.doMock('../api/appointmentApi', () => ({ appointmentApi }))
+  vi.doMock('@/domains/schedule/api/scheduleApi', () => ({ scheduleApi }))
+  return await import('./appointmentStore')
+}
+
+beforeEach(() => {
+  vi.resetModules()
+})
+
+afterEach(() => {
+  vi.doUnmock('../api/appointmentApi')
+  vi.doUnmock('@/domains/schedule/api/scheduleApi')
+})
+
+describe('appointmentStore - list fetching', () => {
+  it('populates appointments and pagination from the API response', async () => {
+    const appointmentApi = makeAppointmentApi({
+      list: vi.fn().mockResolvedValue({
+        data: [makeAppointment({ id: 'appt-A' })],
+        meta: { pagination: { page: 2, per_page: 25, total: 40, last_page: 2 } },
+      }),
+    })
+    const { useAppointmentStore } = await loadStore(appointmentApi)
+    const store = useAppointmentStore()
+
+    await store.fetchAppointments(2, 25, { status: 'scheduled', doctor_id: 'doctor-1' })
+
+    expect(appointmentApi.list).toHaveBeenCalledWith(2, 25, { status: 'scheduled', doctor_id: 'doctor-1' })
+    expect(store.appointments).toHaveLength(1)
+    expect(store.pagination).toEqual({ page: 2, per_page: 25, total: 40, last_page: 2 })
+    expect(store.isLoading).toBe(false)
+  })
+
+  it('clears isLoading when the list request fails', async () => {
+    const appointmentApi = makeAppointmentApi({
+      list: vi.fn().mockRejectedValue(new Error('network down')),
+    })
+    const { useAppointmentStore } = await loadStore(appointmentApi)
+    const store = useAppointmentStore()
+
+    await expect(store.fetchAppointments()).rejects.toThrow('network down')
+    expect(store.isLoading).toBe(false)
+  })
+
+  it('fetchAllForRange includes date range and optional status', async () => {
+    const appointmentApi = makeAppointmentApi({
+      list: vi.fn().mockResolvedValue(makeListResponse([makeAppointment({ id: 'appt-range' })])),
+    })
+    const { useAppointmentStore } = await loadStore(appointmentApi)
+    const store = useAppointmentStore()
+
+    const result = await store.fetchAllForRange('2026-05-01', '2026-05-31', 'checked_in')
+
+    expect(result[0]?.id).toBe('appt-range')
+    expect(appointmentApi.list).toHaveBeenCalledWith(1, 500, {
+      start_date: '2026-05-01',
+      end_date: '2026-05-31',
+      status: 'checked_in',
+    })
+  })
+})
+
+describe('appointmentStore - board data', () => {
+  it('loads doctors once and reuses cached doctors on later calls', async () => {
+    const appointmentApi = makeAppointmentApi()
+    const { useAppointmentStore } = await loadStore(appointmentApi)
+    const store = useAppointmentStore()
+
+    await store.fetchDoctors()
+    await store.fetchDoctors()
+
+    expect(appointmentApi.getDoctors).toHaveBeenCalledOnce()
+    expect(store.boardDoctors[0]?.id).toBe('doctor-1')
+  })
+
+  it('loads board appointments, visible doctors, availability, and de-duplicated blocks', async () => {
+    const doctorOne = makeDoctor({ id: 'doctor-1' })
+    const doctorTwo = makeDoctor({ id: 'doctor-2' })
+    const sameDay = makeAppointment({ id: 'appt-today', doctor_id: 'doctor-1', scheduled_at: '2026-05-06T01:00:00.000Z' })
+    const otherDay = makeAppointment({ id: 'appt-other', doctor_id: 'doctor-2', scheduled_at: '2026-05-07T01:00:00.000Z' })
+    const appointmentApi = makeAppointmentApi({
+      list: vi.fn().mockResolvedValue(makeListResponse([sameDay, otherDay])),
+      getDoctors: vi.fn().mockResolvedValue({ data: [doctorOne, doctorTwo] }),
+    })
+    const scheduleApi = makeScheduleApi({
+      getAvailability: vi.fn()
+        .mockResolvedValueOnce({ data: { slots: [makeSlot({ start_at: '2026-05-06T01:00:00.000Z' })], blocks: [makeBlock({ id: 'block-shared' })] } })
+        .mockResolvedValueOnce({ data: { slots: [makeSlot({ start_at: '2026-05-06T02:00:00.000Z' })], blocks: [makeBlock({ id: 'block-shared' })] } }),
+    })
+    const { useAppointmentStore } = await loadStore(appointmentApi, scheduleApi)
+    const store = useAppointmentStore()
+
+    await store.fetchBoardData({
+      date: '2026-05-06',
+      start: '2026-05-01',
+      end: '2026-05-31',
+      doctorFilter: 'all',
+      statusFilter: 'all',
+    })
+
+    expect(store.boardMonthAppointments.map((appointment) => appointment.id)).toEqual(['appt-today', 'appt-other'])
+    expect(store.boardAppointments.map((appointment) => appointment.id)).toEqual(['appt-today'])
+    expect(scheduleApi.getAvailability).toHaveBeenCalledTimes(2)
+    expect(store.boardAvailabilityByDoctor['doctor-1']).toHaveLength(1)
+    expect(store.boardAvailabilityByDoctor['doctor-2']).toHaveLength(1)
+    expect(store.boardCalendarBlocks).toHaveLength(1)
+    expect(store.boardError).toBeNull()
+    expect(store.isLoadingBoard).toBe(false)
+  })
+
+  it('sets boardError when the board list request fails', async () => {
+    const appointmentApi = makeAppointmentApi({
+      list: vi.fn().mockRejectedValue(new Error('boom')),
+    })
+    const { useAppointmentStore } = await loadStore(appointmentApi)
+    const store = useAppointmentStore()
+
+    await store.fetchBoardData({
+      date: '2026-05-06',
+      start: '2026-05-01',
+      end: '2026-05-31',
+      doctorFilter: 'all',
+      statusFilter: 'all',
+    })
+
+    expect(store.boardError).toBe('Failed to load appointment board.')
+    expect(store.isLoadingBoard).toBe(false)
+  })
+})
+
+describe('appointmentStore - mutations', () => {
+  it('fetchAppointment stores the current appointment', async () => {
+    const appointmentApi = makeAppointmentApi({
+      get: vi.fn().mockResolvedValue({ data: makeAppointment({ id: 'appt-current' }) }),
+    })
+    const { useAppointmentStore } = await loadStore(appointmentApi)
+    const store = useAppointmentStore()
+
+    await store.fetchAppointment('appt-current')
+
+    expect(store.current?.id).toBe('appt-current')
+    expect(store.isLoading).toBe(false)
+  })
+
+  it('createAppointment returns created data and clears isCreating', async () => {
+    const appointmentApi = makeAppointmentApi({
+      create: vi.fn().mockResolvedValue({ data: makeAppointment({ id: 'appt-created' }) }),
+    })
+    const { useAppointmentStore } = await loadStore(appointmentApi)
+    const store = useAppointmentStore()
+
+    const result = await store.createAppointment({
+      patient_id: 'patient-1',
+      doctor_id: 'doctor-1',
+      scheduled_at: '2026-05-06T01:00:00.000Z',
+    })
+
+    expect(result.id).toBe('appt-created')
+    expect(store.isCreating).toBe(false)
+  })
+
+  it('cancelAppointment updates the matching list item and current appointment', async () => {
+    const cancelled = makeAppointment({ id: 'appt-1', status: 'cancelled', cancellation_reason: 'Patient request' })
+    const appointmentApi = makeAppointmentApi({
+      cancel: vi.fn().mockResolvedValue({ data: cancelled }),
+    })
+    const { useAppointmentStore } = await loadStore(appointmentApi)
+    const store = useAppointmentStore()
+    store.appointments = [makeAppointment({ id: 'appt-1' }), makeAppointment({ id: 'appt-2' })]
+    store.current = makeAppointment({ id: 'appt-1' })
+
+    await store.cancelAppointment('appt-1', 'Patient request')
+
+    expect(appointmentApi.cancel).toHaveBeenCalledWith('appt-1', { reason: 'Patient request' })
+    expect(store.appointments[0]?.status).toBe('cancelled')
+    expect(store.appointments[1]?.id).toBe('appt-2')
+    expect(store.current?.status).toBe('cancelled')
+  })
+
+  it('checkInAppointment uses the nested appointment payload', async () => {
+    const appointmentApi = makeAppointmentApi({
+      checkIn: vi.fn().mockResolvedValue({ data: { appointment: makeAppointment({ id: 'appt-1', status: 'checked_in' }) } }),
+    })
+    const { useAppointmentStore } = await loadStore(appointmentApi)
+    const store = useAppointmentStore()
+    store.appointments = [makeAppointment({ id: 'appt-1' })]
+    store.current = makeAppointment({ id: 'appt-1' })
+
+    await store.checkInAppointment('appt-1')
+
+    expect(store.appointments[0]?.status).toBe('checked_in')
+    expect(store.current?.status).toBe('checked_in')
+  })
+
+  it('markNoShow updates the matching list item and current appointment', async () => {
+    const appointmentApi = makeAppointmentApi({
+      noShow: vi.fn().mockResolvedValue({ data: makeAppointment({ id: 'appt-1', status: 'no_show' }) }),
+    })
+    const { useAppointmentStore } = await loadStore(appointmentApi)
+    const store = useAppointmentStore()
+    store.appointments = [makeAppointment({ id: 'appt-1' })]
+    store.current = makeAppointment({ id: 'appt-1' })
+
+    await store.markNoShow('appt-1')
+
+    expect(store.appointments[0]?.status).toBe('no_show')
+    expect(store.current?.status).toBe('no_show')
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -43,6 +43,8 @@ export default defineConfig({
       include: [
         'src/components/layout/{GracePeriodBanner,TrialBanner}.vue',
         'src/components/shared/{FeatureGate,UpgradePrompt}.vue',
+        'src/domains/appointment/components/{AppointmentCard,AppointmentStatusBadge}.vue',
+        'src/domains/appointment/stores/**/*.ts',
         'src/domains/auth/components/{CredentialsForm,PasswordForm}.vue',
         'src/domains/auth/stores/**/*.ts',
         'src/domains/patient/components/EditPatientDialog.vue',
@@ -69,7 +71,7 @@ export default defineConfig({
         branches: 70,
         // Vue template handlers are counted as generated functions; raise this
         // phase-by-phase as more component interaction tests land.
-        functions: 64,
+        functions: 70,
         statements: 70,
       },
     },


### PR DESCRIPTION
## Summary

Extends the frontend coverage baseline into the appointment board slice.

## Changes

- Adds appointment store tests for list fetching, range fetching, doctor caching, board data loading, board errors, and appointment mutations.
- Adds component tests for `AppointmentCard` rendering/events and `AppointmentStatusBadge` status labels.
- Expands the Vitest coverage gate to include appointment store/card/status badge.
- Raises the global function coverage threshold from 64% to 70% after appointment coverage lifted the measured baseline.
- Makes authenticated Playwright specs skip cleanly when `E2E_EMAIL` and `E2E_PASSWORD` are not provided, instead of trying invalid fallback credentials.

## Validation

- `TEST_CMD="npx vitest run src/domains/appointment/stores/appointmentStore.spec.ts src/domains/appointment/components/AppointmentStatusBadge.spec.ts src/domains/appointment/components/AppointmentCard.spec.ts" docker compose -p clinicapp-fe-tests-p3 -f docker-compose.test.yml run --rm frontend-test`
  - Passed: 3 files, 21 tests.
- `TEST_CMD="npm run test:coverage" docker compose -p clinicapp-fe-tests-p3 -f docker-compose.test.yml run --rm frontend-test`
  - Passed: 32 files, 378 tests passed, 1 existing skipped test.
  - Phase 3 coverage gate: lines/statements 96.13%, branches 85.64%, functions 70.83%.
- `TEST_CMD="npx playwright test e2e/appointments-board.spec.ts" docker compose -p clinicapp-fe-tests-p3 -f docker-compose.test.yml run --rm frontend-feature-test`
  - Passed by clean skip: 2 skipped because local `E2E_EMAIL` / `E2E_PASSWORD` were not set.
- `TEST_CMD="npm run build" docker compose -p clinicapp-fe-tests-p3 -f docker-compose.test.yml run --rm frontend-test`
  - Passed. Existing slim-container `git` warning and bundle-size warnings remain.
