### PR TITLE
Add phase 20 component coverage

### DIFF
--- a/src/components/shared/UpgradePrompt.spec.ts
+++ b/src/components/shared/UpgradePrompt.spec.ts
@@ -92,4 +92,27 @@ describe('UpgradePrompt', () => {
     expect(pushSpy).toHaveBeenCalledOnce()
     expect(pushSpy.mock.calls[0]?.[0]).toMatchObject({ name: expect.any(String) })
   })
+
+  it('clicking Maybe Later in dialog mode closes the prompt', async () => {
+    const wrapper = mount({ open: true })
+    const closeBtn = wrapper.findAll('.btn').find((b) => b.text().includes('Maybe Later'))
+    expect(closeBtn).toBeDefined()
+
+    await closeBtn!.trigger('click')
+
+    expect(wrapper.emitted('update:open')).toEqual([[false]])
+  })
+
+  it('clicking Upgrade in dialog mode closes and navigates', async () => {
+    pushSpy.mockClear()
+    const wrapper = mount({ open: true })
+    const upgradeBtn = wrapper.findAll('.btn').find((b) => b.text().trim() === 'Upgrade')
+    expect(upgradeBtn).toBeDefined()
+
+    await upgradeBtn!.trigger('click')
+
+    expect(wrapper.emitted('update:open')).toEqual([[false]])
+    expect(pushSpy).toHaveBeenCalledOnce()
+    expect(pushSpy.mock.calls[0]?.[0]).toMatchObject({ name: expect.any(String) })
+  })
 })

--- a/src/domains/patient/components/EditPatientDialog.spec.ts
+++ b/src/domains/patient/components/EditPatientDialog.spec.ts
@@ -189,6 +189,40 @@ describe('EditPatientDialog', () => {
     expect(payload.note).toBeNull()
   })
 
+  it('submits edited demographic and optional fields', async () => {
+    const wrapper = mount()
+    await flushPromises()
+
+    await wrapper.find('.dob-picker').setValue('1991-02-03')
+    wrapper.findAllComponents({ name: 'Select' })[0].vm.$emit('update:modelValue', 'female')
+    wrapper.findAllComponents({ name: 'Select' })[1].vm.$emit('update:modelValue', 'O+')
+    await wrapper.find('#edit_email').setValue('updated@example.com')
+    await wrapper.find('#edit_note').setValue('Updated note')
+    await flushPromises()
+
+    await wrapper.find('form').trigger('submit.prevent')
+    await flushPromises()
+
+    expect(updatePatientSpy).toHaveBeenCalledOnce()
+    const payload = updatePatientSpy.mock.calls[0]?.[1] as Record<string, unknown>
+    expect(payload.date_of_birth).toBe('1991-02-03')
+    expect(payload.sex).toBe('female')
+    expect(payload.blood_type).toBe('O+')
+    expect(payload.email).toBe('updated@example.com')
+    expect(payload.note).toBe('Updated note')
+  })
+
+  it('emits close when cancel is clicked', async () => {
+    const wrapper = mount()
+    await flushPromises()
+
+    const cancelButton = wrapper.findAll('button').find((button) => button.text().includes('Cancel'))
+    expect(cancelButton).toBeDefined()
+    await cancelButton!.trigger('click')
+
+    expect(wrapper.emitted('update:open')).toContainEqual([false])
+  })
+
   it('shows a general error when the patient name is incomplete', async () => {
     const wrapper = mount()
     await flushPromises()

--- a/src/domains/schedule/components/BreakEditor.spec.ts
+++ b/src/domains/schedule/components/BreakEditor.spec.ts
@@ -48,6 +48,23 @@ describe('BreakEditor', () => {
     ])
   })
 
+  it('updates break start and end times independently', async () => {
+    const wrapper = mountEditor([
+      { label: 'Lunch', start_time: '12:00', end_time: '13:00' },
+    ])
+    const timeInputs = wrapper.findAll('input[type="time"]')
+
+    await timeInputs[0].setValue('12:15')
+    await timeInputs[1].setValue('13:15')
+
+    expect(wrapper.emitted('update:breaks')?.[0]?.[0]).toEqual([
+      { label: 'Lunch', start_time: '12:15', end_time: '13:00' },
+    ])
+    expect(wrapper.emitted('update:breaks')?.[1]?.[0]).toEqual([
+      { label: 'Lunch', start_time: '12:00', end_time: '13:15' },
+    ])
+  })
+
   it('removes the selected break', async () => {
     const wrapper = mountEditor([
       { label: 'Lunch', start_time: '12:00', end_time: '13:00' },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -101,7 +101,7 @@ export default defineConfig({
         branches: 70,
         // Vue template handlers are counted as generated functions; raise this
         // phase-by-phase as more component interaction tests land.
-        functions: 92,
+        functions: 95,
         statements: 70,
       },
     },


### PR DESCRIPTION
## Summary

Extends the frontend component coverage pass across the remaining low-function-coverage surfaces.

## Changes

- Adds dialog action coverage for `UpgradePrompt` close and upgrade navigation paths.
- Adds edited demographic/optional-field and cancel-path coverage for `EditPatientDialog`.
- Adds start/end time update coverage for `BreakEditor`.
- Raises the global function coverage threshold from 92% to 95%.

## Coverage Movement

- Overall function coverage: 94.95% -> 97.79%.
- `UpgradePrompt.vue` functions: 33.33% -> 66.66%.
- `EditPatientDialog.vue` functions: 46.15% -> 92.30%.
- `BreakEditor.vue` functions: 71.42% -> 100%.

## Validation

- `TEST_CMD="npx vitest run src/components/shared/UpgradePrompt.spec.ts src/domains/schedule/components/BreakEditor.spec.ts src/domains/patient/components/EditPatientDialog.spec.ts" docker compose -p clinicapp-fe-tests-p20 -f docker-compose.test.yml run --rm frontend-test`
  - Passed: 3 files, 24 tests.
- `TEST_CMD="npm run test:coverage" docker compose -p clinicapp-fe-tests-p20 -f docker-compose.test.yml run --rm frontend-test`
  - Passed: 70 files, 571 tests, 1 skipped.
  - Phase 20 coverage gate: 99.93% statements, 96.03% branches, 97.79% functions, 99.93% lines.
- `TEST_CMD="npx playwright test e2e/dental-fee-schedule.spec.ts" docker compose -p clinicapp-fe-tests-p20 -f docker-compose.test.yml run --rm frontend-feature-test`
  - Clean skipped: 3 tests skipped because local E2E credentials were not set.
- `TEST_CMD="npm run build" docker compose -p clinicapp-fe-tests-p20 -f docker-compose.test.yml run --rm frontend-test`
  - Passed. Existing slim-container git warning and bundle-size warnings remain.
