### PR TITLE
Add phase 4 schedule coverage

### DIFF
--- a/src/domains/schedule/components/BreakEditor.spec.ts
+++ b/src/domains/schedule/components/BreakEditor.spec.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import { mountWithDeps } from '@/__tests__/helpers/mountWithDeps'
+import BreakEditor from './BreakEditor.vue'
+import type { Break } from '../types/schedule.types'
+
+const STUBS = {
+  Button: {
+    emits: ['click'],
+    template: '<button type="button" @click="$emit(`click`, $event)"><slot /></button>',
+  },
+  Input: {
+    props: ['modelValue', 'type', 'placeholder'],
+    emits: ['update:modelValue'],
+    template: '<input :type="type" :placeholder="placeholder" :value="modelValue" @input="$emit(`update:modelValue`, ($event.target).value)" />',
+  },
+  Label: { template: '<label><slot /></label>' },
+}
+
+function mountEditor(breaks: Break[] = []) {
+  return mountWithDeps(BreakEditor, {
+    props: { breaks, dayStart: '09:00', dayEnd: '17:00' },
+    global: { stubs: STUBS },
+  })
+}
+
+describe('BreakEditor', () => {
+  it('adds a default break at the day start', async () => {
+    const wrapper = mountEditor()
+
+    await wrapper.find('button').trigger('click')
+
+    expect(wrapper.emitted('update:breaks')).toEqual([[[
+      { label: 'Break', start_time: '09:00', end_time: '09:00' },
+    ]]])
+  })
+
+  it('updates a break field without mutating sibling breaks', async () => {
+    const wrapper = mountEditor([
+      { label: 'Lunch', start_time: '12:00', end_time: '13:00' },
+      { label: 'Admin', start_time: '15:00', end_time: '15:30' },
+    ])
+
+    await wrapper.find('input[placeholder="e.g. Lunch"]').setValue('Meal')
+
+    expect(wrapper.emitted('update:breaks')?.[0]?.[0]).toEqual([
+      { label: 'Meal', start_time: '12:00', end_time: '13:00' },
+      { label: 'Admin', start_time: '15:00', end_time: '15:30' },
+    ])
+  })
+
+  it('removes the selected break', async () => {
+    const wrapper = mountEditor([
+      { label: 'Lunch', start_time: '12:00', end_time: '13:00' },
+      { label: 'Admin', start_time: '15:00', end_time: '15:30' },
+    ])
+
+    await wrapper.find('button[aria-label="Remove break"]').trigger('click')
+
+    expect(wrapper.emitted('update:breaks')?.[0]?.[0]).toEqual([
+      { label: 'Admin', start_time: '15:00', end_time: '15:30' },
+    ])
+  })
+})

