### PR TITLE
Add phase 6 consultation fee discount coverage

### DIFF
--- a/src/domains/consultation/composables/useFeeDiscount.spec.ts
+++ b/src/domains/consultation/composables/useFeeDiscount.spec.ts
@@ -1,0 +1,157 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ConsultationResponse } from '../types/consultation.types'
+
+interface MockEncounterApi {
+  saveFeeDiscount: ReturnType<typeof vi.fn>
+}
+
+function makeConsultation(overrides: Partial<ConsultationResponse> = {}): ConsultationResponse {
+  return {
+    id: 'encounter-1',
+    payment: {
+      fee_discount_type: null,
+      fee_discount_value: null,
+    },
+    ...overrides,
+  } as ConsultationResponse
+}
+
+function makeEncounterApi(overrides: Partial<MockEncounterApi> = {}): MockEncounterApi {
+  return {
+    saveFeeDiscount: vi.fn().mockResolvedValue({}),
+    ...overrides,
+  }
+}
+
+async function loadComposable(encounterApi: MockEncounterApi) {
+  vi.doMock('@/domains/encounter/api/encounterApi', () => ({ encounterApi }))
+  return await import('./useFeeDiscount')
+}
+
+beforeEach(() => {
+  vi.resetModules()
+})
+
+afterEach(() => {
+  vi.doUnmock('@/domains/encounter/api/encounterApi')
+})
+
+describe('useFeeDiscount', () => {
+  it('opens the modal with the current consultation discount', async () => {
+    const encounterApi = makeEncounterApi()
+    const consultation = makeConsultation({
+      payment: {
+        fee_discount_type: 'fixed',
+        fee_discount_value: 150,
+      },
+    })
+    const { useFeeDiscount } = await loadComposable(encounterApi)
+
+    const discount = useFeeDiscount(() => consultation, vi.fn())
+    discount.openFeeDiscountModal()
+
+    expect(discount.feeDiscountType.value).toBe('fixed')
+    expect(discount.feeDiscountValue.value).toBe('150')
+    expect(discount.showFeeDiscountModal.value).toBe(true)
+  })
+
+  it('defaults to a percentage discount when no existing value is present', async () => {
+    const encounterApi = makeEncounterApi()
+    const { useFeeDiscount } = await loadComposable(encounterApi)
+
+    const discount = useFeeDiscount(() => makeConsultation(), vi.fn())
+    discount.feeDiscountType.value = 'fixed'
+    discount.feeDiscountValue.value = '99'
+
+    discount.openFeeDiscountModal()
+
+    expect(discount.feeDiscountType.value).toBe('percentage')
+    expect(discount.feeDiscountValue.value).toBe('')
+  })
+
+  it('saves a positive discount and updates local consultation payment state', async () => {
+    const encounterApi = makeEncounterApi()
+    const consultation = makeConsultation()
+    const updateStore = vi.fn()
+    const { useFeeDiscount } = await loadComposable(encounterApi)
+    const discount = useFeeDiscount(() => consultation, updateStore)
+
+    discount.showFeeDiscountModal.value = true
+    discount.feeDiscountType.value = 'percentage'
+    discount.feeDiscountValue.value = '20'
+    await discount.saveFeeDiscount()
+
+    expect(encounterApi.saveFeeDiscount).toHaveBeenCalledWith('encounter-1', {
+      fee_discount_type: 'percentage',
+      fee_discount_value: 20,
+    })
+    expect(updateStore).toHaveBeenCalledWith({
+      payment: {
+        fee_discount_type: 'percentage',
+        fee_discount_value: 20,
+      },
+    })
+    expect(discount.showFeeDiscountModal.value).toBe(false)
+    expect(discount.isSavingDiscount.value).toBe(false)
+  })
+
+  it('clears the discount when the entered amount is zero or invalid', async () => {
+    const encounterApi = makeEncounterApi()
+    const consultation = makeConsultation({
+      payment: {
+        invoice_id: 'invoice-1',
+        fee_discount_type: 'fixed',
+        fee_discount_value: 100,
+      },
+    })
+    const updateStore = vi.fn()
+    const { useFeeDiscount } = await loadComposable(encounterApi)
+    const discount = useFeeDiscount(() => consultation, updateStore)
+
+    discount.feeDiscountType.value = 'fixed'
+    discount.feeDiscountValue.value = 'not-a-number'
+    await discount.saveFeeDiscount()
+
+    expect(encounterApi.saveFeeDiscount).toHaveBeenCalledWith('encounter-1', {
+      fee_discount_type: null,
+      fee_discount_value: null,
+    })
+    expect(updateStore).toHaveBeenCalledWith({
+      payment: {
+        invoice_id: 'invoice-1',
+        fee_discount_type: null,
+        fee_discount_value: null,
+      },
+    })
+  })
+
+  it('does nothing when no consultation is loaded', async () => {
+    const encounterApi = makeEncounterApi()
+    const updateStore = vi.fn()
+    const { useFeeDiscount } = await loadComposable(encounterApi)
+    const discount = useFeeDiscount(() => null, updateStore)
+
+    await discount.saveFeeDiscount()
+
+    expect(encounterApi.saveFeeDiscount).not.toHaveBeenCalled()
+    expect(updateStore).not.toHaveBeenCalled()
+    expect(discount.isSavingDiscount.value).toBe(false)
+  })
+
+  it('keeps the modal open and clears saving state when the API rejects', async () => {
+    const encounterApi = makeEncounterApi({
+      saveFeeDiscount: vi.fn().mockRejectedValue(new Error('boom')),
+    })
+    const updateStore = vi.fn()
+    const { useFeeDiscount } = await loadComposable(encounterApi)
+    const discount = useFeeDiscount(() => makeConsultation(), updateStore)
+
+    discount.showFeeDiscountModal.value = true
+    discount.feeDiscountValue.value = '10'
+    await discount.saveFeeDiscount()
+
+    expect(updateStore).not.toHaveBeenCalled()
+    expect(discount.showFeeDiscountModal.value).toBe(true)
+    expect(discount.isSavingDiscount.value).toBe(false)
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -47,6 +47,7 @@ export default defineConfig({
         'src/domains/appointment/stores/**/*.ts',
         'src/domains/auth/components/{CredentialsForm,PasswordForm}.vue',
         'src/domains/auth/stores/**/*.ts',
+        'src/domains/consultation/composables/useFeeDiscount.ts',
         'src/domains/patient/components/EditPatientDialog.vue',
         'src/domains/patient/composables/usePatientSync.ts',
         'src/domains/patient/utils/profileCompleteness.ts',
@@ -75,7 +76,7 @@ export default defineConfig({
         branches: 70,
         // Vue template handlers are counted as generated functions; raise this
         // phase-by-phase as more component interaction tests land.
-        functions: 76,
+        functions: 77,
         statements: 70,
       },
     },


### PR DESCRIPTION
## Summary

Extends the frontend coverage baseline into consultation fee-discount logic.

## Changes

- Adds focused tests for `useFeeDiscount` covering modal initialization, default state, positive discount save, clearing invalid/zero values, no-loaded-consultation behavior, and API failure handling.
- Expands the Vitest coverage gate to include `useFeeDiscount`.
- Raises the global function coverage threshold from 76% to 77%.

## Validation

- `TEST_CMD="npx vitest run src/domains/consultation/composables/useFeeDiscount.spec.ts src/domains/consultation/components/VitalFieldRenderer.spec.ts" docker compose -p clinicapp-fe-tests-p6 -f docker-compose.test.yml run --rm frontend-test`
  - Passed: 2 files, 16 tests.
- `TEST_CMD="npm run test:coverage" docker compose -p clinicapp-fe-tests-p6 -f docker-compose.test.yml run --rm frontend-test`
  - Passed: 39 files, 415 tests passed, 1 existing skipped test.
  - Phase 6 coverage gate: lines/statements 97.13%, branches 86.56%, functions 77.35%.
- `TEST_CMD="npx playwright test e2e/queue-consultation.spec.ts" docker compose -p clinicapp-fe-tests-p6 -f docker-compose.test.yml run --rm frontend-feature-test`
  - Clean skipped: 3 tests skipped because local E2E credentials were not set.
- `TEST_CMD="npm run build" docker compose -p clinicapp-fe-tests-p6 -f docker-compose.test.yml run --rm frontend-test`
  - Passed. Existing slim-container git warning and bundle-size warnings remain.