### PR TITLE
fix: guard sensitive frontend routes

### DIFF
--- a/src/router/index.spec.ts
+++ b/src/router/index.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import router, { canAccessRequiredPermission } from './index'
+import { RouteNames } from './routeNames'
+
+function metaFor(routeName: string) {
+  const route = router.getRoutes().find((candidate) => candidate.name === routeName)
+  expect(route, `route ${routeName} should exist`).toBeTruthy()
+  return route!.meta
+}
+
+describe('sensitive route guards', () => {
+  it('allows array-based route permissions when the user has any required permission', () => {
+    expect(canAccessRequiredPermission(['billing.view', 'billing.view-own'], (permission) => permission === 'billing.view-own')).toBe(true)
+    expect(canAccessRequiredPermission(['billing.view', 'billing.view-own'], (permission) => permission === 'patients.view')).toBe(false)
+  })
+
+  it('requires billing permissions for the billing route', () => {
+    expect(metaFor(RouteNames.BILLING).requiredPermission).toEqual(['billing.view', 'billing.view-own'])
+  })
+
+  it('requires owner-level clinic management for subscription access', () => {
+    expect(metaFor(RouteNames.SUBSCRIPTION).requiredPermission).toBe('clinic.manage')
+  })
+
+  it('requires clinic management for template list and editor routes', () => {
+    expect(metaFor(RouteNames.CLINIC_TEMPLATES).requiredPermission).toBe('clinic.manage')
+    expect(metaFor(RouteNames.TEMPLATE_EDITOR).requiredPermission).toBe('clinic.manage')
+  })
+})

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -5,7 +5,7 @@ declare module 'vue-router' {
     requiresAuth?: boolean
     requiresClinicContext?: boolean
     requiresGuest?: boolean
-    requiredPermission?: string
+    requiredPermission?: string | string[]
     requiredFeature?: string
     usesCustomTopbar?: boolean
     devOnly?: boolean
@@ -16,6 +16,17 @@ import HomeView from '@/views/HomeView.vue'
 import { RouteNames } from './routeNames'
 import { useAuthStore } from '@/domains/auth/stores/authStore'
 import { HttpError } from '@/lib/http'
+
+export function canAccessRequiredPermission(
+  requiredPermission: string | string[] | undefined,
+  hasPermission: (permission: string) => boolean,
+): boolean {
+  if (!requiredPermission) return true
+  if (Array.isArray(requiredPermission)) {
+    return requiredPermission.some((permission) => hasPermission(permission))
+  }
+  return hasPermission(requiredPermission)
+}
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -126,6 +137,7 @@ const router = createRouter({
               path: 'templates',
               name: RouteNames.CLINIC_TEMPLATES,
               component: () => import('@/domains/template/views/TemplateListView.vue'),
+              meta: { requiredPermission: 'clinic.manage' },
             },
             {
               path: 'team',
@@ -151,6 +163,7 @@ const router = createRouter({
           path: 'clinic/templates/:category/:variation',
           name: RouteNames.TEMPLATE_EDITOR,
           component: () => import('@/domains/template/views/TemplateEditorView.vue'),
+          meta: { requiredPermission: 'clinic.manage' },
         },
         {
           path: 'schedule',
@@ -173,11 +186,13 @@ const router = createRouter({
           path: 'billing',
           name: RouteNames.BILLING,
           component: () => import('@/domains/billing/views/BillingView.vue'),
+          meta: { requiredPermission: ['billing.view', 'billing.view-own'] },
         },
         {
           path: 'subscription',
           name: RouteNames.SUBSCRIPTION,
           component: () => import('@/domains/subscription/views/SubscriptionView.vue'),
+          meta: { requiredPermission: 'clinic.manage' },
         },
         {
           path: 'account',
@@ -353,7 +368,7 @@ router.beforeEach(async (to) => {
     if (to.meta.requiredFeature && !authStore.hasFeature(to.meta.requiredFeature)) {
       return { name: RouteNames.HOME }
     }
-    if (to.meta.requiredPermission && !authStore.hasPermission(to.meta.requiredPermission)) {
+    if (!canAccessRequiredPermission(to.meta.requiredPermission, authStore.hasPermission)) {
       return { name: RouteNames.HOME }
     }
   }


### PR DESCRIPTION
## Summary
- Adds route-level permission metadata for sensitive Billing, Subscription, and clinic template routes
- Supports any-of permission arrays for routes such as Billing (`billing.view` or `billing.view-own`)
- Adds router tests covering the sensitive route guard metadata and array permission helper

## Test Plan
- [x] `TEST_CMD='npm run test -- src/router/index.spec.ts' docker compose -p fe-old-issues-378 -f docker-compose.test.yml run --rm frontend-test`
- [x] `TEST_CMD='npm run build' docker compose -p fe-old-issues-378 -f docker-compose.test.yml run --rm frontend-test`

Closes #15