### PR TITLE
Add phase 9 clinic admin API coverage

### DIFF
--- a/src/domains/clinic/api/clinicApi.spec.ts
+++ b/src/domains/clinic/api/clinicApi.spec.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+interface MockHttp {
+  get: ReturnType<typeof vi.fn>
+  post: ReturnType<typeof vi.fn>
+  patch: ReturnType<typeof vi.fn>
+  upload: ReturnType<typeof vi.fn>
+}
+
+function makeHttp(): MockHttp {
+  return {
+    get: vi.fn().mockResolvedValue({ data: { id: 'clinic-1' } }),
+    post: vi.fn().mockResolvedValue({ data: { id: 'clinic-1' }, meta: { access_token: 'token', token_type: 'Bearer' } }),
+    patch: vi.fn().mockResolvedValue({ data: { id: 'clinic-1' } }),
+    upload: vi.fn().mockResolvedValue({ data: { logo_url: 'https://example.test/logo.png' } }),
+  }
+}
+
+async function loadApi(http: MockHttp) {
+  vi.doMock('@/lib/http', () => ({ http }))
+  return await import('./clinicApi')
+}
+
+beforeEach(() => {
+  vi.resetModules()
+})
+
+afterEach(() => {
+  vi.doUnmock('@/lib/http')
+})
+
+describe('clinicApi', () => {
+  it('delegates create, show, and update requests', async () => {
+    const http = makeHttp()
+    const { clinicApi } = await loadApi(http)
+    const createPayload = { clinic_name: 'MediFlow Clinic', email: 'hello@example.test' }
+    const updatePayload = { clinic_name: 'MediFlow Plus', contact_number: '09171234567' }
+
+    await clinicApi.create(createPayload)
+    await clinicApi.show()
+    await clinicApi.update(updatePayload)
+
+    expect(http.post).toHaveBeenCalledWith('/clinics', createPayload)
+    expect(http.get).toHaveBeenCalledWith('/clinic/profile')
+    expect(http.patch).toHaveBeenCalledWith('/clinic/profile', updatePayload)
+  })
+
+  it('uploads the clinic logo as form data', async () => {
+    const http = makeHttp()
+    const { clinicApi } = await loadApi(http)
+    const file = new File(['logo'], 'logo.png', { type: 'image/png' })
+
+    await clinicApi.uploadLogo(file)
+
+    expect(http.upload).toHaveBeenCalledWith('/clinic/logo', expect.any(FormData))
+    const formData = http.upload.mock.calls[0][1] as FormData
+    expect(formData.get('logo')).toBe(file)
+  })
+})

--- a/src/domains/roles/api/roleApi.spec.ts
+++ b/src/domains/roles/api/roleApi.spec.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+interface MockHttp {
+  get: ReturnType<typeof vi.fn>
+  post: ReturnType<typeof vi.fn>
+  patch: ReturnType<typeof vi.fn>
+  delete: ReturnType<typeof vi.fn>
+}
+
+function makeHttp(): MockHttp {
+  return {
+    get: vi.fn().mockResolvedValue({ data: [] }),
+    post: vi.fn().mockResolvedValue({ data: { id: 'role-1' } }),
+    patch: vi.fn().mockResolvedValue({ data: { id: 'role-1' } }),
+    delete: vi.fn().mockResolvedValue(undefined),
+  }
+}
+
+async function loadApi(http: MockHttp) {
+  vi.doMock('@/lib/http', () => ({ http }))
+  return await import('./roleApi')
+}
+
+beforeEach(() => {
+  vi.resetModules()
+})
+
+afterEach(() => {
+  vi.doUnmock('@/lib/http')
+})
+
+describe('roleApi', () => {
+  it('loads clinic roles and permission groups', async () => {
+    const http = makeHttp()
+    const { roleApi } = await loadApi(http)
+
+    await roleApi.list()
+    await roleApi.permissions()
+
+    expect(http.get).toHaveBeenNthCalledWith(1, '/clinic/roles')
+    expect(http.get).toHaveBeenNthCalledWith(2, '/clinic/roles/permissions')
+  })
+
+  it('delegates create, update, and remove requests', async () => {
+    const http = makeHttp()
+    const { roleApi } = await loadApi(http)
+    const payload = { name: 'Front Desk', permissions: ['patients.view'] }
+
+    await roleApi.create(payload)
+    await roleApi.update('role-1', { ...payload, permissions: ['patients.view', 'queue.manage'] })
+    await roleApi.remove('role-1')
+
+    expect(http.post).toHaveBeenCalledWith('/clinic/roles', payload)
+    expect(http.patch).toHaveBeenCalledWith('/clinic/roles/role-1', { name: 'Front Desk', permissions: ['patients.view', 'queue.manage'] })
+    expect(http.delete).toHaveBeenCalledWith('/clinic/roles/role-1')
+  })
+})

