### PR TITLE
Add phase 13 consultation API coverage

### DIFF
--- a/src/domains/consultation/api/consultationApi.spec.ts
+++ b/src/domains/consultation/api/consultationApi.spec.ts
@@ -1,0 +1,46 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+interface MockHttp {
+  get: ReturnType<typeof vi.fn>
+  post: ReturnType<typeof vi.fn>
+}
+
+function makeHttp(): MockHttp {
+  return {
+    get: vi.fn().mockResolvedValue({ data: [] }),
+    post: vi.fn().mockResolvedValue({ data: { medcert_requested_by: 'doctor-1', medcert_requested_at: '2026-05-07T04:00:00Z' } }),
+  }
+}
+
+async function loadApi(http: MockHttp) {
+  vi.doMock('@/lib/http', () => ({ http }))
+  return await import('./consultationApi')
+}
+
+beforeEach(() => {
+  vi.resetModules()
+})
+
+afterEach(() => {
+  vi.doUnmock('@/lib/http')
+})
+
+describe('consultationApi', () => {
+  it('encodes diagnosis search queries', async () => {
+    const http = makeHttp()
+    const { consultationApi } = await loadApi(http)
+
+    await consultationApi.searchDiagnoses('acute fever + cough')
+
+    expect(http.get).toHaveBeenCalledWith('/diagnoses/search?q=acute%20fever%20%2B%20cough')
+  })
+
+  it('requests a medical certificate for an encounter', async () => {
+    const http = makeHttp()
+    const { consultationApi } = await loadApi(http)
+
+    await consultationApi.requestMedCert('encounter-1')
+
+    expect(http.post).toHaveBeenCalledWith('/encounters/encounter-1/request-medcert', {})
+  })
+})

--- a/src/domains/consultation/api/documentApi.spec.ts
+++ b/src/domains/consultation/api/documentApi.spec.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+interface MockHttp {
+  get: ReturnType<typeof vi.fn>
+  post: ReturnType<typeof vi.fn>
+}
+
+function makeHttp(): MockHttp {
+  return {
+    get: vi.fn().mockResolvedValue({ data: { url: 'https://signed.example.test/document.pdf' } }),
+    post: vi.fn().mockResolvedValue({ data: { id: 'document-1' } }),
+  }
+}
+
+async function loadApi(http: MockHttp) {
+  vi.doMock('@/lib/http', () => ({ http }))
+  return await import('./documentApi')
+}
+
+beforeEach(() => {
+  vi.resetModules()
+})
+
+afterEach(() => {
+  vi.doUnmock('@/lib/http')
+})
+
+describe('documentApi', () => {
+  it('generates documents with and without metadata', async () => {
+    const http = makeHttp()
+    const { documentApi } = await loadApi(http)
+
+    await documentApi.generate('encounter-1', 'prescription')
+    await documentApi.generate('encounter-1', 'lab-request', { copy: 'patient' })
+
+    expect(http.post).toHaveBeenNthCalledWith(1, '/encounters/encounter-1/documents', { type: 'prescription' })
+    expect(http.post).toHaveBeenNthCalledWith(2, '/encounters/encounter-1/documents', { type: 'lab-request', meta: { copy: 'patient' } })
+  })
+
+  it('lists generated encounter documents', async () => {
+    const http = makeHttp()
+    const { documentApi } = await loadApi(http)
+
+    await documentApi.list('encounter-1')
+
+    expect(http.get).toHaveBeenCalledWith('/encounters/encounter-1/documents')
+  })
+
+  it('unwraps signed document URLs', async () => {
+    const http = makeHttp()
+    const { documentApi } = await loadApi(http)
+
+    await expect(documentApi.getSignedUrl('document-1')).resolves.toBe('https://signed.example.test/document.pdf')
+
+    expect(http.get).toHaveBeenCalledWith('/documents/document-1/signed-url')
+  })
+})

