### PR TITLE
Add phase 16 subscription API coverage

### DIFF
--- a/src/domains/subscription/api/subscriptionApi.spec.ts
+++ b/src/domains/subscription/api/subscriptionApi.spec.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+interface MockHttp {
+  get: ReturnType<typeof vi.fn>
+  post: ReturnType<typeof vi.fn>
+}
+
+function makeHttp(): MockHttp {
+  return {
+    get: vi.fn().mockResolvedValue({ data: {} }),
+    post: vi.fn().mockResolvedValue({ message: 'ok' }),
+  }
+}
+
+async function loadApi(http: MockHttp) {
+  vi.doMock('@/lib/http', () => ({ http }))
+  return await import('./subscriptionApi')
+}
+
+beforeEach(() => {
+  vi.resetModules()
+})
+
+afterEach(() => {
+  vi.doUnmock('@/lib/http')
+})
+
+describe('subscriptionApi', () => {
+  it('creates pro checkout sessions', async () => {
+    const http = makeHttp()
+    const { subscriptionApi } = await loadApi(http)
+
+    await subscriptionApi.createCheckout()
+
+    expect(http.post).toHaveBeenCalledWith('/subscription/checkout', { plan: 'pro' })
+  })
+
+  it('loads subscription status and paginated payment history', async () => {
+    const http = makeHttp()
+    const { subscriptionApi } = await loadApi(http)
+
+    await subscriptionApi.getStatus()
+    await subscriptionApi.getHistory()
+    await subscriptionApi.getHistory(3, 25)
+
+    expect(http.get).toHaveBeenNthCalledWith(1, '/subscription/status')
+    expect(http.get).toHaveBeenNthCalledWith(2, '/subscription/history?page=1&per_page=10')
+    expect(http.get).toHaveBeenNthCalledWith(3, '/subscription/history?page=3&per_page=25')
+  })
+
+  it('delegates cancellation and reactivation requests', async () => {
+    const http = makeHttp()
+    const { subscriptionApi } = await loadApi(http)
+
+    await subscriptionApi.cancel()
+    await subscriptionApi.reactivate()
+
+    expect(http.post).toHaveBeenNthCalledWith(1, '/subscription/cancel')
+    expect(http.post).toHaveBeenNthCalledWith(2, '/subscription/reactivate')
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -72,6 +72,7 @@ export default defineConfig({
         'src/domains/schedule/components/{BreakEditor,DayScheduleRow}.vue',
         'src/domains/schedule/stores/**/*.ts',
         'src/domains/service/api/serviceApi.ts',
+        'src/domains/subscription/api/subscriptionApi.ts',
         'src/domains/subscription/components/{PricingCard,SubscriptionStatus}.vue',
         'src/domains/subscription/stores/**/*.ts',
         'src/domains/team/api/teamApi.ts',


### PR DESCRIPTION
## Summary

Extends the frontend coverage baseline into the subscription API client.

## Changes

- Adds subscription API tests for pro checkout creation.
- Adds status and paginated payment history request coverage.
- Adds cancellation and reactivation endpoint coverage.
- Expands the Vitest coverage gate to include `subscriptionApi.ts`.

## Validation

- `TEST_CMD="npx vitest run src/domains/subscription/api/subscriptionApi.spec.ts" docker compose -p clinicapp-fe-tests-p16 -f docker-compose.test.yml run --rm frontend-test`
  - Passed: 1 file, 3 tests.
- `TEST_CMD="npm run test:coverage" docker compose -p clinicapp-fe-tests-p16 -f docker-compose.test.yml run --rm frontend-test`
  - Passed: 66 files, 509 tests passed, 1 skipped.
  - Phase 16 coverage gate: lines/statements 98.01%, branches 90.39%, functions 90.97%.
- `TEST_CMD="npx playwright test e2e/dental-fee-schedule.spec.ts" docker compose -p clinicapp-fe-tests-p16 -f docker-compose.test.yml run --rm frontend-feature-test`
  - Clean skipped: 3 tests skipped because local E2E credentials were not set.
- `TEST_CMD="npm run build" docker compose -p clinicapp-fe-tests-p16 -f docker-compose.test.yml run --rm frontend-test`
  - Passed. Existing slim-container git warning and bundle-size warnings remain.
