### PR TITLE
Add phase 8 catalog API coverage

### DIFF
--- a/src/domains/consumable/api/consumableApi.spec.ts
+++ b/src/domains/consumable/api/consumableApi.spec.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+interface MockHttp {
+  get: ReturnType<typeof vi.fn>
+  post: ReturnType<typeof vi.fn>
+  patch: ReturnType<typeof vi.fn>
+  delete: ReturnType<typeof vi.fn>
+}
+
+function makeHttp(): MockHttp {
+  return {
+    get: vi.fn().mockResolvedValue({ data: [] }),
+    post: vi.fn().mockResolvedValue({ data: { id: 'consumable-1' } }),
+    patch: vi.fn().mockResolvedValue({ data: { id: 'consumable-1' } }),
+    delete: vi.fn().mockResolvedValue({ data: { id: 'consumable-1' } }),
+  }
+}
+
+async function loadApi(http: MockHttp) {
+  vi.doMock('@/lib/http', () => ({ http }))
+  return await import('./consumableApi')
+}
+
+beforeEach(() => {
+  vi.resetModules()
+})
+
+afterEach(() => {
+  vi.doUnmock('@/lib/http')
+})
+
+describe('consumableApi', () => {
+  it('builds list query params with pagination and search', async () => {
+    const http = makeHttp()
+    const { consumableApi } = await loadApi(http)
+
+    await consumableApi.list(3, 25, 'gloves small')
+
+    expect(http.get).toHaveBeenCalledWith('/consumables?page=3&per_page=25&q=gloves+small')
+  })
+
+  it('omits empty search query', async () => {
+    const http = makeHttp()
+    const { consumableApi } = await loadApi(http)
+
+    await consumableApi.list(1, 20, '')
+
+    expect(http.get).toHaveBeenCalledWith('/consumables?page=1&per_page=20')
+  })
+
+  it('delegates create, update, deactivate, and stock adjustment requests', async () => {
+    const http = makeHttp()
+    const { consumableApi } = await loadApi(http)
+
+    await consumableApi.create({ name: 'Syringe', unit: 'piece', stock_quantity: 20 })
+    await consumableApi.update('consumable-1', { name: 'Syringe 5ml' })
+    await consumableApi.deactivate('consumable-1')
+    await consumableApi.adjustStock('consumable-1', { delta: -2, reason: 'used' })
+
+    expect(http.post).toHaveBeenNthCalledWith(1, '/consumables', { name: 'Syringe', unit: 'piece', stock_quantity: 20 })
+    expect(http.patch).toHaveBeenCalledWith('/consumables/consumable-1', { name: 'Syringe 5ml' })
+    expect(http.delete).toHaveBeenCalledWith('/consumables/consumable-1')
+    expect(http.post).toHaveBeenNthCalledWith(2, '/consumables/consumable-1/adjust-stock', { delta: -2, reason: 'used' })
+  })
+})