--- a/src/domains/consultation/api/labOrderApi.spec.ts
+++ b/src/domains/consultation/api/labOrderApi.spec.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+interface MockHttp {
+  get: ReturnType<typeof vi.fn>
+  post: ReturnType<typeof vi.fn>
+  patch: ReturnType<typeof vi.fn>
+  delete: ReturnType<typeof vi.fn>
+  upload: ReturnType<typeof vi.fn>
+}
+
+function makeHttp(): MockHttp {
+  return {
+    get: vi.fn().mockResolvedValue({ data: [] }),
+    post: vi.fn().mockResolvedValue({ data: { id: 'lab-order-1' } }),
+    patch: vi.fn().mockResolvedValue({ data: { id: 'lab-order-1' } }),
+    delete: vi.fn().mockResolvedValue({ data: { id: 'lab-order-1' } }),
+    upload: vi.fn().mockResolvedValue({ data: { id: 'lab-order-1' } }),
+  }
+}
+
+async function loadApi(http: MockHttp) {
+  vi.doMock('@/lib/http', () => ({ http }))
+  return await import('./labOrderApi')
+}
+
+beforeEach(() => {
+  vi.resetModules()
+})
+
+afterEach(() => {
+  vi.doUnmock('@/lib/http')
+})
+
+describe('labOrderApi', () => {
+  it('loads and creates encounter lab orders', async () => {
+    const http = makeHttp()
+    const { labOrderApi } = await loadApi(http)
+    const items = [{ description: 'CBC', instruction: 'Fasting not required' }]
+
+    await labOrderApi.getForEncounter('encounter-1')
+    await labOrderApi.create('encounter-1', items)
+
+    expect(http.get).toHaveBeenCalledWith('/encounters/encounter-1/lab-order')
+    expect(http.post).toHaveBeenCalledWith('/encounters/encounter-1/lab-order', { items })
+  })
+
+  it('delegates lab order item mutations', async () => {
+    const http = makeHttp()
+    const { labOrderApi } = await loadApi(http)
+    const createPayload = { description: 'Urinalysis', instruction: 'Morning sample' }
+    const updatePayload = { instruction: 'Repeat if contaminated' }
+
+    await labOrderApi.addItem('lab-order-1', createPayload)
+    await labOrderApi.updateItem('lab-order-1', 'item-1', updatePayload)
+    await labOrderApi.removeItem('lab-order-1', 'item-1')
+
+    expect(http.post).toHaveBeenCalledWith('/lab-orders/lab-order-1/items', createPayload)
+    expect(http.patch).toHaveBeenCalledWith('/lab-orders/lab-order-1/items/item-1', updatePayload)
+    expect(http.delete).toHaveBeenCalledWith('/lab-orders/lab-order-1/items/item-1')
+  })
+
+  it('uploads lab result files as form data', async () => {
+    const http = makeHttp()
+    const { labOrderApi } = await loadApi(http)
+    const file = new File(['result'], 'result.pdf', { type: 'application/pdf' })
+
+    await labOrderApi.uploadResult('lab-order-1', 'item-1', file)
+
+    expect(http.upload).toHaveBeenCalledWith('/lab-orders/lab-order-1/items/item-1/result', expect.any(FormData))
+    const formData = http.upload.mock.calls[0][1] as FormData
+    expect(formData.get('file')).toBe(file)
+  })
+
+  it('encodes system lab item search terms', async () => {
+    const http = makeHttp()
+    const { labOrderApi } = await loadApi(http)
+
+    await labOrderApi.searchSystemItems('blood sugar + fasting')
+
+    expect(http.get).toHaveBeenCalledWith('/system/lab-items?q=blood%20sugar%20%2B%20fasting')
+  })
+})

