### PR TITLE
Add phase 7 subscription coverage

### DIFF
--- a/src/domains/subscription/components/PricingCard.spec.ts
+++ b/src/domains/subscription/components/PricingCard.spec.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mountWithDeps } from '@/__tests__/helpers/mountWithDeps'
+import PricingCard from './PricingCard.vue'
+import { useAuthStore } from '@/domains/auth/stores/authStore'
+import { createPinia, setActivePinia } from 'pinia'
+
+const STUBS = {
+  Button: {
+    props: ['disabled'],
+    emits: ['click'],
+    template: '<button type="button" :disabled="disabled" @click="$emit(`click`, $event)"><slot /></button>',
+  },
+  Card: { template: '<section><slot /></section>' },
+  CardContent: { template: '<div><slot /></div>' },
+  CardDescription: { template: '<p><slot /></p>' },
+  CardHeader: { template: '<header><slot /></header>' },
+  CardTitle: { template: '<h2><slot /></h2>' },
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date('2026-05-07T00:00:00.000Z'))
+  setActivePinia(createPinia())
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+function mountCard(options: { loading?: boolean; trialEndsAt?: string | null } = {}) {
+  const authStore = useAuthStore()
+  authStore.user = {
+    current_clinic: {
+      is_trial: options.trialEndsAt !== undefined,
+      trial_ends_at: options.trialEndsAt ?? null,
+    },
+  } as any
+  return mountWithDeps(PricingCard, {
+    noPinia: true,
+    props: { loading: options.loading },
+    global: { stubs: STUBS },
+  })
+}
+
+describe('PricingCard', () => {
+  it('renders Pro price and feature list', () => {
+    const wrapper = mountCard()
+
+    expect(wrapper.text()).toContain('MediFlow Pro')
+    expect(wrapper.text()).toContain('PHP 1,299')
+    expect(wrapper.text()).toContain('Messages & Chat')
+    expect(wrapper.text()).toContain('Unlimited Team Members')
+  })
+
+  it('emits upgrade when the upgrade button is clicked', async () => {
+    const wrapper = mountCard()
+
+    await wrapper.find('button').trigger('click')
+
+    expect(wrapper.emitted('upgrade')).toHaveLength(1)
+    expect(wrapper.text()).toContain('Upgrade to Pro')
+  })
+
+  it('shows trial subscribe copy and plural day grammar', () => {
+    const wrapper = mountCard({ trialEndsAt: '2026-05-10T00:00:00.000Z' })
+
+    expect(wrapper.text()).toContain('Your trial ends in 3 days')
+    expect(wrapper.text()).toContain('Subscribe Now')
+  })
+
+  it('disables the action while loading', () => {
+    const wrapper = mountCard({ loading: true })
+
+    expect(wrapper.find('button').attributes('disabled')).toBeDefined()
+  })
+})

