### PR TITLE
Add phase 11 scheduling billing API coverage

### DIFF
--- a/src/domains/appointment/api/appointmentApi.spec.ts
+++ b/src/domains/appointment/api/appointmentApi.spec.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+interface MockHttp {
+  get: ReturnType<typeof vi.fn>
+  post: ReturnType<typeof vi.fn>
+  patch: ReturnType<typeof vi.fn>
+}
+
+function makeHttp(): MockHttp {
+  return {
+    get: vi.fn().mockResolvedValue({ data: [] }),
+    post: vi.fn().mockResolvedValue({ data: { uuid: 'appointment-1' } }),
+    patch: vi.fn().mockResolvedValue({ data: { uuid: 'appointment-1' } }),
+  }
+}
+
+async function loadApi(http: MockHttp) {
+  vi.doMock('@/lib/http', () => ({ http }))
+  return await import('./appointmentApi')
+}
+
+beforeEach(() => {
+  vi.resetModules()
+})
+
+afterEach(() => {
+  vi.doUnmock('@/lib/http')
+})
+
+describe('appointmentApi', () => {
+  it('delegates appointment creation', async () => {
+    const http = makeHttp()
+    const { appointmentApi } = await loadApi(http)
+    const payload = { patient_id: 'patient-1', doctor_id: 'doctor-1', scheduled_at: '2026-05-08T09:00:00Z' }
+
+    await appointmentApi.create(payload)
+
+    expect(http.post).toHaveBeenCalledWith('/appointments', payload)
+  })
+
+  it('builds appointment list requests with pagination and filters', async () => {
+    const http = makeHttp()
+    const { appointmentApi } = await loadApi(http)
+
+    await appointmentApi.list()
+    await appointmentApi.list(2, 30, {
+      doctor_id: 'doctor-1',
+      patient_id: 'patient-1',
+      status: 'scheduled',
+      date: '2026-05-08',
+      start_date: '2026-05-01',
+      end_date: '2026-05-31',
+    })
+
+    expect(http.get).toHaveBeenNthCalledWith(1, '/appointments?page=1&per_page=15')
+    expect(http.get).toHaveBeenNthCalledWith(
+      2,
+      '/appointments?page=2&per_page=30&doctor_id=doctor-1&patient_id=patient-1&status=scheduled&date=2026-05-08&start_date=2026-05-01&end_date=2026-05-31',
+    )
+  })
+
+  it('loads appointment details and clinic doctors', async () => {
+    const http = makeHttp()
+    const { appointmentApi } = await loadApi(http)
+
+    await appointmentApi.get('appointment-1')
+    await appointmentApi.getDoctors()
+
+    expect(http.get).toHaveBeenNthCalledWith(1, '/appointments/appointment-1')
+    expect(http.get).toHaveBeenNthCalledWith(2, '/clinic/doctors')
+  })
+
+  it('delegates appointment state mutations', async () => {
+    const http = makeHttp()
+    const { appointmentApi } = await loadApi(http)
+
+    await appointmentApi.cancel('appointment-1', { reason: 'patient requested' })
+    await appointmentApi.checkIn('appointment-1')
+    await appointmentApi.noShow('appointment-1')
+    await appointmentApi.reschedule('appointment-1', '2026-05-08T10:00:00Z')
+    await appointmentApi.resize('appointment-1', 45)
+
+    expect(http.patch).toHaveBeenNthCalledWith(1, '/appointments/appointment-1/cancel', { reason: 'patient requested' })
+    expect(http.post).toHaveBeenCalledWith('/appointments/appointment-1/check-in')
+    expect(http.patch).toHaveBeenNthCalledWith(2, '/appointments/appointment-1/no-show')
+    expect(http.patch).toHaveBeenNthCalledWith(3, '/appointments/appointment-1/reschedule', { scheduled_at: '2026-05-08T10:00:00Z' })
+    expect(http.patch).toHaveBeenNthCalledWith(4, '/appointments/appointment-1/resize', { duration: 45 })
+  })
+})

