### PR TITLE
Add phase 5 queue coverage

### DIFF
--- a/src/domains/queue/components/QueueCard.spec.ts
+++ b/src/domains/queue/components/QueueCard.spec.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mountWithDeps } from '@/__tests__/helpers/mountWithDeps'
+import QueueCard from './QueueCard.vue'
+import type { QueueVisitResponse } from '../types/queue.types'
+
+const pushMock = vi.fn()
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: pushMock }),
+}))
+
+const STUBS = {
+  Badge: { template: '<span><slot /></span>' },
+  Button: {
+    emits: ['click'],
+    template: '<button type="button" @click="$emit(`click`, $event)"><slot /></button>',
+  },
+  PatientAvatar: { template: '<span data-testid="avatar" />' },
+  QueueStatusBadge: {
+    props: ['status'],
+    template: '<span data-testid="status">{{ status }}</span>',
+  },
+}
+
+function makeVisit(overrides: Partial<QueueVisitResponse> = {}): QueueVisitResponse {
+  return {
+    id: 'visit-1',
+    clinic_id: 'clinic-1',
+    patient_id: 'patient-1',
+    patient_name: 'Juan Dela Cruz',
+    patient_sex: 'male',
+    patient_avatar_url: null,
+    doctor_id: 'doctor-1',
+    doctor_name: 'Maria Santos',
+    appointment_id: null,
+    encounter_id: 'encounter-1',
+    status: 'waiting',
+    type: 'walk_in',
+    priority: 0,
+    position: 3,
+    reason: 'Follow-up',
+    checked_in_at: '2026-05-06T01:00:00.000Z',
+    called_at: null,
+    completed_at: null,
+    notes: null,
+    created_at: '2026-05-06T01:00:00.000Z',
+    updated_at: '2026-05-06T01:00:00.000Z',
+    ...overrides,
+  }
+}
+
+function mountCard(visit = makeVisit(), props: Record<string, unknown> = {}) {
+  return mountWithDeps(QueueCard, {
+    props: {
+      visit,
+      canManage: true,
+      canCall: true,
+      currentUserId: 'doctor-1',
+      ...props,
+    },
+    global: { stubs: STUBS },
+  })
+}
+
+describe('QueueCard', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-06T01:45:00.000Z'))
+    pushMock.mockClear()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('renders patient, position, doctor, reason, type, status, and wait time', () => {
+    const wrapper = mountCard()
+
+    expect(wrapper.text()).toContain('#3')
+    expect(wrapper.text()).toContain('Juan Dela Cruz')
+    expect(wrapper.text()).toContain('Dr. Maria Santos')
+    expect(wrapper.text()).toContain('Follow-up')
+    expect(wrapper.text()).toContain('Walk-in')
+    expect(wrapper.text()).toContain('waiting')
+    expect(wrapper.text()).toContain('45m')
+  })
+
+  it('shows carryover detail for an active visit from a previous day', () => {
+    const wrapper = mountCard(makeVisit({ checked_in_at: '2026-05-05T23:00:00.000Z' }))
+
+    expect(wrapper.text()).toContain('From May 5')
+    expect(wrapper.classes()).toContain('border-amber-300')
+  })
+
+  it('emits waiting actions when the user can manage the queue', async () => {
+    const wrapper = mountCard()
+
+    await wrapper.findAll('button').find((button) => button.text().includes('Call'))?.trigger('click')
+    await wrapper.findAll('button').find((button) => !button.text().trim())?.trigger('click')
+
+    expect(wrapper.emitted('call')).toEqual([['visit-1']])
+    expect(wrapper.emitted('cancel')).toEqual([['visit-1']])
+  })
+
+  it('emits complete for an in-progress visit assigned to the current doctor', async () => {
+    const wrapper = mountCard(makeVisit({ status: 'in_progress' }), { canManage: false, canCall: true })
+
+    await wrapper.findAll('button').find((button) => button.text().includes('Complete'))?.trigger('click')
+
+    expect(wrapper.emitted('complete')).toEqual([['visit-1']])
+    expect(wrapper.text()).not.toContain('Call')
+  })
+
+  it('hides action buttons when the user cannot act on the visit', () => {
+    const wrapper = mountCard(makeVisit({ doctor_id: 'doctor-2' }), { canManage: false, canCall: true })
+
+    expect(wrapper.text()).not.toContain('Call')
+    expect(wrapper.text()).not.toContain('Complete')
+  })
+
+  it('opens the linked consultation when present', async () => {
+    const wrapper = mountCard()
+
+    await wrapper.findAll('button').find((button) => button.text().includes('Consultation'))?.trigger('click')
+
+    expect(pushMock).toHaveBeenCalledWith({
+      name: 'encounter-detail',
+      params: {
+        patientId: 'patient-1',
+        id: 'encounter-1',
+      },
+    })
+  })
+})