--- a/src/domains/team/api/teamApi.spec.ts
+++ b/src/domains/team/api/teamApi.spec.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+interface MockHttp {
+  get: ReturnType<typeof vi.fn>
+  post: ReturnType<typeof vi.fn>
+  patch: ReturnType<typeof vi.fn>
+  delete: ReturnType<typeof vi.fn>
+}
+
+function makeHttp(): MockHttp {
+  return {
+    get: vi.fn().mockResolvedValue({ data: [] }),
+    post: vi.fn().mockResolvedValue({ data: { id: 'member-1' } }),
+    patch: vi.fn().mockResolvedValue({ data: { id: 'member-1' } }),
+    delete: vi.fn().mockResolvedValue(undefined),
+  }
+}
+
+async function loadApi(http: MockHttp) {
+  vi.doMock('@/lib/http', () => ({ http }))
+  return await import('./teamApi')
+}
+
+beforeEach(() => {
+  vi.resetModules()
+})
+
+afterEach(() => {
+  vi.doUnmock('@/lib/http')
+})
+
+describe('teamApi', () => {
+  it('builds list query params for status and role filters', async () => {
+    const http = makeHttp()
+    const { teamApi } = await loadApi(http)
+
+    await teamApi.list({ status: 'pending', role: 'staff nurse' })
+    await teamApi.list()
+
+    expect(http.get).toHaveBeenNthCalledWith(1, '/clinic/members?status=pending&role=staff+nurse')
+    expect(http.get).toHaveBeenNthCalledWith(2, '/clinic/members')
+  })
+
+  it('delegates invitation and resend requests', async () => {
+    const http = makeHttp()
+    const { teamApi } = await loadApi(http)
+    const invite = { email: 'staff@example.test', role: 'staff' }
+
+    await teamApi.invite(invite)
+    await teamApi.resendInvite('member-1')
+
+    expect(http.post).toHaveBeenNthCalledWith(1, '/clinic/members/invite', invite)
+    expect(http.post).toHaveBeenNthCalledWith(2, '/clinic/members/member-1/resend-invite')
+  })
+
+  it('delegates role and membership state changes', async () => {
+    const http = makeHttp()
+    const { teamApi } = await loadApi(http)
+
+    await teamApi.changeRole('member-1', { role: 'doctor' })
+    await teamApi.disable('member-1')
+    await teamApi.enable('member-1')
+    await teamApi.remove('member-1')
+
+    expect(http.patch).toHaveBeenNthCalledWith(1, '/clinic/members/member-1/role', { role: 'doctor' })
+    expect(http.patch).toHaveBeenNthCalledWith(2, '/clinic/members/member-1/disable')
+    expect(http.patch).toHaveBeenNthCalledWith(3, '/clinic/members/member-1/enable')
+    expect(http.delete).toHaveBeenCalledWith('/clinic/members/member-1')
+  })
+})

