### PR TITLE
Add phase 12 queue API coverage

### DIFF
--- a/src/domains/queue/api/centrifugoApi.spec.ts
+++ b/src/domains/queue/api/centrifugoApi.spec.ts
@@ -1,0 +1,46 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+interface MockHttp {
+  get: ReturnType<typeof vi.fn>
+  post: ReturnType<typeof vi.fn>
+}
+
+function makeHttp(): MockHttp {
+  return {
+    get: vi.fn().mockResolvedValue({ token: 'connection-token' }),
+    post: vi.fn().mockResolvedValue({ token: 'subscription-token' }),
+  }
+}
+
+async function loadApi(http: MockHttp) {
+  vi.doMock('@/lib/http', () => ({ http }))
+  return await import('./centrifugoApi')
+}
+
+beforeEach(() => {
+  vi.resetModules()
+})
+
+afterEach(() => {
+  vi.doUnmock('@/lib/http')
+})
+
+describe('centrifugoApi', () => {
+  it('loads a connection token', async () => {
+    const http = makeHttp()
+    const { centrifugoApi } = await loadApi(http)
+
+    await centrifugoApi.getConnectionToken()
+
+    expect(http.get).toHaveBeenCalledWith('/centrifugo/connection-token')
+  })
+
+  it('loads a subscription token for a channel', async () => {
+    const http = makeHttp()
+    const { centrifugoApi } = await loadApi(http)
+
+    await centrifugoApi.getSubscriptionToken('queue:clinic-1')
+
+    expect(http.post).toHaveBeenCalledWith('/centrifugo/subscription-token', { channel: 'queue:clinic-1' })
+  })
+})