--- a/src/domains/schedule/components/DayScheduleRow.spec.ts
+++ b/src/domains/schedule/components/DayScheduleRow.spec.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+import { mountWithDeps } from '@/__tests__/helpers/mountWithDeps'
+import DayScheduleRow from './DayScheduleRow.vue'
+import type { DaySchedule } from '../types/schedule.types'
+
+const STUBS = {
+  BreakEditor: {
+    props: ['breaks', 'dayStart', 'dayEnd'],
+    emits: ['update:breaks'],
+    template: '<button type="button" data-testid="break-editor" @click="$emit(`update:breaks`, [{ label: `Lunch`, start_time: `12:00`, end_time: `13:00` }])">Break editor</button>',
+  },
+  Checkbox: {
+    props: ['modelValue', 'id'],
+    emits: ['update:modelValue'],
+    template: '<input :id="id" type="checkbox" :checked="modelValue" @change="$emit(`update:modelValue`, ($event.target).checked)" />',
+  },
+  Input: {
+    props: ['modelValue', 'type'],
+    emits: ['update:modelValue'],
+    template: '<input :type="type" :value="modelValue" @input="$emit(`update:modelValue`, ($event.target).value)" />',
+  },
+  Label: { template: '<label><slot /></label>' },
+}
+
+function makeDay(overrides: Partial<DaySchedule> = {}): DaySchedule {
+  return {
+    day: 1,
+    enabled: true,
+    start_time: '09:00',
+    end_time: '17:00',
+    breaks: [],
+    ...overrides,
+  }
+}
+
+function mountRow(day = makeDay()) {
+  return mountWithDeps(DayScheduleRow, {
+    props: { day },
+    global: { stubs: STUBS },
+  })
+}
+
+describe('DayScheduleRow', () => {
+  it('renders the day name and enabled time inputs', () => {
+    const wrapper = mountRow()
+
+    expect(wrapper.text()).toContain('Monday')
+    expect(wrapper.findAll('input[type="time"]')).toHaveLength(2)
+    expect(wrapper.text()).not.toContain('Day off')
+  })
+
+  it('renders day off state when disabled', () => {
+    const wrapper = mountRow(makeDay({ enabled: false }))
+
+    expect(wrapper.text()).toContain('Day off')
+    expect(wrapper.findAll('input[type="time"]')).toHaveLength(0)
+  })
+
+  it('emits enabled changes', async () => {
+    const wrapper = mountRow(makeDay({ enabled: false }))
+
+    await wrapper.find('input[type="checkbox"]').setValue(true)
+
+    expect(wrapper.emitted('update:day')?.[0]?.[0]).toEqual(makeDay({ enabled: true }))
+  })
+
+  it('emits time field changes without dropping other fields', async () => {
+    const wrapper = mountRow()
+
+    await wrapper.findAll('input[type="time"]')[0]?.setValue('08:30')
+
+    expect(wrapper.emitted('update:day')?.[0]?.[0]).toEqual(makeDay({ start_time: '08:30' }))
+  })
+
+  it('emits break changes from the nested editor', async () => {
+    const wrapper = mountRow()
+
+    await wrapper.find('[data-testid="break-editor"]').trigger('click')
+
+    expect(wrapper.emitted('update:day')?.[0]?.[0]).toEqual(makeDay({
+      breaks: [{ label: 'Lunch', start_time: '12:00', end_time: '13:00' }],
+    }))
+  })
+})

