### PR TITLE
test: cover low frontend coverage areas

### DIFF
--- a/src/domains/appointment/components/AppointmentCard.spec.ts
+++ b/src/domains/appointment/components/AppointmentCard.spec.ts
@@ -80,10 +80,34 @@ describe('AppointmentCard', () => {
     expect(wrapper.text()).toContain('in 1h')
   })
 
+  it.each([
+    ['2026-05-06T01:30:10.000Z', 'now'],
+    ['2026-05-06T01:00:00.000Z', '30m ago'],
+    ['2026-05-08T01:30:00.000Z', 'in 2d'],
+    ['2026-06-20T01:30:00.000Z', 'in 1mo'],
+  ])('renders relative time for %s as %s', (scheduledAt, expected) => {
+    const wrapper = mountCard(makeAppointment({ scheduled_at: scheduledAt }))
+
+    expect(wrapper.text()).toContain(expected)
+  })
+
   it('falls back to Unknown Patient when patient_name is missing', () => {
     const wrapper = mountCard(makeAppointment({ patient_name: null }))
 
     expect(wrapper.text()).toContain('Unknown Patient')
+  })
+
+  it('omits optional appointment details and relative time when they are not applicable', () => {
+    const wrapper = mountCard(makeAppointment({
+      status: 'cancelled',
+      doctor_name: null,
+      reason: null,
+    }))
+
+    expect(wrapper.text()).not.toContain('Dr.')
+    expect(wrapper.text()).not.toContain('Follow-up')
+    expect(wrapper.text()).not.toContain('ago')
+    expect(wrapper.text()).not.toContain('in ')
   })
 
   it('emits click when the card body is selected', async () => {

--- a/src/domains/appointment/stores/appointmentStore.spec.ts
+++ b/src/domains/appointment/stores/appointmentStore.spec.ts
@@ -168,6 +168,19 @@ describe('appointmentStore - list fetching', () => {
       status: 'checked_in',
     })
   })