--- a/src/domains/queue/api/queueApi.spec.ts
+++ b/src/domains/queue/api/queueApi.spec.ts
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+interface MockHttp {
+  get: ReturnType<typeof vi.fn>
+  post: ReturnType<typeof vi.fn>
+  patch: ReturnType<typeof vi.fn>
+  delete: ReturnType<typeof vi.fn>
+}
+
+function makeHttp(): MockHttp {
+  return {
+    get: vi.fn().mockResolvedValue({ data: [] }),
+    post: vi.fn().mockResolvedValue({ data: { uuid: 'queue-1' } }),
+    patch: vi.fn().mockResolvedValue({ data: { uuid: 'queue-1' } }),
+    delete: vi.fn().mockResolvedValue(undefined),
+  }
+}
+
+async function loadApi(http: MockHttp) {
+  vi.doMock('@/lib/http', () => ({ http }))
+  return await import('./queueApi')
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  vi.stubEnv('VITE_API_URL', 'https://api.example.test')
+})
+
+afterEach(() => {
+  vi.doUnmock('@/lib/http')
+  vi.unstubAllEnvs()
+  vi.unstubAllGlobals()
+})
+
+describe('queueApi', () => {
+  it('builds queue list requests with optional filters', async () => {
+    const http = makeHttp()
+    const { queueApi } = await loadApi(http)
+
+    await queueApi.list()
+    await queueApi.list({ doctor_id: 'doctor-1', status: 'waiting' })
+
+    expect(http.get).toHaveBeenNthCalledWith(1, '/queue')
+    expect(http.get).toHaveBeenNthCalledWith(2, '/queue?doctor_id=doctor-1&status=waiting')
+  })
+
+  it('delegates walk-in and queue state mutations', async () => {
+    const http = makeHttp()
+    const { queueApi } = await loadApi(http)
+    const payload = { patient_id: 'patient-1', doctor_id: 'doctor-1', chief_complaint: 'Fever' }
+
+    await queueApi.walkIn(payload)
+    await queueApi.call('queue-1')
+    await queueApi.complete('queue-1')
+    await queueApi.cancel('queue-1')
+
+    expect(http.post).toHaveBeenCalledWith('/queue/walk-in', payload)
+    expect(http.patch).toHaveBeenNthCalledWith(1, '/queue/queue-1/call')
+    expect(http.patch).toHaveBeenNthCalledWith(2, '/queue/queue-1/complete')
+    expect(http.patch).toHaveBeenNthCalledWith(3, '/queue/queue-1/cancel')
+  })
+
+  it('loads public queue display data', async () => {
+    const http = makeHttp()
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ clinic_name: 'MediFlow', queue: [] }),
+    })
+    vi.stubGlobal('fetch', fetch)
+    const { queueApi } = await loadApi(http)
+
+    await expect(queueApi.getDisplay('display-token')).resolves.toEqual({ clinic_name: 'MediFlow', queue: [] })
+
+    expect(fetch).toHaveBeenCalledWith('https://api.example.test/queue-display/display-token', {
+      headers: { Accept: 'application/json' },
+    })
+  })
+
+  it('refreshes public queue display Centrifugo tokens', async () => {
+    const http = makeHttp()
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ connection_token: 'connection', subscription_token: 'subscription' }),
+    })
+    vi.stubGlobal('fetch', fetch)
+    const { queueApi } = await loadApi(http)
+
+    await expect(queueApi.refreshDisplayTokens('display-token')).resolves.toEqual({
+      connection_token: 'connection',
+      subscription_token: 'subscription',
+    })
+
+    expect(fetch).toHaveBeenCalledWith('https://api.example.test/queue-display/display-token/centrifugo-tokens', {
+      method: 'POST',
+      headers: { Accept: 'application/json' },
+    })
+  })
+
+  it('maps public display fetch failures to stable errors', async () => {
+    const http = makeHttp()
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: false, status: 404 })
+      .mockResolvedValueOnce({ ok: false, status: 500 })
+      .mockResolvedValueOnce({ ok: false, status: 404 })
+      .mockResolvedValueOnce({ ok: false, status: 500 })
+    vi.stubGlobal('fetch', fetch)
+    const { queueApi } = await loadApi(http)
+
+    await expect(queueApi.getDisplay('missing')).rejects.toThrow('INVALID_TOKEN')
+    await expect(queueApi.getDisplay('broken')).rejects.toThrow('NETWORK_ERROR')
+    await expect(queueApi.refreshDisplayTokens('missing')).rejects.toThrow('INVALID_TOKEN')
+    await expect(queueApi.refreshDisplayTokens('broken')).rejects.toThrow('NETWORK_ERROR')
+  })
+
+  it('delegates display token management requests', async () => {
+    const http = makeHttp()
+    const { queueApi } = await loadApi(http)
+
+    await queueApi.getDisplayTokenStatus()
+    await queueApi.generateDisplayToken()
+    await queueApi.revokeDisplayToken()
+
+    expect(http.get).toHaveBeenCalledWith('/clinic/queue-display-token')
+    expect(http.post).toHaveBeenCalledWith('/clinic/queue-display-token')
+    expect(http.delete).toHaveBeenCalledWith('/clinic/queue-display-token')
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -61,6 +61,7 @@ export default defineConfig({
         'src/domains/patient/components/EditPatientDialog.vue',
         'src/domains/patient/composables/usePatientSync.ts',
         'src/domains/patient/utils/profileCompleteness.ts',
+        'src/domains/queue/api/{centrifugoApi,queueApi}.ts',
         'src/domains/queue/components/{QueueCard,QueueStatusBadge}.vue',
         'src/domains/queue/stores/**/*.ts',
         'src/domains/roles/api/roleApi.ts',


### PR DESCRIPTION
## Summary

Extends the frontend coverage baseline into queue API clients, including public queue-display endpoints.

## Changes

- Adds queue API tests for list query construction and walk-in/call/complete/cancel delegation.
- Adds queue-display fetch tests for public display data, Centrifugo token refresh, and stable error mapping.
- Adds display token management API tests.
- Adds Centrifugo API tests for connection and subscription token delegation.
- Expands the Vitest coverage gate to include queue API modules.

## Validation

- `TEST_CMD="npx vitest run src/domains/queue/api/queueApi.spec.ts src/domains/queue/api/centrifugoApi.spec.ts" docker compose -p clinicapp-fe-tests-p12 -f docker-compose.test.yml run --rm frontend-test`
  - Passed: 2 files, 8 tests.
- `TEST_CMD="npm run test:coverage" docker compose -p clinicapp-fe-tests-p12 -f docker-compose.test.yml run --rm frontend-test`
  - Passed: 59 files, 482 tests passed, 1 skipped.
  - Phase 12 coverage gate: lines/statements 97.79%, branches 89.56%, functions 88.78%.
  - Function threshold remains 88% because actual coverage is below the next whole-percent threshold.
- `TEST_CMD="npx playwright test e2e/dental-fee-schedule.spec.ts" docker compose -p clinicapp-fe-tests-p12 -f docker-compose.test.yml run --rm frontend-feature-test`
  - Clean skipped: 3 tests skipped because local E2E credentials were not set.
- `TEST_CMD="npm run build" docker compose -p clinicapp-fe-tests-p12 -f docker-compose.test.yml run --rm frontend-test`
  - Passed. Existing slim-container git warning and bundle-size warnings remain.