--- a/src/domains/schedule/stores/scheduleStore.spec.ts
+++ b/src/domains/schedule/stores/scheduleStore.spec.ts
@@ -1,0 +1,286 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AppointmentResponse } from '@/domains/appointment/types/appointment.types'
+import type {
+  AvailabilityResponse,
+  CalendarBlock,
+  Slot,
+  WorkingSchedule,
+} from '../types/schedule.types'
+
+class FakeHttpError extends Error {
+  readonly status: number
+
+  constructor(status: number, message: string) {
+    super(message)
+    this.status = status
+  }
+}
+
+interface MockScheduleApi {
+  getSchedule: ReturnType<typeof vi.fn>
+  upsertSchedule: ReturnType<typeof vi.fn>
+  createBlock: ReturnType<typeof vi.fn>
+  updateBlock: ReturnType<typeof vi.fn>
+  getAvailability: ReturnType<typeof vi.fn>
+  listAllBlocks: ReturnType<typeof vi.fn>
+}
+
+interface MockAppointmentApi {
+  list: ReturnType<typeof vi.fn>
+}
+
+function makeSchedule(overrides: Partial<WorkingSchedule> = {}): WorkingSchedule {
+  return {
+    id: 'schedule-1',
+    clinic_id: 'clinic-1',
+    user_id: 'doctor-1',
+    timezone: 'Asia/Manila',
+    slot_duration: 30,
+    days: [
+      { day: 1, enabled: true, start_time: '09:00', end_time: '17:00', breaks: [] },
+    ],
+    created_at: '2026-05-01T00:00:00.000Z',
+    updated_at: '2026-05-01T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+function makeAppointment(overrides: Partial<AppointmentResponse> = {}): AppointmentResponse {
+  return {
+    id: 'appt-1',
+    clinic_id: 'clinic-1',
+    patient_id: 'patient-1',
+    patient_name: 'Patient One',
+    patient_avatar_url: null,
+    doctor_id: 'doctor-1',
+    doctor_name: 'Doctor One',
+    doctor_avatar_url: null,
+    created_by: 'user-1',
+    status: 'scheduled',
+    scheduled_at: '2026-05-06T01:00:00.000Z',
+    duration: 30,
+    reason: null,
+    cancellation_reason: null,
+    cancelled_by: null,
+    checked_in_at: null,
+    completed_at: null,
+    notes: null,
+    created_at: '2026-05-01T00:00:00.000Z',
+    updated_at: '2026-05-01T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+function makeSlot(overrides: Partial<Slot> = {}): Slot {
+  return {
+    start: '2026-05-06T01:00:00.000Z',
+    end: '2026-05-06T01:30:00.000Z',
+    available: true,
+    ...overrides,
+  }
+}
+
+function makeBlock(overrides: Partial<CalendarBlock> = {}): CalendarBlock {
+  return {
+    id: 'block-1',
+    clinic_id: 'clinic-1',
+    user_id: 'doctor-1',
+    user_name: 'Doctor One',
+    user_avatar_url: null,
+    title: 'Clinic meeting',
+    type: 'meeting',
+    all_day: false,
+    recurring: false,
+    start: '2026-05-06T04:00:00.000Z',
+    end: '2026-05-06T05:00:00.000Z',
+    notes: null,
+    created_at: '2026-05-01T00:00:00.000Z',
+    updated_at: '2026-05-01T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+function makeScheduleApi(overrides: Partial<MockScheduleApi> = {}): MockScheduleApi {
+  const availability: AvailabilityResponse = {
+    data: {
+      slots: [makeSlot()],
+      blocks: [makeBlock()],
+      schedule: makeSchedule(),
+    },
+  }
+
+  return {
+    getSchedule: vi.fn().mockResolvedValue({ data: makeSchedule() }),
+    upsertSchedule: vi.fn().mockResolvedValue({ data: makeSchedule({ slot_duration: 15 }) }),
+    createBlock: vi.fn().mockResolvedValue({ data: makeBlock() }),
+    updateBlock: vi.fn().mockResolvedValue({ data: makeBlock({ title: 'Updated' }) }),
+    getAvailability: vi.fn().mockResolvedValue(availability),
+    listAllBlocks: vi.fn().mockResolvedValue({ data: [makeBlock({ id: 'upcoming-1' })] }),
+    ...overrides,
+  }
+}
+
+function makeAppointmentApi(overrides: Partial<MockAppointmentApi> = {}): MockAppointmentApi {
+  return {
+    list: vi.fn().mockResolvedValue({
+      data: [makeAppointment(), makeAppointment({ id: 'appt-other-day', scheduled_at: '2026-05-07T01:00:00.000Z' })],
+      meta: { pagination: { page: 1, per_page: 300, total: 2, last_page: 1 } },
+    }),
+    ...overrides,
+  }
+}
+
+async function loadStore(scheduleApi: MockScheduleApi, appointmentApi: MockAppointmentApi = makeAppointmentApi()) {
+  vi.doMock('@/lib/http', () => ({ HttpError: FakeHttpError }))
+  vi.doMock('../api/scheduleApi', () => ({ scheduleApi }))
+  vi.doMock('@/domains/appointment/api/appointmentApi', () => ({ appointmentApi }))
+  return await import('./scheduleStore')
+}
+
+beforeEach(() => {
+  vi.resetModules()
+})
+
+afterEach(() => {
+  vi.doUnmock('@/lib/http')
+  vi.doUnmock('../api/scheduleApi')
+  vi.doUnmock('@/domains/appointment/api/appointmentApi')
+})
+
+describe('scheduleStore - schedule lifecycle', () => {
+  it('fetchSchedule stores the schedule response', async () => {
+    const scheduleApi = makeScheduleApi({
+      getSchedule: vi.fn().mockResolvedValue({ data: makeSchedule({ id: 'schedule-77' }) }),
+    })
+    const { useScheduleStore } = await loadStore(scheduleApi)
+    const store = useScheduleStore()
+
+    await store.fetchSchedule('doctor-1')
+
+    expect(scheduleApi.getSchedule).toHaveBeenCalledWith('doctor-1')
+    expect(store.schedule?.id).toBe('schedule-77')
+    expect(store.isLoadingSchedule).toBe(false)
+  })
+
+  it('fetchSchedule treats 404 as an empty schedule', async () => {
+    const scheduleApi = makeScheduleApi({
+      getSchedule: vi.fn().mockRejectedValue(new FakeHttpError(404, 'not found')),
+    })
+    const { useScheduleStore } = await loadStore(scheduleApi)
+    const store = useScheduleStore()
+    store.schedule = makeSchedule()
+
+    await store.fetchSchedule('doctor-1')
+
+    expect(store.schedule).toBeNull()
+    expect(store.isLoadingSchedule).toBe(false)
+  })
+
+  it('fetchSchedule rethrows non-404 errors and still clears loading', async () => {
+    const scheduleApi = makeScheduleApi({
+      getSchedule: vi.fn().mockRejectedValue(new FakeHttpError(500, 'server error')),
+    })
+    const { useScheduleStore } = await loadStore(scheduleApi)
+    const store = useScheduleStore()
+
+    await expect(store.fetchSchedule('doctor-1')).rejects.toThrow('server error')
+    expect(store.isLoadingSchedule).toBe(false)
+  })
+
+  it('saveSchedule updates the current schedule and clears saving state', async () => {
+    const saved = makeSchedule({ slot_duration: 15 })
+    const scheduleApi = makeScheduleApi({
+      upsertSchedule: vi.fn().mockResolvedValue({ data: saved }),
+    })
+    const { useScheduleStore } = await loadStore(scheduleApi)
+    const store = useScheduleStore()
+
+    await store.saveSchedule('doctor-1', {
+      timezone: 'Asia/Manila',
+      slot_duration: 15,
+      days: saved.days,
+    })
+
+    expect(store.schedule?.slot_duration).toBe(15)
+    expect(store.isSavingSchedule).toBe(false)
+  })
+
+  it('createBlock and updateBlock delegate to the API', async () => {
+    const scheduleApi = makeScheduleApi()
+    const { useScheduleStore } = await loadStore(scheduleApi)
+    const store = useScheduleStore()
+
+    await store.createBlock({
+      user_id: 'doctor-1',
+      title: 'Out',
+      type: 'unavailable',
+      all_day: false,
+      recurring: false,
+      start: '2026-05-06T01:00:00.000Z',
+      end: '2026-05-06T02:00:00.000Z',
+    })
+    await store.updateBlock('block-1', { title: 'Updated' })
+
+    expect(scheduleApi.createBlock).toHaveBeenCalledOnce()
+    expect(scheduleApi.updateBlock).toHaveBeenCalledWith('block-1', { title: 'Updated' })
+  })
+})
+
+describe('scheduleStore - studio data', () => {
+  it('loads month appointments, selected-day appointments, slots, day blocks, and upcoming blocks', async () => {
+    const scheduleApi = makeScheduleApi({
+      getAvailability: vi.fn().mockResolvedValue({
+        data: {
+          slots: [makeSlot({ start: '2026-05-06T02:00:00.000Z' })],
+          blocks: [makeBlock({ id: 'day-block' })],
+          schedule: makeSchedule(),
+        },
+      }),
+      listAllBlocks: vi.fn().mockResolvedValue({ data: [makeBlock({ id: 'future-block' })] }),
+    })
+    const appointmentApi = makeAppointmentApi()
+    const { useScheduleStore } = await loadStore(scheduleApi, appointmentApi)
+    const store = useScheduleStore()
+
+    await store.fetchStudioData({
+      userId: 'doctor-1',
+      date: '2026-05-06',
+      start: '2026-05-01',
+      end: '2026-05-31',
+      blockRangeEnd: '2026-06-30',
+    })
+
+    expect(appointmentApi.list).toHaveBeenCalledWith(1, 300, {
+      doctor_id: 'doctor-1',
+      start_date: '2026-05-01',
+      end_date: '2026-05-31',
+    })
+    expect(store.studioMonthAppointments.map((appointment) => appointment.id)).toEqual(['appt-1', 'appt-other-day'])
+    expect(store.studioAppointments.map((appointment) => appointment.id)).toEqual(['appt-1'])
+    expect(store.studioSlots[0]?.start).toBe('2026-05-06T02:00:00.000Z')
+    expect(store.studioDayBlocks[0]?.id).toBe('day-block')
+    expect(store.studioUpcomingBlocks[0]?.id).toBe('future-block')
+    expect(store.studioError).toBeNull()
+    expect(store.isLoadingStudio).toBe(false)
+  })
+
+  it('sets studioError when studio loading fails', async () => {
+    const scheduleApi = makeScheduleApi()
+    const appointmentApi = makeAppointmentApi({
+      list: vi.fn().mockRejectedValue(new Error('boom')),
+    })
+    const { useScheduleStore } = await loadStore(scheduleApi, appointmentApi)
+    const store = useScheduleStore()
+
+    await store.fetchStudioData({
+      userId: 'doctor-1',
+      date: '2026-05-06',
+      start: '2026-05-01',
+      end: '2026-05-31',
+      blockRangeEnd: '2026-06-30',
+    })
+
+    expect(store.studioError).toBe('Failed to load schedule view.')
+    expect(store.isLoadingStudio).toBe(false)
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -50,6 +50,8 @@ export default defineConfig({
         'src/domains/patient/components/EditPatientDialog.vue',
         'src/domains/patient/composables/usePatientSync.ts',
         'src/domains/patient/utils/profileCompleteness.ts',
+        'src/domains/schedule/components/{BreakEditor,DayScheduleRow}.vue',
+        'src/domains/schedule/stores/**/*.ts',
         'src/lib/validationRules.ts',
       ],
       // Don't fail builds on tier-0 / infra files that exist mostly to
@@ -71,7 +73,7 @@ export default defineConfig({
         branches: 70,
         // Vue template handlers are counted as generated functions; raise this
         // phase-by-phase as more component interaction tests land.
-        functions: 70,
+        functions: 73,
         statements: 70,
       },
     },


### PR DESCRIPTION
## Summary

Extends the frontend coverage baseline into the schedule availability slice.

## Changes

- Adds schedule store tests for schedule fetch/save, 404 handling, calendar block delegation, studio data loading, and studio error handling.
- Adds component tests for `BreakEditor` and `DayScheduleRow`.
- Expands the Vitest coverage gate to include schedule store and schedule edit controls.
- Raises the global function coverage threshold from 70% to 73%.

## Validation

- `TEST_CMD="npx vitest run src/domains/schedule/stores/scheduleStore.spec.ts src/domains/schedule/components/BreakEditor.spec.ts src/domains/schedule/components/DayScheduleRow.spec.ts" docker compose -p clinicapp-fe-tests-p4 -f docker-compose.test.yml run --rm frontend-test`
  - Passed: 3 files, 15 tests.
- `TEST_CMD="npm run test:coverage" docker compose -p clinicapp-fe-tests-p4 -f docker-compose.test.yml run --rm frontend-test`
  - Passed: 35 files, 393 tests passed, 1 existing skipped test.
  - Phase 4 coverage gate: lines/statements 96.72%, branches 86.37%, functions 73.62%.
- `TEST_CMD="npx playwright test e2e/dental-fee-schedule.spec.ts" docker compose -p clinicapp-fe-tests-p4 -f docker-compose.test.yml run --rm frontend-feature-test`
  - Clean skipped: 3 tests skipped because local E2E credentials were not set.
- `TEST_CMD="npm run build" docker compose -p clinicapp-fe-tests-p4 -f docker-compose.test.yml run --rm frontend-test`
  - Passed. Existing slim-container git warning and bundle-size warnings remain.