--- a/src/domains/billing/api/billingApi.spec.ts
+++ b/src/domains/billing/api/billingApi.spec.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+interface MockHttp {
+  get: ReturnType<typeof vi.fn>
+  post: ReturnType<typeof vi.fn>
+  patch: ReturnType<typeof vi.fn>
+}
+
+function makeHttp(): MockHttp {
+  return {
+    get: vi.fn().mockResolvedValue({ data: {} }),
+    post: vi.fn().mockResolvedValue({ data: { id: 'invoice-1' } }),
+    patch: vi.fn().mockResolvedValue({ data: { id: 'invoice-1' } }),
+  }
+}
+
+async function loadApi(http: MockHttp) {
+  vi.doMock('@/lib/http', () => ({ http }))
+  return await import('./billingApi')
+}
+
+beforeEach(() => {
+  vi.resetModules()
+})
+
+afterEach(() => {
+  vi.doUnmock('@/lib/http')
+})
+
+describe('billingApi', () => {
+  it('builds invoice list requests with optional filters', async () => {
+    const http = makeHttp()
+    const { billingApi } = await loadApi(http)
+
+    await billingApi.list()
+    await billingApi.list({ page: 2, per_page: 25, status: 'paid', search: 'Juan Dela Cruz' })
+
+    expect(http.get).toHaveBeenNthCalledWith(1, '/invoices')
+    expect(http.get).toHaveBeenNthCalledWith(2, '/invoices?page=2&per_page=25&status=paid&search=Juan+Dela+Cruz')
+  })
+
+  it('loads invoice detail, encounter invoice, summary, and pdf metadata', async () => {
+    const http = makeHttp()
+    const { billingApi } = await loadApi(http)
+
+    await billingApi.get('invoice-1')
+    await billingApi.forEncounter('encounter-1')
+    await billingApi.summary()
+    await billingApi.getPdf('invoice-1')
+
+    expect(http.get).toHaveBeenNthCalledWith(1, '/invoices/invoice-1')
+    expect(http.get).toHaveBeenNthCalledWith(2, '/encounters/encounter-1/invoice')
+    expect(http.get).toHaveBeenNthCalledWith(3, '/billing/summary')
+    expect(http.get).toHaveBeenNthCalledWith(4, '/invoices/invoice-1/pdf')
+  })
+
+  it('delegates invoice create and update requests', async () => {
+    const http = makeHttp()
+    const { billingApi } = await loadApi(http)
+    const createPayload = { patient_id: 'patient-1', items: [] }
+    const updatePayload = { notes: 'Updated after discount' }
+
+    await billingApi.create(createPayload)
+    await billingApi.update('invoice-1', updatePayload)
+
+    expect(http.post).toHaveBeenCalledWith('/invoices', createPayload)
+    expect(http.patch).toHaveBeenCalledWith('/invoices/invoice-1', updatePayload)
+  })
+
+  it('delegates invoice payment, void, med cert, and pdf generation requests', async () => {
+    const http = makeHttp()
+    const { billingApi } = await loadApi(http)
+    const paymentPayload = { amount: 500, method: 'cash' }
+    const voidPayload = { reason: 'wrong patient' }
+
+    await billingApi.recordPayment('invoice-1', paymentPayload)
+    await billingApi.void('invoice-1', voidPayload)
+    await billingApi.requestMedCert('invoice-1')
+    await billingApi.generatePdf('invoice-1')
+
+    expect(http.post).toHaveBeenNthCalledWith(1, '/invoices/invoice-1/payments', paymentPayload)
+    expect(http.patch).toHaveBeenCalledWith('/invoices/invoice-1/void', voidPayload)
+    expect(http.post).toHaveBeenNthCalledWith(2, '/invoices/invoice-1/request-medcert')
+    expect(http.post).toHaveBeenNthCalledWith(3, '/invoices/invoice-1/pdf')
+  })
+})