--- a/src/domains/queue/components/QueueStatusBadge.spec.ts
+++ b/src/domains/queue/components/QueueStatusBadge.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { mountWithDeps } from '@/__tests__/helpers/mountWithDeps'
+import QueueStatusBadge from './QueueStatusBadge.vue'
+import type { QueueVisitStatus } from '../types/queue.types'
+
+const STUBS = {
+  Badge: {
+    template: '<span v-bind="$attrs"><slot /></span>',
+  },
+}
+
+function mountBadge(status: QueueVisitStatus) {
+  return mountWithDeps(QueueStatusBadge, {
+    props: { status },
+    global: { stubs: STUBS },
+  })
+}
+
+describe('QueueStatusBadge', () => {
+  it.each([
+    ['waiting', 'Waiting', 'amber'],
+    ['in_progress', 'In Progress', 'blue'],
+    ['completed', 'Completed', 'green'],
+    ['cancelled', 'Cancelled', 'gray'],
+  ] as const)('renders %s status styling', (status, label, colorClass) => {
+    const wrapper = mountBadge(status)
+
+    expect(wrapper.text()).toBe(label)
+    expect(wrapper.find('span').attributes('class')).toContain(colorClass)
+  })
+})

--- a/src/domains/queue/stores/queueStore.spec.ts
+++ b/src/domains/queue/stores/queueStore.spec.ts
@@ -1,0 +1,157 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { CreateWalkInPayload, QueueVisitResponse } from '../types/queue.types'
+
+interface MockQueueApi {
+  list: ReturnType<typeof vi.fn>
+  walkIn: ReturnType<typeof vi.fn>
+  call: ReturnType<typeof vi.fn>
+  complete: ReturnType<typeof vi.fn>
+  cancel: ReturnType<typeof vi.fn>
+}
+
+function makeVisit(overrides: Partial<QueueVisitResponse> = {}): QueueVisitResponse {
+  return {
+    id: 'visit-1',
+    clinic_id: 'clinic-1',
+    patient_id: 'patient-1',
+    patient_name: 'Juan Dela Cruz',
+    patient_sex: 'male',
+    patient_avatar_url: null,
+    doctor_id: 'doctor-1',
+    doctor_name: 'Maria Santos',
+    appointment_id: null,
+    encounter_id: null,
+    status: 'waiting',
+    type: 'walk_in',
+    priority: 0,
+    position: 1,
+    reason: 'Consultation',
+    checked_in_at: '2026-05-06T01:00:00.000Z',
+    called_at: null,
+    completed_at: null,
+    notes: null,
+    created_at: '2026-05-06T01:00:00.000Z',
+    updated_at: '2026-05-06T01:00:00.000Z',
+    ...overrides,
+  }
+}
+
+function makeQueueApi(overrides: Partial<MockQueueApi> = {}): MockQueueApi {
+  return {
+    list: vi.fn().mockResolvedValue({ data: [makeVisit()] }),
+    walkIn: vi.fn().mockResolvedValue({ data: makeVisit({ id: 'walk-in-1' }) }),
+    call: vi.fn().mockResolvedValue({ data: makeVisit({ status: 'in_progress' }) }),
+    complete: vi.fn().mockResolvedValue({ data: makeVisit({ status: 'completed' }) }),
+    cancel: vi.fn().mockResolvedValue({ data: makeVisit({ status: 'cancelled' }) }),
+    ...overrides,
+  }
+}
+
+async function loadStore(queueApi: MockQueueApi) {
+  vi.doMock('../api/queueApi', () => ({ queueApi }))
+  return await import('./queueStore')
+}
+
+beforeEach(() => {
+  vi.resetModules()
+})
+
+afterEach(() => {
+  vi.doUnmock('../api/queueApi')
+  vi.useRealTimers()
+})
+
+describe('queueStore - fetching and mutations', () => {
+  it('fetchQueue stores visits and remembers filters', async () => {
+    const queueApi = makeQueueApi({
+      list: vi.fn().mockResolvedValue({ data: [makeVisit({ id: 'visit-filtered' })] }),
+    })
+    const { useQueueStore } = await loadStore(queueApi)
+    const store = useQueueStore()
+
+    await store.fetchQueue({ doctor_id: 'doctor-1', status: 'waiting' })
+    await store.fetchQueue()
+
+    expect(queueApi.list).toHaveBeenNthCalledWith(1, { doctor_id: 'doctor-1', status: 'waiting' })
+    expect(queueApi.list).toHaveBeenNthCalledWith(2, { doctor_id: 'doctor-1', status: 'waiting' })
+    expect(store.visits[0]?.id).toBe('visit-filtered')
+    expect(store.isLoading).toBe(false)
+  })
+
+  it('clears isLoading when fetchQueue fails', async () => {
+    const queueApi = makeQueueApi({
+      list: vi.fn().mockRejectedValue(new Error('network down')),
+    })
+    const { useQueueStore } = await loadStore(queueApi)
+    const store = useQueueStore()
+
+    await expect(store.fetchQueue()).rejects.toThrow('network down')
+
+    expect(store.isLoading).toBe(false)
+  })
+
+  it('createWalkIn posts the payload, refreshes queue, and clears creating state', async () => {
+    const queueApi = makeQueueApi()
+    const { useQueueStore } = await loadStore(queueApi)
+    const store = useQueueStore()
+    const payload: CreateWalkInPayload = {
+      patient_id: 'patient-1',
+      doctor_id: 'doctor-1',
+      reason: 'Fever',
+      notes: 'First visit',
+    }
+
+    const result = await store.createWalkIn(payload)
+
+    expect(queueApi.walkIn).toHaveBeenCalledWith(payload)
+    expect(queueApi.list).toHaveBeenCalledOnce()
+    expect(result.id).toBe('walk-in-1')
+    expect(store.isCreating).toBe(false)
+  })
+
+  it('callPatient, completeVisit, and cancelVisit refresh queue after action', async () => {
+    const queueApi = makeQueueApi()
+    const { useQueueStore } = await loadStore(queueApi)
+    const store = useQueueStore()
+
+    await store.callPatient('visit-1')
+    await store.completeVisit('visit-1')
+    await store.cancelVisit('visit-1')
+
+    expect(queueApi.call).toHaveBeenCalledWith('visit-1')
+    expect(queueApi.complete).toHaveBeenCalledWith('visit-1')
+    expect(queueApi.cancel).toHaveBeenCalledWith('visit-1')
+    expect(queueApi.list).toHaveBeenCalledTimes(3)
+  })
+})
+
+describe('queueStore - polling and realtime', () => {
+  it('polls with the active filters and can stop polling', async () => {
+    vi.useFakeTimers()
+    const queueApi = makeQueueApi()
+    const { useQueueStore } = await loadStore(queueApi)
+    const store = useQueueStore()
+
+    store.startPolling(1000, { status: 'waiting' })
+    await vi.advanceTimersByTimeAsync(1000)
+    store.stopPolling()
+    await vi.advanceTimersByTimeAsync(1000)
+
+    expect(queueApi.list).toHaveBeenCalledOnce()
+    expect(queueApi.list).toHaveBeenCalledWith({ status: 'waiting' })
+  })
+
+  it('adds or replaces visits from realtime events', async () => {
+    const queueApi = makeQueueApi()
+    const { useQueueStore } = await loadStore(queueApi)
+    const store = useQueueStore()
+
+    store.handleRealtimeEvent({ type: 'queue.visit.created', data: makeVisit({ id: 'visit-1' }) })
+    store.handleRealtimeEvent({ type: 'queue.visit.created', data: makeVisit({ id: 'visit-1', position: 2 }) })
+    store.handleRealtimeEvent({ type: 'queue.visit.called', data: makeVisit({ id: 'visit-2', status: 'in_progress' }) })
+
+    expect(store.visits).toHaveLength(2)
+    expect(store.visits[0]?.position).toBe(2)
+    expect(store.visits[1]?.status).toBe('in_progress')
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -50,6 +50,8 @@ export default defineConfig({
         'src/domains/patient/components/EditPatientDialog.vue',
         'src/domains/patient/composables/usePatientSync.ts',
         'src/domains/patient/utils/profileCompleteness.ts',
+        'src/domains/queue/components/{QueueCard,QueueStatusBadge}.vue',
+        'src/domains/queue/stores/**/*.ts',
         'src/domains/schedule/components/{BreakEditor,DayScheduleRow}.vue',
         'src/domains/schedule/stores/**/*.ts',
         'src/lib/validationRules.ts',
@@ -73,7 +75,7 @@ export default defineConfig({
         branches: 70,
         // Vue template handlers are counted as generated functions; raise this
         // phase-by-phase as more component interaction tests land.
-        functions: 73,
+        functions: 76,
         statements: 70,
       },
     },


### PR DESCRIPTION
## Summary

Extends the frontend coverage baseline into the queue workflow slice.

## Changes

- Adds queue store tests for fetching, retained filters, walk-in creation, visit actions, polling, and realtime visit updates.
- Adds component tests for `QueueStatusBadge` labels/styling and `QueueCard` rendering, permissions, action emits, carryover display, and consultation navigation.
- Expands the Vitest coverage gate to include queue store and queue card/status components.
- Raises the global function coverage threshold from 73% to 76%.

## Validation

- `TEST_CMD="npx vitest run src/domains/queue/stores/queueStore.spec.ts src/domains/queue/components/QueueStatusBadge.spec.ts src/domains/queue/components/QueueCard.spec.ts" docker compose -p clinicapp-fe-tests-p5 -f docker-compose.test.yml run --rm frontend-test`
  - Passed: 3 files, 16 tests.
- `TEST_CMD="npm run test:coverage" docker compose -p clinicapp-fe-tests-p5 -f docker-compose.test.yml run --rm frontend-test`
  - Passed: 38 files, 409 tests passed, 1 existing skipped test.
  - Phase 5 coverage gate: lines/statements 97.06%, branches 86.04%, functions 76.69%.
- `TEST_CMD="npx playwright test e2e/queue-consultation.spec.ts" docker compose -p clinicapp-fe-tests-p5 -f docker-compose.test.yml run --rm frontend-feature-test`
  - Clean skipped: 3 tests skipped because local E2E credentials were not set.
- `TEST_CMD="npm run build" docker compose -p clinicapp-fe-tests-p5 -f docker-compose.test.yml run --rm frontend-test`
  - Passed. Existing slim-container git warning and bundle-size warnings remain.