--- a/src/domains/template/api/templateApi.spec.ts
+++ b/src/domains/template/api/templateApi.spec.ts
@@ -1,0 +1,49 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+interface MockHttp {
+  get: ReturnType<typeof vi.fn>
+  put: ReturnType<typeof vi.fn>
+}
+
+function makeHttp(): MockHttp {
+  return {
+    get: vi.fn().mockResolvedValue({ data: [] }),
+    put: vi.fn().mockResolvedValue({ data: { id: 'template-1' } }),
+  }
+}
+
+async function loadApi(http: MockHttp) {
+  vi.doMock('@/lib/http', () => ({ http }))
+  return await import('./templateApi')
+}
+
+beforeEach(() => {
+  vi.resetModules()
+})
+
+afterEach(() => {
+  vi.doUnmock('@/lib/http')
+})
+
+describe('templateApi', () => {
+  it('loads template lists and specific category variations', async () => {
+    const http = makeHttp()
+    const { templateApi } = await loadApi(http)
+
+    await templateApi.list()
+    await templateApi.show('prescription', 'default')
+
+    expect(http.get).toHaveBeenNthCalledWith(1, '/clinic/templates')
+    expect(http.get).toHaveBeenNthCalledWith(2, '/clinic/templates/prescription/default')
+  })
+
+  it('upserts a category variation with config payload', async () => {
+    const http = makeHttp()
+    const { templateApi } = await loadApi(http)
+    const payload = { name: 'Compact Rx', config: { paperSize: 'a5' }, is_active: true }
+
+    await templateApi.upsert('prescription', 'compact', payload)
+
+    expect(http.put).toHaveBeenCalledWith('/clinic/templates/prescription/compact', payload)
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -47,6 +47,7 @@ export default defineConfig({
         'src/domains/appointment/stores/**/*.ts',
         'src/domains/auth/components/{CredentialsForm,PasswordForm}.vue',
         'src/domains/auth/stores/**/*.ts',
+        'src/domains/clinic/api/clinicApi.ts',
         'src/domains/consultation/composables/useFeeDiscount.ts',
         'src/domains/consumable/api/consumableApi.ts',
         'src/domains/labService/api/labServiceApi.ts',
@@ -56,11 +57,14 @@ export default defineConfig({
         'src/domains/patient/utils/profileCompleteness.ts',
         'src/domains/queue/components/{QueueCard,QueueStatusBadge}.vue',
         'src/domains/queue/stores/**/*.ts',
+        'src/domains/roles/api/roleApi.ts',
         'src/domains/schedule/components/{BreakEditor,DayScheduleRow}.vue',
         'src/domains/schedule/stores/**/*.ts',
         'src/domains/service/api/serviceApi.ts',
         'src/domains/subscription/components/{PricingCard,SubscriptionStatus}.vue',
         'src/domains/subscription/stores/**/*.ts',
+        'src/domains/team/api/teamApi.ts',
+        'src/domains/template/api/templateApi.ts',
         'src/lib/validationRules.ts',
       ],
       // Don't fail builds on tier-0 / infra files that exist mostly to
@@ -82,7 +86,7 @@ export default defineConfig({
         branches: 70,
         // Vue template handlers are counted as generated functions; raise this
         // phase-by-phase as more component interaction tests land.
-        functions: 82,
+        functions: 84,
         statements: 70,
       },
     },


### PR DESCRIPTION
## Summary

Extends the frontend coverage baseline into clinic administration API clients.

## Changes

- Adds clinic API tests for create/show/update delegation and logo upload form-data handling.
- Adds role API tests for role/permission loading and create/update/remove delegation.
- Adds team API tests for list query construction plus invitation, role, membership state, and removal delegation.
- Adds template API tests for list/show/upsert endpoint delegation.
- Expands the Vitest coverage gate to include clinic, roles, team, and template API modules.
- Raises the global function coverage threshold from 82% to 84%.

## Validation

- `TEST_CMD="npx vitest run src/domains/roles/api/roleApi.spec.ts src/domains/team/api/teamApi.spec.ts src/domains/clinic/api/clinicApi.spec.ts src/domains/template/api/templateApi.spec.ts" docker compose -p clinicapp-fe-tests-p9 -f docker-compose.test.yml run --rm frontend-test`
  - Passed: 4 files, 9 tests.
- `TEST_CMD="npm run test:coverage" docker compose -p clinicapp-fe-tests-p9 -f docker-compose.test.yml run --rm frontend-test`
  - Passed: 50 files, 454 tests passed, 1 skipped.
  - Phase 9 coverage gate: lines/statements 97.56%, branches 87.95%, functions 84.61%.
- `TEST_CMD="npx playwright test e2e/dental-fee-schedule.spec.ts" docker compose -p clinicapp-fe-tests-p9 -f docker-compose.test.yml run --rm frontend-feature-test`
  - Clean skipped: 3 tests skipped because local E2E credentials were not set.
- `TEST_CMD="npm run build" docker compose -p clinicapp-fe-tests-p9 -f docker-compose.test.yml run --rm frontend-test`
  - Passed. Existing slim-container git warning and bundle-size warnings remain.