--- a/src/domains/labService/api/labServiceApi.spec.ts
+++ b/src/domains/labService/api/labServiceApi.spec.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+interface MockHttp {
+  get: ReturnType<typeof vi.fn>
+  post: ReturnType<typeof vi.fn>
+  patch: ReturnType<typeof vi.fn>
+  delete: ReturnType<typeof vi.fn>
+}
+
+function makeHttp(): MockHttp {
+  return {
+    get: vi.fn().mockResolvedValue({ data: [] }),
+    post: vi.fn().mockResolvedValue({ data: { id: 'lab-1' } }),
+    patch: vi.fn().mockResolvedValue({ data: { id: 'lab-1' } }),
+    delete: vi.fn().mockResolvedValue({ data: { id: 'lab-1' } }),
+  }
+}
+
+async function loadApi(http: MockHttp) {
+  vi.doMock('@/lib/http', () => ({ http }))
+  return await import('./labServiceApi')
+}
+
+beforeEach(() => {
+  vi.resetModules()
+})
+
+afterEach(() => {
+  vi.doUnmock('@/lib/http')
+})
+
+describe('labServiceApi', () => {
+  it('builds list query params with pagination and search', async () => {
+    const http = makeHttp()
+    const { labServiceApi } = await loadApi(http)
+
+    await labServiceApi.list(4, 30, 'cbc platelet')
+
+    expect(http.get).toHaveBeenCalledWith('/lab-services?page=4&per_page=30&q=cbc+platelet')
+  })
+
+  it('delegates create, update, deactivate, and find-or-create requests', async () => {
+    const http = makeHttp()
+    const { labServiceApi } = await loadApi(http)
+
+    await labServiceApi.create({ name: 'CBC', category: 'Hematology', price: 500 })
+    await labServiceApi.update('lab-1', { price: 550 })
+    await labServiceApi.deactivate('lab-1')
+    await labServiceApi.findOrCreate({ name: 'Urinalysis', category: 'Chemistry' })
+
+    expect(http.post).toHaveBeenNthCalledWith(1, '/lab-services', { name: 'CBC', category: 'Hematology', price: 500 })
+    expect(http.patch).toHaveBeenCalledWith('/lab-services/lab-1', { price: 550 })
+    expect(http.delete).toHaveBeenCalledWith('/lab-services/lab-1')
+    expect(http.post).toHaveBeenNthCalledWith(2, '/lab-services/find-or-create', { name: 'Urinalysis', category: 'Chemistry' })
+  })
+
+  it('encodes system lab item search terms', async () => {
+    const http = makeHttp()
+    const { labServiceApi } = await loadApi(http)
+
+    await labServiceApi.searchSystem('blood sugar')
+
+    expect(http.get).toHaveBeenCalledWith('/system/lab-items?q=blood%20sugar')
+  })
+})

--- a/src/domains/medicine/api/medicineApi.spec.ts
+++ b/src/domains/medicine/api/medicineApi.spec.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+interface MockHttp {
+  get: ReturnType<typeof vi.fn>
+  post: ReturnType<typeof vi.fn>
+  patch: ReturnType<typeof vi.fn>
+  delete: ReturnType<typeof vi.fn>
+}
+
+function makeHttp(): MockHttp {
+  return {
+    get: vi.fn().mockResolvedValue({ data: [] }),
+    post: vi.fn().mockResolvedValue({ data: { id: 'medicine-1' } }),
+    patch: vi.fn().mockResolvedValue({ data: { id: 'medicine-1' } }),
+    delete: vi.fn().mockResolvedValue({ data: { id: 'medicine-1' } }),
+  }
+}
+
+async function loadApi(http: MockHttp) {
+  vi.doMock('@/lib/http', () => ({ http }))
+  return await import('./medicineApi')
+}
+
+beforeEach(() => {
+  vi.resetModules()
+})
+
+afterEach(() => {
+  vi.doUnmock('@/lib/http')
+})
+
+describe('medicineApi', () => {
+  it('builds list query params with pagination, search, and inactive flag', async () => {
+    const http = makeHttp()
+    const { medicineApi } = await loadApi(http)
+
+    await medicineApi.list(2, 50, 'amox 500', true)
+
+    expect(http.get).toHaveBeenCalledWith('/medicines?page=2&per_page=50&q=amox+500&include_inactive=1')
+  })
+
+  it('omits optional list params when they are not provided', async () => {
+    const http = makeHttp()
+    const { medicineApi } = await loadApi(http)
+
+    await medicineApi.list()
+
+    expect(http.get).toHaveBeenCalledWith('/medicines?page=1&per_page=20')
+  })
+
+  it('encodes medicine and system search terms', async () => {
+    const http = makeHttp()
+    const { medicineApi } = await loadApi(http)
+
+    await medicineApi.search('vitamin c+zinc')
+    await medicineApi.searchSystem('pain relief')
+
+    expect(http.get).toHaveBeenNthCalledWith(1, '/medicines/search?q=vitamin%20c%2Bzinc')
+    expect(http.get).toHaveBeenNthCalledWith(2, '/system/medicines?q=pain%20relief')
+  })
+
+  it('delegates create, update, deactivate, and stock adjustment requests', async () => {
+    const http = makeHttp()
+    const { medicineApi } = await loadApi(http)
+
+    await medicineApi.create({ name: 'Paracetamol', unit: 'tablet', stock_quantity: 10 })
+    await medicineApi.update('medicine-1', { name: 'Paracetamol 500mg' })
+    await medicineApi.deactivate('medicine-1')
+    await medicineApi.adjustStock('medicine-1', { delta: 5, reason: 'restock' })
+
+    expect(http.post).toHaveBeenNthCalledWith(1, '/medicines', { name: 'Paracetamol', unit: 'tablet', stock_quantity: 10 })
+    expect(http.patch).toHaveBeenCalledWith('/medicines/medicine-1', { name: 'Paracetamol 500mg' })
+    expect(http.delete).toHaveBeenCalledWith('/medicines/medicine-1')
+    expect(http.post).toHaveBeenNthCalledWith(2, '/medicines/medicine-1/adjust-stock', { delta: 5, reason: 'restock' })
+  })
+})