--- a/src/domains/consultation/api/prescriptionApi.spec.ts
+++ b/src/domains/consultation/api/prescriptionApi.spec.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+interface MockHttp {
+  get: ReturnType<typeof vi.fn>
+  post: ReturnType<typeof vi.fn>
+  patch: ReturnType<typeof vi.fn>
+  delete: ReturnType<typeof vi.fn>
+}
+
+function makeHttp(): MockHttp {
+  return {
+    get: vi.fn().mockResolvedValue({ data: { id: 'prescription-1' } }),
+    post: vi.fn().mockResolvedValue({ data: { id: 'prescription-1' } }),
+    patch: vi.fn().mockResolvedValue({ data: { id: 'prescription-1' } }),
+    delete: vi.fn().mockResolvedValue({ data: { id: 'prescription-1' } }),
+  }
+}
+
+async function loadApi(http: MockHttp) {
+  vi.doMock('@/lib/http', () => ({ http }))
+  return await import('./prescriptionApi')
+}
+
+beforeEach(() => {
+  vi.resetModules()
+})
+
+afterEach(() => {
+  vi.doUnmock('@/lib/http')
+})
+
+describe('prescriptionApi', () => {
+  it('loads and creates encounter prescriptions', async () => {
+    const http = makeHttp()
+    const { prescriptionApi } = await loadApi(http)
+    const items = [{ drug_name: 'Paracetamol', dose: '500mg', frequency: 'TID', duration: '3 days' }]
+
+    await prescriptionApi.getForEncounter('encounter-1')
+    await prescriptionApi.create('encounter-1', items)
+
+    expect(http.get).toHaveBeenCalledWith('/encounters/encounter-1/prescription')
+    expect(http.post).toHaveBeenCalledWith('/encounters/encounter-1/prescription', { items })
+  })
+
+  it('delegates prescription item mutations', async () => {
+    const http = makeHttp()
+    const { prescriptionApi } = await loadApi(http)
+    const createPayload = { drug_name: 'Amoxicillin', dose: '500mg', frequency: 'TID', quantity: 21 }
+    const updatePayload = { instructions: 'Take after meals', quantity: 18 }
+
+    await prescriptionApi.addItem('prescription-1', createPayload)
+    await prescriptionApi.updateItem('prescription-1', 'item-1', updatePayload)
+    await prescriptionApi.removeItem('prescription-1', 'item-1')
+
+    expect(http.post).toHaveBeenCalledWith('/prescriptions/prescription-1/items', createPayload)
+    expect(http.patch).toHaveBeenCalledWith('/prescriptions/prescription-1/items/item-1', updatePayload)
+    expect(http.delete).toHaveBeenCalledWith('/prescriptions/prescription-1/items/item-1')
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -51,6 +51,7 @@ export default defineConfig({
         'src/domains/billing/api/billingApi.ts',
         'src/domains/audit-log/api/auditLogApi.ts',
         'src/domains/clinic/api/clinicApi.ts',
+        'src/domains/consultation/api/{consultationApi,documentApi,labOrderApi,prescriptionApi}.ts',
         'src/domains/consultation/composables/useFeeDiscount.ts',
         'src/domains/consumable/api/consumableApi.ts',
         'src/domains/dashboard/api/dashboardApi.ts',
@@ -94,7 +95,7 @@ export default defineConfig({
         branches: 70,
         // Vue template handlers are counted as generated functions; raise this
         // phase-by-phase as more component interaction tests land.
-        functions: 88,
+        functions: 89,
         statements: 70,
       },
     },


### PR DESCRIPTION
## Summary

Extends the frontend coverage baseline into consultation API clients.

## Changes

- Adds consultation API tests for diagnosis search encoding and med-cert request delegation.
- Adds document API tests for generation payloads, encounter document listing, and signed URL unwrapping.
- Adds lab order API tests for encounter lab orders, item mutations, result upload FormData, and system item search encoding.
- Adds prescription API tests for encounter prescriptions and prescription item mutations.
- Expands the Vitest coverage gate to include consultation API modules.
- Raises the global function coverage threshold from 88% to 89%.

## Validation

- `TEST_CMD="npx vitest run src/domains/consultation/api/consultationApi.spec.ts src/domains/consultation/api/documentApi.spec.ts src/domains/consultation/api/labOrderApi.spec.ts src/domains/consultation/api/prescriptionApi.spec.ts" docker compose -p clinicapp-fe-tests-p13 -f docker-compose.test.yml run --rm frontend-test`
  - Passed: 4 files, 11 tests.
- `TEST_CMD="npm run test:coverage" docker compose -p clinicapp-fe-tests-p13 -f docker-compose.test.yml run --rm frontend-test`
  - Passed: 63 files, 493 tests passed, 1 skipped.
  - Phase 13 coverage gate: lines/statements 97.89%, branches 89.82%, functions 89.61%.
- `TEST_CMD="npx playwright test e2e/dental-fee-schedule.spec.ts" docker compose -p clinicapp-fe-tests-p13 -f docker-compose.test.yml run --rm frontend-feature-test`
  - Clean skipped: 3 tests skipped because local E2E credentials were not set.
- `TEST_CMD="npm run build" docker compose -p clinicapp-fe-tests-p13 -f docker-compose.test.yml run --rm frontend-test`
  - Passed. Existing slim-container git warning and bundle-size warnings remain.