+
+  it('fetchAllForRange omits status when no status filter is provided', async () => {
+    const appointmentApi = makeAppointmentApi()
+    const { useAppointmentStore } = await loadStore(appointmentApi)
+    const store = useAppointmentStore()
+
+    await store.fetchAllForRange('2026-05-01', '2026-05-31')
+
+    expect(appointmentApi.list).toHaveBeenCalledWith(1, 500, {
+      start_date: '2026-05-01',
+      end_date: '2026-05-31',
+    })
+  })
 })
 
 describe('appointmentStore - board data', () => {
@@ -236,6 +249,69 @@ describe('appointmentStore - board data', () => {
     expect(store.boardError).toBe('Failed to load appointment board.')
     expect(store.isLoadingBoard).toBe(false)
   })
+
+  it('applies doctor and status filters and tolerates availability failures', async () => {
+    const doctorOne = makeDoctor({ id: 'doctor-1' })
+    const doctorTwo = makeDoctor({ id: 'doctor-2' })
+    const appointmentApi = makeAppointmentApi({
+      list: vi.fn().mockResolvedValue(makeListResponse([
+        makeAppointment({ id: 'appt-filtered', doctor_id: 'doctor-2', status: 'checked_in' }),
+      ])),
+      getDoctors: vi.fn().mockResolvedValue({ data: [doctorOne, doctorTwo] }),
+    })
+    const scheduleApi = makeScheduleApi({
+      getAvailability: vi.fn().mockRejectedValue(new Error('availability down')),
+    })
+    const { useAppointmentStore } = await loadStore(appointmentApi, scheduleApi)
+    const store = useAppointmentStore()
+
+    await store.fetchBoardData({
+      date: '2026-05-06',
+      start: '2026-05-01',
+      end: '2026-05-31',
+      doctorFilter: 'doctor-2',
+      statusFilter: 'checked_in',
+    })
+
+    expect(appointmentApi.list).toHaveBeenCalledWith(1, 500, {
+      start_date: '2026-05-01',
+      end_date: '2026-05-31',
+      doctor_id: 'doctor-2',
+      status: 'checked_in',
+    })
+    expect(scheduleApi.getAvailability).toHaveBeenCalledWith('doctor-2', '2026-05-06')
+    expect(store.boardAppointments.map((appointment) => appointment.id)).toEqual(['appt-filtered'])
+    expect(store.boardAvailabilityByDoctor).toEqual({ 'doctor-2': [] })
+    expect(store.boardCalendarBlocks).toEqual([])
+  })
+
+  it('ignores duplicate in-flight board requests for the same parameters', async () => {
+    let resolveList: (value: ReturnType<typeof makeListResponse>) => void = () => {}
+    const appointmentApi = makeAppointmentApi({
+      list: vi.fn().mockImplementation(() => new Promise((resolve) => {
+        resolveList = resolve
+      })),
+    })
+    const { useAppointmentStore } = await loadStore(appointmentApi)
+    const store = useAppointmentStore()
+    const params = {
+      date: '2026-05-06',
+      start: '2026-05-01',
+      end: '2026-05-31',
+      doctorFilter: 'all',
+      statusFilter: 'all',
+    }
+
+    const first = store.fetchBoardData(params)
+    const second = store.fetchBoardData(params)
+
+    await expect(second).resolves.toBeUndefined()
+    expect(appointmentApi.list).toHaveBeenCalledOnce()
+    resolveList(makeListResponse())
+    await first
+    await second
+    expect(store.isLoadingBoard).toBe(false)
+  })
 })
 
 describe('appointmentStore - mutations', () => {
@@ -285,6 +361,22 @@ describe('appointmentStore - mutations', () => {
     expect(store.appointments[0]?.status).toBe('cancelled')
     expect(store.appointments[1]?.id).toBe('appt-2')
     expect(store.current?.status).toBe('cancelled')
+  })
+
+  it('cancelAppointment omits the reason payload and leaves unrelated state unchanged', async () => {
+    const appointmentApi = makeAppointmentApi({
+      cancel: vi.fn().mockResolvedValue({ data: makeAppointment({ id: 'appt-missing', status: 'cancelled' }) }),
+    })
+    const { useAppointmentStore } = await loadStore(appointmentApi)
+    const store = useAppointmentStore()
+    store.appointments = [makeAppointment({ id: 'appt-1' })]
+    store.current = makeAppointment({ id: 'appt-1' })
+
+    await store.cancelAppointment('appt-missing')
+
+    expect(appointmentApi.cancel).toHaveBeenCalledWith('appt-missing', undefined)
+    expect(store.appointments[0]?.id).toBe('appt-1')
+    expect(store.current?.id).toBe('appt-1')
   })
 
   it('checkInAppointment uses the nested appointment payload', async () => {

--- a/src/domains/auth/components/CredentialsForm.spec.ts
+++ b/src/domains/auth/components/CredentialsForm.spec.ts
@@ -19,6 +19,7 @@ import { flushPromises } from '@vue/test-utils'
 import { mountWithDeps } from '@/__tests__/helpers/mountWithDeps'
 import { setupTestPinia } from '@/__tests__/helpers/createPinia'
 import { useAuthStore } from '@/domains/auth/stores/authStore'
+import { HttpError } from '@/lib/http'
 import CredentialsForm from './CredentialsForm.vue'
 
 const updateProfileSpy = vi.fn().mockResolvedValue(undefined)
@@ -99,6 +100,15 @@ describe('CredentialsForm', () => {
     expect(httpGetSpy).toHaveBeenCalledWith('/specialties')
   })
 
+  it('silently keeps the specialty dropdown empty when the fetch fails', async () => {
+    httpGetSpy.mockRejectedValueOnce(new Error('network down'))
+    const wrapper = mount()
+    await flushPromises()
+
+    expect(httpGetSpy).toHaveBeenCalledWith('/specialties')
+    expect(wrapper.text()).not.toContain('Family Medicine')
+  })
+
   it('blocks submit when PRC license is longer than 50 chars', async () => {
     updateProfileSpy.mockClear()
     const wrapper = mount()
@@ -112,6 +122,38 @@ describe('CredentialsForm', () => {
 
     expect(updateProfileSpy).not.toHaveBeenCalled()
     expect(wrapper.text()).toContain('PRC license number must be no more than 50 characters.')
+  })
+
+  it('blocks submit and renders specialty field validation errors', async () => {
+    updateProfileSpy.mockClear()
+    const wrapper = mount({
+      specialty: 's'.repeat(256),
+      sub_specialty: 'x'.repeat(256),
+    })
+    await flushPromises()
+
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+
+    expect(updateProfileSpy).not.toHaveBeenCalled()
+    expect(wrapper.text()).toContain('Specialty must be no more than 255 characters.')
+    expect(wrapper.text()).toContain('Sub-specialty must be no more than 255 characters.')
+  })
+
+  it('blocks submit and renders PTR and S2 field validation errors', async () => {
+    updateProfileSpy.mockClear()
+    const wrapper = mount()
+    await flushPromises()
+    await wrapper.find('#cred-ptr').setValue('2'.repeat(51))
+    await wrapper.find('#cred-s2').setValue('3'.repeat(51))
+    await flushPromises()
+
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+
+    expect(updateProfileSpy).not.toHaveBeenCalled()
+    expect(wrapper.text()).toContain('PTR number must be no more than 50 characters.')
+    expect(wrapper.text()).toContain('S2 license number must be no more than 50 characters.')
   })
 
   it('submits null for specialty when "none" is selected', async () => {
@@ -145,5 +187,76 @@ describe('CredentialsForm', () => {
     expect(payload.ptr_number).toBeNull()
     expect(payload.s2_license_number).toBeNull()
     expect(payload.sub_specialty).toBeNull()
+  })
+
+  it('submits the selected specialty when it is not "none"', async () => {
+    updateProfileSpy.mockClear()
+    const wrapper = mount({
+      specialty: 'family_medicine',
+      sub_specialty: 'Geriatrics',
+    })
+    await flushPromises()
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+
+    expect(updateProfileSpy).toHaveBeenCalledOnce()
+    const payload = updateProfileSpy.mock.calls[0]?.[0] as Record<string, unknown>
+    expect(payload.specialty).toBe('family_medicine')
+    expect(payload.sub_specialty).toBe('Geriatrics')
+  })
+
+  it('shows the saving state while updateProfile is pending', async () => {
+    let resolveUpdate: (() => void) | undefined
+    updateProfileSpy.mockImplementationOnce(() => new Promise<void>((resolve) => {
+      resolveUpdate = resolve
+    }))
+    const wrapper = mount()
+    await flushPromises()
+
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Saving...')
+
+    resolveUpdate?.()
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Save credentials')
+  })
+
+  it('surfaces 422 field errors from updateProfile', async () => {
+    updateProfileSpy.mockRejectedValueOnce(new HttpError(422, 'Invalid', {
+      message: 'Please review your credentials.',
+      errors: {
+        ptr_number: ['PTR number is invalid.'],
+      },
+    }))
+    const wrapper = mount()
+    await flushPromises()
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Please review your credentials.')
+    expect(wrapper.text()).toContain('PTR number is invalid.')
+  })
+
+  it('uses the fallback validation message for 422 responses without a message', async () => {
+    updateProfileSpy.mockRejectedValueOnce(new HttpError(422, 'Invalid', { errors: {} }))
+    const wrapper = mount()
+    await flushPromises()
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Validation failed.')
+  })
+
+  it('surfaces a generic message when updateProfile fails unexpectedly', async () => {
+    updateProfileSpy.mockRejectedValueOnce(new Error('server unavailable'))
+    const wrapper = mount()
+    await flushPromises()
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('An unexpected error occurred. Please try again.')
   })
 })

--- a/src/domains/auth/components/PasswordForm.spec.ts
+++ b/src/domains/auth/components/PasswordForm.spec.ts
@@ -13,6 +13,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import { flushPromises } from '@vue/test-utils'
 import { mountWithDeps } from '@/__tests__/helpers/mountWithDeps'
+import { HttpError } from '@/lib/http'
 import PasswordForm from './PasswordForm.vue'
 
 // `vi.mock` is hoisted to the top of the file; the spies it references must
@@ -132,5 +133,53 @@ describe('PasswordForm', () => {
     expect(payload.new_password).toBe(btoa('newpass-1234'))
     expect(payload.new_password_confirmation).toBe(btoa('newpass-1234'))
     expect(toastSuccess).toHaveBeenCalledWith('Password changed successfully.')
+  })
+
+  it('surfaces 422 field errors from changePassword', async () => {
+    changePasswordSpy.mockRejectedValueOnce(new HttpError(422, 'Invalid', {
+      message: 'Please review your password.',
+      errors: {
+        current_password: ['Current password is incorrect.'],
+      },
+    }))
+    const wrapper = mountWithDeps(PasswordForm, { global: { stubs: STUBS } })
+
+    await setField(wrapper, 'current-password', 'oldpass1234')
+    await setField(wrapper, 'new-password', 'newpass-1234')
+    await setField(wrapper, 'new-password-confirmation', 'newpass-1234')
+    await flushPromises()
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Please review your password.')
+    expect(wrapper.text()).toContain('Current password is incorrect.')
+  })
+
+  it('uses the fallback validation message for 422 responses without a message', async () => {
+    changePasswordSpy.mockRejectedValueOnce(new HttpError(422, 'Invalid', { errors: {} }))
+    const wrapper = mountWithDeps(PasswordForm, { global: { stubs: STUBS } })
+
+    await setField(wrapper, 'current-password', 'oldpass1234')
+    await setField(wrapper, 'new-password', 'newpass-1234')
+    await setField(wrapper, 'new-password-confirmation', 'newpass-1234')
+    await flushPromises()
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Validation failed.')
+  })
+
+  it('surfaces a generic message when changePassword fails unexpectedly', async () => {
+    changePasswordSpy.mockRejectedValueOnce(new Error('server unavailable'))
+    const wrapper = mountWithDeps(PasswordForm, { global: { stubs: STUBS } })
+
+    await setField(wrapper, 'current-password', 'oldpass1234')
+    await setField(wrapper, 'new-password', 'newpass-1234')
+    await setField(wrapper, 'new-password-confirmation', 'newpass-1234')
+    await flushPromises()
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('An unexpected error occurred. Please try again.')
   })
 })

--- a/src/domains/auth/stores/authStore.spec.ts
+++ b/src/domains/auth/stores/authStore.spec.ts
@@ -232,6 +232,75 @@ describe('authStore — login flow', () => {
     expect(store.memberships).toHaveLength(2)
     expect(store.needsClinicSelection).toBe(true)
   })
+
+  it('fetches user without selecting when memberships are inactive', async () => {
+    const loginResp: LoginResponse = {
+      data: { access_token: 'login-tok', token_type: 'Bearer', expires_in: 3600 },
+      meta: {
+        memberships: [makeMembership({ clinic_id: 'c1', status: 'inactive' })],
+      },
+    }
+    const meResp: MeResponse = {
+      data: makeUser({ current_clinic: null }),
+      meta: { memberships: loginResp.meta.memberships },
+    }
+    const api = makeAuthApi({
+      login: vi.fn().mockResolvedValue(loginResp),
+      me: vi.fn().mockResolvedValue(meResp),
+    })
+
+    const { useAuthStore } = await loadStore(api)
+    const store = useAuthStore()
+    await store.login({ email: 't@example.com', password: 'secret' })
+
+    expect(api.selectClinic).not.toHaveBeenCalled()
+    expect(api.me).toHaveBeenCalled()
+    expect(store.needsClinicSelection).toBe(true)
+  })
+
+  it('forwards google auth, google link, confirm link, and signup calls', async () => {
+    const api = makeAuthApi({
+      googleAuth: vi.fn().mockResolvedValue({
+        data: { access_token: 'google-tok', token_type: 'Bearer', expires_in: 3600 },
+        meta: { memberships: [] },
+      }),
+      confirmGoogleLink: vi.fn().mockResolvedValue({
+        data: { access_token: 'linked-tok', token_type: 'Bearer', expires_in: 3600 },
+        meta: { memberships: [] },
+      }),
+    })
+
+    const { useAuthStore } = await loadStore(api)
+    const store = useAuthStore()
+
+    await store.googleLogin('google-credential', true)
+    await store.requestGoogleLink('link-credential')
+    await store.confirmGoogleLink('t@example.com', '123456', false)
+    await store.signup({
+      first_name: 'Dr',
+      last_name: 'Test',
+      email: 't@example.com',
+      password: 'secret-password',
+      recaptcha_token: 'recaptcha-token',
+    })
+
+    expect(api.googleAuth).toHaveBeenCalledWith({ credential: 'google-credential', remember_me: true })
+    expect(api.requestGoogleLink).toHaveBeenCalledWith({ credential: 'link-credential' })
+    expect(api.confirmGoogleLink).toHaveBeenCalledWith({
+      email: 't@example.com',
+      token: '123456',
+      remember_me: false,
+    })
+    expect(api.signup).toHaveBeenCalledWith({
+      first_name: 'Dr',
+      last_name: 'Test',
+      email: 't@example.com',
+      password: 'secret-password',
+      recaptcha_token: 'recaptcha-token',
+    })
+    expect(api.me).toHaveBeenCalledTimes(2)
+    expect(store.token).toBe('linked-tok')
+  })
 })
 
 describe('authStore — selectClinic', () => {
@@ -335,6 +404,53 @@ describe('authStore — permission + feature helpers', () => {
     expect(store.getLimit('team_members')).toEqual({ max: 10, used: 3, remaining: 7 })
     // null max → unlimited (remaining null)
     expect(store.getLimit('pdf_generation_daily')).toEqual({ max: null, used: 5, remaining: null })
+  })
+
+  it('getLimit defaults missing limits and clamps overage remaining at zero', async () => {
+    const meResp: MeResponse = {
+      data: makeUser({
+        current_clinic: makeClinicContext({
+          limits: {
+            team_members: { max: 2, used: 5 },
+          } as ClinicContext['limits'],
+        }),
+      }),
+      meta: { memberships: [makeMembership()] },
+    }
+    const api = makeAuthApi({ me: vi.fn().mockResolvedValue(meResp) })
+    const { useAuthStore } = await loadStore(api)
+    const store = useAuthStore()
+    await store.fetchUser()
+
+    expect(store.getLimit('team_members')).toEqual({ max: 2, used: 5, remaining: 0 })
+    expect(store.getLimit('pdf_generation_daily')).toEqual({ max: null, used: 0, remaining: null })
+  })
+})
+
+describe('authStore — fetchUser side effects', () => {
+  it('applies theme and loads specialty config when present', async () => {
+    const setTheme = vi.fn()
+    const fetchConfig = vi.fn()
+    const api = makeAuthApi({
+      me: vi.fn().mockResolvedValue({
+        data: makeUser({ theme: 'dark', specialty: 'cardiology' }),
+        meta: { memberships: [] },
+      }),
+    })
+    vi.doMock('../api/authApi', () => ({ authApi: api }))
+    vi.doMock('@/lib/http', () => ({ setAuthToken: vi.fn() }))
+    vi.doMock('@/composables/useTheme', () => ({ useTheme: () => ({ setTheme }) }))
+    vi.doMock('@/composables/useCentrifugo', () => ({ useCentrifugo: () => ({ disconnect: vi.fn() }) }))
+    vi.doMock('@/stores/specialtyConfigStore', () => ({
+      useSpecialtyConfigStore: () => ({ fetchConfig }),
+    }))
+    const { useAuthStore } = await import('./authStore')
+    const store = useAuthStore()
+
+    await store.fetchUser()
+
+    expect(setTheme).toHaveBeenCalledWith('dark')
+    expect(fetchConfig).toHaveBeenCalledWith('cardiology')
   })
 })
 
@@ -462,5 +578,29 @@ describe('authStore — logout', () => {
     expect(store.user).toBeNull()
     expect(store.memberships).toEqual([])
     expect(store.isAuthenticated).toBe(false)
+  })
+
+  it('still clears local state when broadcast and indexedDB cleanup are unavailable', async () => {
+    const api = makeAuthApi()
+    const { useAuthStore } = await loadStore(api)
+    const store = useAuthStore()
+
+    store.user = makeUser({ current_clinic: makeClinicContext() })
+    store.memberships = [makeMembership()]
+    store.setToken('tok')
+    vi.stubGlobal('BroadcastChannel', vi.fn(() => {
+      throw new Error('not supported')
+    }))
+    vi.stubGlobal('indexedDB', {
+      deleteDatabase: vi.fn(() => {
+        throw new Error('not supported')
+      }),
+    })
+
+    await store.logout()
+
+    expect(store.token).toBeNull()
+    expect(store.user).toBeNull()
+    expect(store.memberships).toEqual([])
   })
 })