--- a/src/domains/subscription/components/SubscriptionStatus.spec.ts
+++ b/src/domains/subscription/components/SubscriptionStatus.spec.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from 'vitest'
+import { mountWithDeps } from '@/__tests__/helpers/mountWithDeps'
+import SubscriptionStatus from './SubscriptionStatus.vue'
+import { useSubscriptionStore } from '../stores/subscriptionStore'
+import type { SubscriptionStatus as StatusType } from '../types/subscription.types'
+
+const STUBS = {
+  Badge: { template: '<span><slot /></span>' },
+  Button: {
+    emits: ['click'],
+    template: '<button type="button" :disabled="disabled" @click="$emit(`click`, $event)"><slot /></button>',
+    props: ['disabled'],
+  },
+  Card: { template: '<section><slot /></section>' },
+  CardContent: { template: '<div><slot /></div>' },
+  CardHeader: { template: '<header><slot /></header>' },
+  CardTitle: { template: '<h2><slot /></h2>' },
+  CancelSubscriptionDialog: { template: '<button type="button">Cancel Subscription</button>' },
+}
+
+function makeStatus(overrides: Partial<StatusType> = {}): StatusType {
+  return {
+    plan: 'pro',
+    is_trial: false,
+    trial_ends_at: null,
+    trial_days_left: null,
+    billing_period_ends_at: '2026-06-01T00:00:00.000Z',
+    cancel_at_period_end: false,
+    is_in_grace_period: false,
+    next_billing_amount: 1299,
+    currency: 'PHP',
+    ...overrides,
+  }
+}
+
+function mountStatus(status = makeStatus()) {
+  return mountWithDeps(SubscriptionStatus, {
+    props: { status },
+    global: { stubs: STUBS },
+  })
+}
+
+describe('SubscriptionStatus', () => {
+  it('renders trial copy with singular day grammar', () => {
+    const wrapper = mountStatus(makeStatus({
+      is_trial: true,
+      trial_days_left: 1,
+      billing_period_ends_at: null,
+    }))
+
+    expect(wrapper.text()).toContain('Pro Trial')
+    expect(wrapper.text()).toContain('Trial ends in 1 day')
+  })
+
+  it('renders grace-period warning', () => {
+    const wrapper = mountStatus(makeStatus({ is_in_grace_period: true }))
+
+    expect(wrapper.text()).toContain('Billing overdue')
+  })
+
+  it('renders next billing details and cancel action for active Pro plans', () => {
+    const wrapper = mountStatus()
+
+    expect(wrapper.text()).toContain('Next billing:')
+    expect(wrapper.text()).toContain('June 1, 2026')
+    expect(wrapper.text()).toContain('PHP 1,299')
+    expect(wrapper.text()).toContain('Cancel Subscription')
+  })
+
+  it('renders scheduled cancellation copy and calls reactivate', async () => {
+    const wrapper = mountStatus(makeStatus({ cancel_at_period_end: true }))
+    const store = useSubscriptionStore()
+    store.reactivateSubscription = vi.fn().mockResolvedValue('reactivated')
+
+    await wrapper.findAll('button').find((button) => button.text().includes('Reactivate'))?.trigger('click')
+
+    expect(wrapper.text()).toContain('Pro access until')
+    expect(wrapper.text()).toContain('cancellation scheduled')
+    expect(store.reactivateSubscription).toHaveBeenCalledOnce()
+  })
+})