--- a/src/domains/schedule/api/scheduleApi.spec.ts
+++ b/src/domains/schedule/api/scheduleApi.spec.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+interface MockHttp {
+  get: ReturnType<typeof vi.fn>
+  put: ReturnType<typeof vi.fn>
+  post: ReturnType<typeof vi.fn>
+  patch: ReturnType<typeof vi.fn>
+}
+
+function makeHttp(): MockHttp {
+  return {
+    get: vi.fn().mockResolvedValue({ data: {} }),
+    put: vi.fn().mockResolvedValue({ data: {} }),
+    post: vi.fn().mockResolvedValue({ data: {} }),
+    patch: vi.fn().mockResolvedValue({ data: {} }),
+  }
+}
+
+async function loadApi(http: MockHttp) {
+  vi.doMock('@/lib/http', () => ({ http }))
+  return await import('./scheduleApi')
+}
+
+beforeEach(() => {
+  vi.resetModules()
+})
+
+afterEach(() => {
+  vi.doUnmock('@/lib/http')
+})
+
+describe('scheduleApi', () => {
+  it('loads and upserts working schedules', async () => {
+    const http = makeHttp()
+    const { scheduleApi } = await loadApi(http)
+    const payload = { timezone: 'Asia/Manila', days: [] }
+
+    await scheduleApi.getSchedule('doctor-1')
+    await scheduleApi.upsertSchedule('doctor-1', payload)
+
+    expect(http.get).toHaveBeenCalledWith('/schedules/doctor-1')
+    expect(http.put).toHaveBeenCalledWith('/schedules/doctor-1', payload)
+  })
+
+  it('builds calendar block and availability query params', async () => {
+    const http = makeHttp()
+    const { scheduleApi } = await loadApi(http)
+
+    await scheduleApi.listAllBlocks('2026-05-01', '2026-05-31')
+    await scheduleApi.getAvailability('doctor-1', '2026-05-08')
+
+    expect(http.get).toHaveBeenNthCalledWith(1, '/calendar-blocks?start=2026-05-01&end=2026-05-31')
+    expect(http.get).toHaveBeenNthCalledWith(2, '/availability?user_id=doctor-1&date=2026-05-08')
+  })
+
+  it('delegates calendar block mutations', async () => {
+    const http = makeHttp()
+    const { scheduleApi } = await loadApi(http)
+    const createPayload = { starts_at: '2026-05-08T09:00:00Z', ends_at: '2026-05-08T10:00:00Z', reason: 'training' }
+    const updatePayload = { reason: 'clinic meeting' }
+
+    await scheduleApi.createBlock(createPayload)
+    await scheduleApi.updateBlock('block-1', updatePayload)
+
+    expect(http.post).toHaveBeenCalledWith('/calendar-blocks', createPayload)
+    expect(http.patch).toHaveBeenCalledWith('/calendar-blocks/block-1', updatePayload)
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -43,10 +43,12 @@ export default defineConfig({
       include: [
         'src/components/layout/{GracePeriodBanner,TrialBanner}.vue',
         'src/components/shared/{FeatureGate,UpgradePrompt}.vue',
+        'src/domains/appointment/api/appointmentApi.ts',
         'src/domains/appointment/components/{AppointmentCard,AppointmentStatusBadge}.vue',
         'src/domains/appointment/stores/**/*.ts',
         'src/domains/auth/components/{CredentialsForm,PasswordForm}.vue',
         'src/domains/auth/stores/**/*.ts',
+        'src/domains/billing/api/billingApi.ts',
         'src/domains/audit-log/api/auditLogApi.ts',
         'src/domains/clinic/api/clinicApi.ts',
         'src/domains/consultation/composables/useFeeDiscount.ts',
@@ -62,6 +64,7 @@ export default defineConfig({
         'src/domains/queue/components/{QueueCard,QueueStatusBadge}.vue',
         'src/domains/queue/stores/**/*.ts',
         'src/domains/roles/api/roleApi.ts',
+        'src/domains/schedule/api/scheduleApi.ts',
         'src/domains/schedule/components/{BreakEditor,DayScheduleRow}.vue',
         'src/domains/schedule/stores/**/*.ts',
         'src/domains/service/api/serviceApi.ts',
@@ -90,7 +93,7 @@ export default defineConfig({
         branches: 70,
         // Vue template handlers are counted as generated functions; raise this
         // phase-by-phase as more component interaction tests land.
-        functions: 86,
+        functions: 88,
         statements: 70,
       },
     },


### PR DESCRIPTION
## Summary

Extends the frontend coverage baseline into appointment, billing, and schedule API clients.

## Changes

- Adds appointment API tests for list query construction, detail/doctor loading, and create/state mutation delegation.
- Adds billing API tests for invoice list filters, detail/summary/pdf loading, and invoice mutation delegation.
- Adds schedule API tests for schedule loading/upsert, calendar block query construction, availability queries, and block mutations.
- Expands the Vitest coverage gate to include appointment, billing, and schedule API modules.
- Raises the global function coverage threshold from 86% to 88%.

## Validation

- `TEST_CMD="npx vitest run src/domains/appointment/api/appointmentApi.spec.ts src/domains/billing/api/billingApi.spec.ts src/domains/schedule/api/scheduleApi.spec.ts" docker compose -p clinicapp-fe-tests-p11 -f docker-compose.test.yml run --rm frontend-test`
  - Passed: 3 files, 11 tests.
- `TEST_CMD="npm run test:coverage" docker compose -p clinicapp-fe-tests-p11 -f docker-compose.test.yml run --rm frontend-test`
  - Passed: 57 files, 474 tests passed, 1 skipped.
  - Phase 11 coverage gate: lines/statements 97.73%, branches 89.17%, functions 88.11%.
- `TEST_CMD="npx playwright test e2e/dental-fee-schedule.spec.ts" docker compose -p clinicapp-fe-tests-p11 -f docker-compose.test.yml run --rm frontend-feature-test`
  - Clean skipped: 3 tests skipped because local E2E credentials were not set.
- `TEST_CMD="npm run build" docker compose -p clinicapp-fe-tests-p11 -f docker-compose.test.yml run --rm frontend-test`
  - Passed. Existing slim-container git warning and bundle-size warnings remain.