--- a/src/domains/patient/components/EditPatientDialog.spec.ts
+++ b/src/domains/patient/components/EditPatientDialog.spec.ts
@@ -13,7 +13,7 @@
  * inline and we can interact with it directly.
  */
 
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { flushPromises } from '@vue/test-utils'
 import { mountWithDeps } from '@/__tests__/helpers/mountWithDeps'
 import EditPatientDialog from './EditPatientDialog.vue'
@@ -134,6 +134,11 @@ function mount(patient = makePatientResponse()) {
 }
 
 describe('EditPatientDialog', () => {
+  beforeEach(() => {
+    updatePatientSpy.mockReset()
+    updatePatientSpy.mockResolvedValue(undefined)
+  })
+
   it('populates the contact number input from the patient on open', async () => {
     const wrapper = mount()
     await flushPromises()
@@ -156,7 +161,6 @@ describe('EditPatientDialog', () => {
   })
 
   it('accepts a +639XXXXXXXXX formatted phone and submits', async () => {
-    updatePatientSpy.mockClear()
     const wrapper = mount()
     await flushPromises()
 
@@ -168,10 +172,11 @@ describe('EditPatientDialog', () => {
     expect(updatePatientSpy).toHaveBeenCalledOnce()
     const payload = updatePatientSpy.mock.calls[0]?.[1] as Record<string, unknown>
     expect(payload.contact_number).toBe('+639171112222')
+    expect(wrapper.emitted('updated')).toEqual([[]])
+    expect(wrapper.emitted('update:open')).toEqual([[false]])
   })
 
   it('normalises empty optional fields to null in the submit payload', async () => {
-    updatePatientSpy.mockClear()
     const wrapper = mount(makePatientResponse({ contact_number: '', email: '', note: '' }))
     await flushPromises()
     await wrapper.find('form').trigger('submit.prevent')
@@ -184,8 +189,38 @@ describe('EditPatientDialog', () => {
     expect(payload.note).toBeNull()
   })
 
+  it('shows a general error when the patient name is incomplete', async () => {
+    const wrapper = mount()
+    await flushPromises()
+
+    wrapper.findComponent({ name: 'NameForm' }).vm.$emit('update:modelValue', {
+      first_name: '',
+      middle_name: null,
+      last_name: 'Dela Cruz',
+      suffix: null,
+    })
+    await flushPromises()
+    await wrapper.find('form').trigger('submit.prevent')
+    await flushPromises()
+
+    expect(updatePatientSpy).not.toHaveBeenCalled()
+    expect(wrapper.text()).toContain('Please enter first and last name.')
+  })
+
+  it('shows a general error when the address is missing', async () => {
+    const wrapper = mount()
+    await flushPromises()
+
+    wrapper.findComponent({ name: 'AddressForm' }).vm.$emit('update:modelValue', null)
+    await flushPromises()
+    await wrapper.find('form').trigger('submit.prevent')
+    await flushPromises()
+
+    expect(updatePatientSpy).not.toHaveBeenCalled()
+    expect(wrapper.text()).toContain('Please complete the address fields.')
+  })
+
   it('maps server-side 422 field errors back onto the form', async () => {
-    updatePatientSpy.mockReset()
     updatePatientSpy.mockRejectedValue(
       new FakeHttpError(422, 'Validation failed', {
         message: 'Validation failed',
@@ -198,5 +233,27 @@ describe('EditPatientDialog', () => {
     await flushPromises()
 
     expect(wrapper.text()).toContain('Already in use.')
+  })
+
+  it('shows a generic error for non-validation HttpError failures', async () => {
+    updatePatientSpy.mockRejectedValue(new FakeHttpError(500, 'Server error'))
+    const wrapper = mount()
+    await flushPromises()
+
+    await wrapper.find('form').trigger('submit.prevent')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('An unexpected error occurred. Please try again.')
+  })
+
+  it('shows a connection error for non-HttpError failures', async () => {
+    updatePatientSpy.mockRejectedValue(new Error('offline'))
+    const wrapper = mount()
+    await flushPromises()
+
+    await wrapper.find('form').trigger('submit.prevent')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Unable to connect to the server. Please try again.')
   })
 })

--- a/src/domains/queue/components/QueueCard.spec.ts
+++ b/src/domains/queue/components/QueueCard.spec.ts
@@ -92,6 +92,20 @@ describe('QueueCard', () => {
     expect(wrapper.classes()).toContain('border-amber-300')
   })
 
+  it('does not mark a completed previous-day visit as carryover and uses completed_at for wait time', () => {
+    const wrapper = mountCard(makeVisit({
+      status: 'completed',
+      checked_in_at: '2026-05-05T23:00:00.000Z',
+      completed_at: '2026-05-06T01:10:00.000Z',
+      type: 'appointment',
+    }))
+
+    expect(wrapper.text()).toContain('Appointment')
+    expect(wrapper.text()).toContain('2h 10m')
+    expect(wrapper.text()).not.toContain('From May 5')
+    expect(wrapper.classes()).not.toContain('border-amber-300')
+  })
+
   it('emits waiting actions when the user can manage the queue', async () => {
     const wrapper = mountCard()
 
@@ -111,11 +125,25 @@ describe('QueueCard', () => {
     expect(wrapper.text()).not.toContain('Call')
   })
 
+  it('allows managers to act even when the visit belongs to another doctor', async () => {
+    const wrapper = mountCard(makeVisit({ doctor_id: 'doctor-2' }), { canManage: true, canCall: false })
+
+    await wrapper.findAll('button').find((button) => button.text().includes('Call'))?.trigger('click')
+
+    expect(wrapper.emitted('call')).toEqual([['visit-1']])
+  })
+
   it('hides action buttons when the user cannot act on the visit', () => {
     const wrapper = mountCard(makeVisit({ doctor_id: 'doctor-2' }), { canManage: false, canCall: true })
 
     expect(wrapper.text()).not.toContain('Call')
     expect(wrapper.text()).not.toContain('Complete')
+  })
+
+  it('hides consultation action when no encounter is linked', () => {
+    const wrapper = mountCard(makeVisit({ encounter_id: null }))
+
+    expect(wrapper.text()).not.toContain('Consultation')
   })
 
   it('opens the linked consultation when present', async () => {

--- a/src/domains/queue/components/QueueStatusBadge.spec.ts
+++ b/src/domains/queue/components/QueueStatusBadge.spec.ts
@@ -28,4 +28,11 @@ describe('QueueStatusBadge', () => {
     expect(wrapper.text()).toBe(label)
     expect(wrapper.find('span').attributes('class')).toContain(colorClass)
   })
+
+  it('falls back to the raw status for unknown values', () => {
+    const wrapper = mountBadge('deferred' as QueueVisitStatus)
+
+    expect(wrapper.text()).toBe('deferred')
+    expect(wrapper.find('span').attributes('class') ?? '').toBe('')
+  })
 })

--- a/src/domains/schedule/stores/scheduleStore.spec.ts
+++ b/src/domains/schedule/stores/scheduleStore.spec.ts
@@ -283,4 +283,36 @@ describe('scheduleStore - studio data', () => {
     expect(store.studioError).toBe('Failed to load schedule view.')
     expect(store.isLoadingStudio).toBe(false)
   })
+
+  it('ignores duplicate in-flight studio requests for the same parameters', async () => {
+    let resolveList: (value: Awaited<ReturnType<MockAppointmentApi['list']>>) => void = () => {}
+    const scheduleApi = makeScheduleApi()
+    const appointmentApi = makeAppointmentApi({
+      list: vi.fn().mockImplementation(() => new Promise((resolve) => {
+        resolveList = resolve
+      })),
+    })
+    const { useScheduleStore } = await loadStore(scheduleApi, appointmentApi)
+    const store = useScheduleStore()
+    const params = {
+      userId: 'doctor-1',
+      date: '2026-05-06',
+      start: '2026-05-01',
+      end: '2026-05-31',
+      blockRangeEnd: '2026-06-30',
+      refreshKey: 1,
+    }
+
+    const first = store.fetchStudioData(params)
+    const second = store.fetchStudioData(params)
+
+    await expect(second).resolves.toBeUndefined()
+    expect(appointmentApi.list).toHaveBeenCalledOnce()
+    resolveList({
+      data: [makeAppointment()],
+      meta: { pagination: { page: 1, per_page: 300, total: 1, last_page: 1 } },
+    })
+    await first
+    expect(store.isLoadingStudio).toBe(false)
+  })
 })

--- a/src/domains/subscription/components/SubscriptionStatus.spec.ts
+++ b/src/domains/subscription/components/SubscriptionStatus.spec.ts
@@ -52,6 +52,29 @@ describe('SubscriptionStatus', () => {
     expect(wrapper.text()).toContain('Trial ends in 1 day')
   })
 
+  it('renders trial copy with plural day grammar', () => {
+    const wrapper = mountStatus(makeStatus({
+      is_trial: true,
+      trial_days_left: 3,
+      billing_period_ends_at: null,
+    }))
+
+    expect(wrapper.text()).toContain('Trial ends in 3 days')
+  })
+
+  it('renders free plan without billing or subscription actions', () => {
+    const wrapper = mountStatus(makeStatus({
+      plan: 'free',
+      billing_period_ends_at: null,
+      next_billing_amount: 0,
+    }))
+
+    expect(wrapper.text()).toContain('Free')
+    expect(wrapper.text()).not.toContain('Next billing')
+    expect(wrapper.text()).not.toContain('Cancel Subscription')
+    expect(wrapper.text()).not.toContain('Reactivate')
+  })
+
   it('renders grace-period warning', () => {
     const wrapper = mountStatus(makeStatus({ is_in_grace_period: true }))
 


### PR DESCRIPTION
## Summary
- expand frontend test coverage across previously low-coverage auth, appointment, patient, queue, schedule, and subscription areas
- cover auth store edge cases, credentials/password error paths, appointment/schedule store branches, and low-coverage component states
- test-only change; no production code changes

## Verification
- `TZ=UTC npx vitest run src/domains/auth/stores/authStore.spec.ts src/domains/auth/components/CredentialsForm.spec.ts src/domains/auth/components/PasswordForm.spec.ts src/domains/appointment/stores/appointmentStore.spec.ts src/domains/appointment/components/AppointmentCard.spec.ts src/domains/queue/components/QueueCard.spec.ts src/domains/queue/components/QueueStatusBadge.spec.ts src/domains/patient/components/EditPatientDialog.spec.ts src/domains/subscription/components/SubscriptionStatus.spec.ts src/domains/schedule/stores/scheduleStore.spec.ts`
  - 10 files passed, 102 tests passed
- `TZ=UTC npm run test:coverage -- --run`
  - 70 files passed, 566 tests passed, 1 skipped
  - statements: 99.93% (2942/2944)
  - branches: 96% (888/925)
  - functions: 94.95% (301/317)
  - lines: 99.93% (2942/2944)
- `npm run build`