--- a/src/domains/subscription/stores/subscriptionStore.spec.ts
+++ b/src/domains/subscription/stores/subscriptionStore.spec.ts
@@ -1,0 +1,167 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { PaymentRecord, SubscriptionStatus } from '../types/subscription.types'
+
+interface MockSubscriptionApi {
+  getStatus: ReturnType<typeof vi.fn>
+  getHistory: ReturnType<typeof vi.fn>
+  createCheckout: ReturnType<typeof vi.fn>
+  cancel: ReturnType<typeof vi.fn>
+  reactivate: ReturnType<typeof vi.fn>
+}
+
+function makeStatus(overrides: Partial<SubscriptionStatus> = {}): SubscriptionStatus {
+  return {
+    plan: 'pro',
+    is_trial: false,
+    trial_ends_at: null,
+    trial_days_left: null,
+    billing_period_ends_at: '2026-06-01T00:00:00.000Z',
+    cancel_at_period_end: false,
+    is_in_grace_period: false,
+    next_billing_amount: 1299,
+    currency: 'PHP',
+    ...overrides,
+  }
+}
+
+function makePayment(overrides: Partial<PaymentRecord> = {}): PaymentRecord {
+  return {
+    id: 'payment-1',
+    amount: 1299,
+    currency: 'PHP',
+    status: 'paid',
+    payment_method: 'card',
+    plan: 'pro',
+    type: 'renewal',
+    billing_period_start: '2026-05-01T00:00:00.000Z',
+    billing_period_end: '2026-06-01T00:00:00.000Z',
+    paid_at: '2026-05-01T00:00:00.000Z',
+    created_at: '2026-05-01T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+function makeSubscriptionApi(overrides: Partial<MockSubscriptionApi> = {}): MockSubscriptionApi {
+  return {
+    getStatus: vi.fn().mockResolvedValue({ data: makeStatus() }),
+    getHistory: vi.fn().mockResolvedValue({
+      data: [makePayment()],
+      meta: { current_page: 2, last_page: 4, per_page: 10, total: 31 },
+    }),
+    createCheckout: vi.fn().mockResolvedValue({
+      data: { checkout_url: 'https://checkout.example/session', payment_id: 'payment-1' },
+    }),
+    cancel: vi.fn().mockResolvedValue({ message: 'Subscription will cancel at period end.' }),
+    reactivate: vi.fn().mockResolvedValue({ message: 'Subscription reactivated.' }),
+    ...overrides,
+  }
+}
+
+async function loadStore(subscriptionApi: MockSubscriptionApi) {
+  vi.doMock('../api/subscriptionApi', () => ({ subscriptionApi }))
+  return await import('./subscriptionStore')
+}
+
+beforeEach(() => {
+  vi.resetModules()
+})
+
+afterEach(() => {
+  vi.doUnmock('../api/subscriptionApi')
+})
+
+describe('subscriptionStore - fetching', () => {
+  it('fetchStatus stores the current subscription status and clears loading', async () => {
+    const subscriptionApi = makeSubscriptionApi({
+      getStatus: vi.fn().mockResolvedValue({ data: makeStatus({ plan: 'free' }) }),
+    })
+    const { useSubscriptionStore } = await loadStore(subscriptionApi)
+    const store = useSubscriptionStore()
+
+    await store.fetchStatus()
+
+    expect(subscriptionApi.getStatus).toHaveBeenCalledOnce()
+    expect(store.status?.plan).toBe('free')
+    expect(store.loading).toBe(false)
+  })
+
+  it('fetchHistory stores payments and pagination', async () => {
+    const subscriptionApi = makeSubscriptionApi()
+    const { useSubscriptionStore } = await loadStore(subscriptionApi)
+    const store = useSubscriptionStore()
+
+    await store.fetchHistory(2)
+
+    expect(subscriptionApi.getHistory).toHaveBeenCalledWith(2)
+    expect(store.payments[0]?.id).toBe('payment-1')
+    expect(store.currentPage).toBe(2)
+    expect(store.totalPages).toBe(4)
+    expect(store.loading).toBe(false)
+  })
+
+  it('clears loading when fetchStatus fails', async () => {
+    const subscriptionApi = makeSubscriptionApi({
+      getStatus: vi.fn().mockRejectedValue(new Error('network down')),
+    })
+    const { useSubscriptionStore } = await loadStore(subscriptionApi)
+    const store = useSubscriptionStore()
+
+    await expect(store.fetchStatus()).rejects.toThrow('network down')
+
+    expect(store.loading).toBe(false)
+  })
+})
+
+describe('subscriptionStore - actions', () => {
+  it('starts checkout only for HTTPS checkout URLs', async () => {
+    const subscriptionApi = makeSubscriptionApi()
+    const { useSubscriptionStore } = await loadStore(subscriptionApi)
+    const store = useSubscriptionStore()
+
+    await store.initiateCheckout()
+
+    expect(subscriptionApi.createCheckout).toHaveBeenCalledOnce()
+    expect(window.location.href).toBe('https://checkout.example/session')
+    expect(store.checkoutLoading).toBe(false)
+  })
+
+  it('rejects invalid checkout URLs and clears checkout loading', async () => {
+    const subscriptionApi = makeSubscriptionApi({
+      createCheckout: vi.fn().mockResolvedValue({
+        data: { checkout_url: 'javascript:alert(1)', payment_id: 'payment-1' },
+      }),
+    })
+    const { useSubscriptionStore } = await loadStore(subscriptionApi)
+    const store = useSubscriptionStore()
+
+    await expect(store.initiateCheckout()).rejects.toThrow('Invalid checkout URL')
+
+    expect(store.checkoutLoading).toBe(false)
+  })
+
+  it('cancelSubscription refreshes status and returns the API message', async () => {
+    const subscriptionApi = makeSubscriptionApi()
+    const { useSubscriptionStore } = await loadStore(subscriptionApi)
+    const store = useSubscriptionStore()
+
+    const message = await store.cancelSubscription()
+
+    expect(subscriptionApi.cancel).toHaveBeenCalledOnce()
+    expect(subscriptionApi.getStatus).toHaveBeenCalledOnce()
+    expect(message).toBe('Subscription will cancel at period end.')
+    expect(store.cancelLoading).toBe(false)
+  })
+
+  it('reactivateSubscription refreshes status and returns the API message', async () => {
+    const subscriptionApi = makeSubscriptionApi()
+    const { useSubscriptionStore } = await loadStore(subscriptionApi)
+    const store = useSubscriptionStore()
+
+    const message = await store.reactivateSubscription()
+
+    expect(subscriptionApi.reactivate).toHaveBeenCalledOnce()
+    expect(subscriptionApi.getStatus).toHaveBeenCalledOnce()
+    expect(message).toBe('Subscription reactivated.')
+    expect(store.cancelLoading).toBe(false)
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -55,6 +55,8 @@ export default defineConfig({
         'src/domains/queue/stores/**/*.ts',
         'src/domains/schedule/components/{BreakEditor,DayScheduleRow}.vue',
         'src/domains/schedule/stores/**/*.ts',
+        'src/domains/subscription/components/{PricingCard,SubscriptionStatus}.vue',
+        'src/domains/subscription/stores/**/*.ts',
         'src/lib/validationRules.ts',
       ],
       // Don't fail builds on tier-0 / infra files that exist mostly to
@@ -76,7 +78,7 @@ export default defineConfig({
         branches: 70,
         // Vue template handlers are counted as generated functions; raise this
         // phase-by-phase as more component interaction tests land.
-        functions: 77,
+        functions: 78,
         statements: 70,
       },
     },


### PR DESCRIPTION
## Summary

Extends the frontend coverage baseline into subscription billing flows.

## Changes

- Adds subscription store tests for status/history loading, checkout URL validation, cancellation, and reactivation.
- Adds component tests for `SubscriptionStatus` trial/grace/billing/cancellation states.
- Adds component tests for `PricingCard` feature rendering, trial copy, loading state, and upgrade emit.
- Expands the Vitest coverage gate to include subscription store and compact subscription components.
- Raises the global function coverage threshold from 77% to 78%.

## Validation

- `TEST_CMD="npx vitest run src/domains/subscription/stores/subscriptionStore.spec.ts src/domains/subscription/components/SubscriptionStatus.spec.ts src/domains/subscription/components/PricingCard.spec.ts" docker compose -p clinicapp-fe-tests-p7 -f docker-compose.test.yml run --rm frontend-test`
  - Passed: 3 files, 15 tests.
- `TEST_CMD="npm run test:coverage" docker compose -p clinicapp-fe-tests-p7 -f docker-compose.test.yml run --rm frontend-test`
  - Passed: 42 files, 430 tests passed, 1 existing skipped test.
  - Phase 7 coverage gate: lines/statements 97.35%, branches 86.71%, functions 78.76%.
- `TEST_CMD="npx playwright test e2e/dental-fee-schedule.spec.ts" docker compose -p clinicapp-fe-tests-p7 -f docker-compose.test.yml run --rm frontend-feature-test`
  - Clean skipped: 3 tests skipped because local E2E credentials were not set.
- `TEST_CMD="npm run build" docker compose -p clinicapp-fe-tests-p7 -f docker-compose.test.yml run --rm frontend-test`
  - Passed. Existing slim-container git warning and bundle-size warnings remain.