--- a/src/domains/service/api/serviceApi.spec.ts
+++ b/src/domains/service/api/serviceApi.spec.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+interface MockHttp {
+  get: ReturnType<typeof vi.fn>
+  post: ReturnType<typeof vi.fn>
+  patch: ReturnType<typeof vi.fn>
+  delete: ReturnType<typeof vi.fn>
+  put: ReturnType<typeof vi.fn>
+}
+
+function makeHttp(): MockHttp {
+  return {
+    get: vi.fn().mockResolvedValue({ data: [] }),
+    post: vi.fn().mockResolvedValue({ data: { id: 'service-1' } }),
+    patch: vi.fn().mockResolvedValue({ data: { id: 'service-1' } }),
+    delete: vi.fn().mockResolvedValue({ data: { id: 'service-1' } }),
+    put: vi.fn().mockResolvedValue({ data: {} }),
+  }
+}
+
+async function loadApi(http: MockHttp) {
+  vi.doMock('@/lib/http', () => ({ http }))
+  return await import('./serviceApi')
+}
+
+beforeEach(() => {
+  vi.resetModules()
+})
+
+afterEach(() => {
+  vi.doUnmock('@/lib/http')
+})
+
+describe('serviceApi', () => {
+  it('builds list query params with pagination and filters', async () => {
+    const http = makeHttp()
+    const { serviceApi } = await loadApi(http)
+
+    await serviceApi.list(2, 15, { q: 'cleaning', category: 'Dental', specialty: 'dentistry' })
+
+    expect(http.get).toHaveBeenCalledWith('/clinic-services?page=2&per_page=15&q=cleaning&category=Dental&specialty=dentistry')
+  })
+
+  it('omits empty list filters', async () => {
+    const http = makeHttp()
+    const { serviceApi } = await loadApi(http)
+
+    await serviceApi.list()
+
+    expect(http.get).toHaveBeenCalledWith('/clinic-services?page=1&per_page=20')
+  })
+
+  it('delegates create, update, and deactivate requests', async () => {
+    const http = makeHttp()
+    const { serviceApi } = await loadApi(http)
+
+    await serviceApi.create({ name: 'Cleaning', category: 'Dental', specialties: ['dentistry'], price: 1200 })
+    await serviceApi.update('service-1', { price: 1500 })
+    await serviceApi.deactivate('service-1')
+
+    expect(http.post).toHaveBeenCalledWith('/clinic-services', { name: 'Cleaning', category: 'Dental', specialties: ['dentistry'], price: 1200 })
+    expect(http.patch).toHaveBeenCalledWith('/clinic-services/service-1', { price: 1500 })
+    expect(http.delete).toHaveBeenCalledWith('/clinic-services/service-1')
+  })
+
+  it('builds system service search params with optional specialty', async () => {
+    const http = makeHttp()
+    const { serviceApi } = await loadApi(http)
+
+    await serviceApi.searchSystem('oral exam', 'dentistry')
+    await serviceApi.searchSystem('follow up')
+
+    expect(http.get).toHaveBeenNthCalledWith(1, '/system-services/search?q=oral+exam&specialty=dentistry')
+    expect(http.get).toHaveBeenNthCalledWith(2, '/system-services/search?q=follow+up')
+  })
+
+  it('saves encounter procedures', async () => {
+    const http = makeHttp()
+    const { serviceApi } = await loadApi(http)
+    const procedures = [{ service_id: 'service-1', name: 'Cleaning', quantity: 1, unit_price: 1200, notes: null }]
+
+    await serviceApi.saveProcedures('encounter-1', procedures)
+
+    expect(http.put).toHaveBeenCalledWith('/encounters/encounter-1/procedures', { procedures })
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -48,6 +48,9 @@ export default defineConfig({
         'src/domains/auth/components/{CredentialsForm,PasswordForm}.vue',
         'src/domains/auth/stores/**/*.ts',
         'src/domains/consultation/composables/useFeeDiscount.ts',
+        'src/domains/consumable/api/consumableApi.ts',
+        'src/domains/labService/api/labServiceApi.ts',
+        'src/domains/medicine/api/medicineApi.ts',
         'src/domains/patient/components/EditPatientDialog.vue',
         'src/domains/patient/composables/usePatientSync.ts',
         'src/domains/patient/utils/profileCompleteness.ts',
@@ -55,6 +58,7 @@ export default defineConfig({
         'src/domains/queue/stores/**/*.ts',
         'src/domains/schedule/components/{BreakEditor,DayScheduleRow}.vue',
         'src/domains/schedule/stores/**/*.ts',
+        'src/domains/service/api/serviceApi.ts',
         'src/domains/subscription/components/{PricingCard,SubscriptionStatus}.vue',
         'src/domains/subscription/stores/**/*.ts',
         'src/lib/validationRules.ts',
@@ -78,7 +82,7 @@ export default defineConfig({
         branches: 70,
         // Vue template handlers are counted as generated functions; raise this
         // phase-by-phase as more component interaction tests land.
-        functions: 78,
+        functions: 82,
         statements: 70,
       },
     },


### PR DESCRIPTION
## Summary

Extends the frontend coverage baseline into catalog and inventory API clients.

## Changes

- Adds medicine API tests for list/search URL construction and create/update/deactivate/stock adjustment delegation.
- Adds consumable API tests for list URL construction and create/update/deactivate/stock adjustment delegation.
- Adds lab-service API tests for list/system-search URL construction and create/update/deactivate/find-or-create delegation.
- Adds clinic-service API tests for list/system-search URL construction, create/update/deactivate delegation, and encounter procedure saving.
- Expands the Vitest coverage gate to include catalog API modules.
- Raises the global function coverage threshold from 78% to 82%.

## Validation

- `TEST_CMD="npx vitest run src/domains/medicine/api/medicineApi.spec.ts src/domains/consumable/api/consumableApi.spec.ts src/domains/labService/api/labServiceApi.spec.ts src/domains/service/api/serviceApi.spec.ts" docker compose -p clinicapp-fe-tests-p8 -f docker-compose.test.yml run --rm frontend-test`
  - Passed: 4 files, 15 tests.
- `TEST_CMD="npm run test:coverage" docker compose -p clinicapp-fe-tests-p8 -f docker-compose.test.yml run --rm frontend-test`
  - Passed: 46 files, 445 tests passed, 1 skipped.
  - Phase 8 coverage gate: lines/statements 97.47%, branches 87.45%, functions 82.48%.
- `TEST_CMD="npx playwright test e2e/dental-fee-schedule.spec.ts" docker compose -p clinicapp-fe-tests-p8 -f docker-compose.test.yml run --rm frontend-feature-test`
  - Clean skipped: 3 tests skipped because local E2E credentials were not set.
- `TEST_CMD="npm run build" docker compose -p clinicapp-fe-tests-p8 -f docker-compose.test.yml run --rm frontend-test`
  - Passed. Existing slim-container git warning and bundle-size warnings remain.
