### PR TITLE
Add phase 18 API helper coverage

### DIFF
--- a/src/api/centrifugoApi.spec.ts
+++ b/src/api/centrifugoApi.spec.ts
@@ -1,0 +1,46 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+interface MockHttp {
+  get: ReturnType<typeof vi.fn>
+  post: ReturnType<typeof vi.fn>
+}
+
+function makeHttp(): MockHttp {
+  return {
+    get: vi.fn().mockResolvedValue({ token: 'connection-token' }),
+    post: vi.fn().mockResolvedValue({ token: 'subscription-token' }),
+  }
+}
+
+async function loadApi(http: MockHttp) {
+  vi.doMock('@/lib/http', () => ({ http }))
+  return await import('./centrifugoApi')
+}
+
+beforeEach(() => {
+  vi.resetModules()
+})
+
+afterEach(() => {
+  vi.doUnmock('@/lib/http')
+})
+
+describe('centrifugoApi', () => {
+  it('loads connection tokens', async () => {
+    const http = makeHttp()
+    const { centrifugoApi } = await loadApi(http)
+
+    await centrifugoApi.getConnectionToken()
+
+    expect(http.get).toHaveBeenCalledWith('/centrifugo/connection-token')
+  })
+
+  it('requests subscription tokens for a channel', async () => {
+    const http = makeHttp()
+    const { centrifugoApi } = await loadApi(http)
+
+    await centrifugoApi.getSubscriptionToken('clinic:clinic-1')
+
+    expect(http.post).toHaveBeenCalledWith('/centrifugo/subscription-token', { channel: 'clinic:clinic-1' })
+  })
+})

--- a/src/domains/patient/api/addressApi.spec.ts
+++ b/src/domains/patient/api/addressApi.spec.ts
@@ -1,0 +1,44 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+interface MockHttp {
+  get: ReturnType<typeof vi.fn>
+}
+
+function makeHttp(): MockHttp {
+  return {
+    get: vi.fn().mockResolvedValue({ data: [] }),
+  }
+}
+
+async function loadApi(http: MockHttp) {
+  vi.doMock('@/lib/http', () => ({ http }))
+  return await import('./addressApi')
+}
+
+beforeEach(() => {
+  vi.resetModules()
+})
+
+afterEach(() => {
+  vi.doUnmock('@/lib/http')
+})
+
+describe('addressApi', () => {
+  it('builds lookup requests with required type only', async () => {
+    const http = makeHttp()
+    const { addressApi } = await loadApi(http)
+
+    await addressApi.lookup('region')
+
+    expect(http.get).toHaveBeenCalledWith('/address/lookup?type=region')
+  })
+
+  it('includes parent code when looking up child addresses', async () => {
+    const http = makeHttp()
+    const { addressApi } = await loadApi(http)
+
+    await addressApi.lookup('city', 'PH-00 + NCR')
+
+    expect(http.get).toHaveBeenCalledWith('/address/lookup?type=city&parent_code=PH-00+%2B+NCR')
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -41,6 +41,7 @@ export default defineConfig({
       // currently covered by Vitest. Broaden this list phase-by-phase as new
       // workflow tests land, instead of counting the entire app at once.
       include: [
+        'src/api/centrifugoApi.ts',
         'src/components/layout/{GracePeriodBanner,TrialBanner}.vue',
         'src/components/shared/{FeatureGate,UpgradePrompt}.vue',
         'src/domains/appointment/api/appointmentApi.ts',
@@ -62,6 +63,7 @@ export default defineConfig({
         'src/domains/medicine/api/medicineApi.ts',
         'src/domains/message/api/messageApi.ts',
         'src/domains/notification/api/notificationApi.ts',
+        'src/domains/patient/api/addressApi.ts',
         'src/domains/patient/components/EditPatientDialog.vue',
         'src/domains/patient/composables/usePatientSync.ts',
         'src/domains/patient/utils/profileCompleteness.ts',


### PR DESCRIPTION
## Summary

Extends the frontend coverage baseline into small API helper clients.

## Changes

- Adds root Centrifugo API tests for connection and subscription token requests.
- Adds patient address lookup tests for type-only and parent-code query construction.
- Expands the Vitest coverage gate to include `src/api/centrifugoApi.ts` and `addressApi.ts`.

## Validation

- `TEST_CMD="npx vitest run src/api/centrifugoApi.spec.ts src/domains/patient/api/addressApi.spec.ts" docker compose -p clinicapp-fe-tests-p18 -f docker-compose.test.yml run --rm frontend-test`
  - Passed: 2 files, 4 tests.
- `TEST_CMD="npm run test:coverage" docker compose -p clinicapp-fe-tests-p18 -f docker-compose.test.yml run --rm frontend-test`
  - Passed: 69 files, 518 tests, 1 skipped.
  - Phase 18 coverage gate: 98.06% statements, 90.65% branches, 91.57% functions, 98.06% lines.
- `TEST_CMD="npx playwright test e2e/dental-fee-schedule.spec.ts" docker compose -p clinicapp-fe-tests-p18 -f docker-compose.test.yml run --rm frontend-feature-test`
  - Clean skipped: 3 tests skipped because local E2E credentials were not set.
- `TEST_CMD="npm run build" docker compose -p clinicapp-fe-tests-p18 -f docker-compose.test.yml run --rm frontend-test`
  - Passed. Existing slim-container git warning and bundle-size warnings remain.
