### PR TITLE
fix(auth): preserve verification resend UX

### DIFF
--- a/src/domains/auth/views/LoginView.spec.ts
+++ b/src/domains/auth/views/LoginView.spec.ts
@@ -1,0 +1,96 @@
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick, ref } from 'vue'
+
+const push = vi.fn()
+const login = vi.fn()
+
+async function mountLoginView() {
+  vi.doMock('vue-router', () => ({
+    useRouter: () => ({ push }),
+    RouterLink: {
+      props: ['to'],
+      template: '<a href="#" :data-to="JSON.stringify(to)"><slot /></a>',
+    },
+  }))
+  vi.doMock('../stores/authStore', () => ({
+    useAuthStore: () => ({ login }),
+  }))
+  vi.doMock('@/lib/http', () => ({ HttpError: class HttpError extends Error {} }))
+  vi.doMock('@/composables/useNeuralNetwork', () => ({ useNeuralNetwork: () => ({ canvasRef: ref(null) }) }))
+  vi.doMock('@/composables/useTheme', () => ({ useTheme: () => ({ isDark: false, toggleTheme: vi.fn() }) }))
+  vi.doMock('../components/GoogleSignInButton.vue', () => ({ default: { template: '<button type="button">Google</button>' } }))
+  vi.doMock('../components/AuthFeedbackAlert.vue', () => ({ default: { template: '<div><slot /></div>' } }))
+
+  const { default: LoginView } = await import('./LoginView.vue')
+
+  return mount(LoginView, {
+    global: {
+      stubs: {
+        AppLogo: { template: '<div />' },
+        Button: { template: '<button><slot /></button>' },
+        Checkbox: { template: '<input type="checkbox" />' },
+        RouterLink: {
+          props: ['to'],
+          template: '<a href="#" :data-to="JSON.stringify(to)"><slot /></a>',
+        },
+        Input: {
+          props: ['modelValue'],
+          emits: ['update:modelValue'],
+          template: '<input :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" />',
+        },
+        PasswordInput: {
+          props: ['modelValue'],
+          emits: ['update:modelValue'],
+          template: '<input type="password" :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" />',
+        },
+        Label: { template: '<label><slot /></label>' },
+        Card: { template: '<div><slot /></div>' },
+        CardContent: { template: '<div><slot /></div>' },
+        CardDescription: { template: '<div><slot /></div>' },
+        CardHeader: { template: '<div><slot /></div>' },
+        CardTitle: { template: '<div><slot /></div>' },
+        AlertDialog: { template: '<div><slot /></div>' },
+        AlertDialogAction: { template: '<button><slot /></button>' },
+        AlertDialogCancel: { template: '<button><slot /></button>' },
+        AlertDialogContent: { template: '<div><slot /></div>' },
+        AlertDialogDescription: { template: '<div><slot /></div>' },
+        AlertDialogFooter: { template: '<div><slot /></div>' },
+        AlertDialogHeader: { template: '<div><slot /></div>' },
+        AlertDialogTitle: { template: '<div><slot /></div>' },
+        Activity: true,
+        Building2: true,
+        Lock: true,
+        LoaderCircle: true,
+        Mail: true,
+        Moon: true,
+        ShieldCheck: true,
+        Sun: true,
+      },
+    },
+  })
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  vi.clearAllMocks()
+  vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+    cb(0)
+    return 1
+  })
+})
+
+describe('LoginView verification UX', () => {
+  it('offers a non-enumerating verification email path before login fails', async () => {
+    const wrapper = await mountLoginView()
+
+    await wrapper.find('input[type="email"]').setValue('doctor@example.test')
+    await nextTick()
+
+    const link = wrapper.findAll('a').find(anchor => anchor.text().includes('Need a verification email?'))
+
+    expect(link).toBeTruthy()
+    expect(link?.attributes('data-to')).toContain('verify-email-notice')
+    expect(link?.attributes('data-to')).toContain('doctor@example.test')
+  })
+})

--- a/src/domains/auth/views/LoginView.vue
+++ b/src/domains/auth/views/LoginView.vue
@@ -52,7 +52,6 @@ const { value: password, errorMessage: passwordError } = useField<string>('passw
 const isLoading = ref(false)
 const generalError = ref<string | null>(null)
 const generalNotice = ref<string | null>(null)
-const showResendLink = ref(false)
 const rememberMe = ref(true)
 const linkDialogOpen = ref(false)
 const pendingGoogleCredential = ref<string | null>(null)
@@ -70,7 +69,6 @@ onMounted(() => {
 const onSubmit = handleSubmit(async (values) => {
   generalError.value = null
   generalNotice.value = null
-  showResendLink.value = false
   isLoading.value = true
 
   try {
@@ -91,12 +89,7 @@ const onSubmit = handleSubmit(async (values) => {
         generalError.value = 'Invalid email or password.'
       } else if (err.status === 403) {
         const body = err.data as { message?: string; error_code?: string }
-        if (body.error_code === 'email_not_verified') {
-          generalError.value = 'Please verify your email address before signing in.'
-          showResendLink.value = true
-        } else {
-          generalError.value = body.message || 'Access denied.'
-        }
+        generalError.value = body.error_code === 'email_not_verified' ? 'Access denied.' : body.message || 'Access denied.'
       } else {
         generalError.value = 'An unexpected error occurred. Please try again.'
       }
@@ -132,7 +125,6 @@ function handleGoogleError(err: unknown): void {
 async function onGoogleCredential(credential: string): Promise<void> {
   generalError.value = null
   generalNotice.value = null
-  showResendLink.value = false
   pendingGoogleCredential.value = credential
   isLoading.value = true
 
@@ -262,13 +254,6 @@ async function requestGoogleLink(): Promise<void> {
                 role="alert"
               >
                 {{ generalError }}
-                <RouterLink
-                  v-if="showResendLink"
-                  :to="{ name: RouteNames.VERIFY_EMAIL_NOTICE, query: { email: email } }"
-                  class="mt-1 block"
-                >
-                  Resend verification email
-                </RouterLink>
               </AuthFeedbackAlert>
 
               <AuthFeedbackAlert
@@ -352,12 +337,20 @@ async function requestGoogleLink(): Promise<void> {
                 :class="ready ? 'translate-y-0 opacity-100' : 'translate-y-4 opacity-0'"
               >
                 <div class="flex justify-end overflow-hidden">
-                  <RouterLink
-                    :to="{ name: RouteNames.FORGOT_PASSWORD }"
-                    class="max-w-full truncate text-xs text-muted-foreground hover:text-primary underline-offset-4 hover:underline"
-                  >
-                    Forgot password?
-                  </RouterLink>
+                  <div class="flex max-w-full flex-wrap justify-end gap-x-3 gap-y-1 text-xs">
+                    <RouterLink
+                      :to="{ name: RouteNames.VERIFY_EMAIL_NOTICE, query: email ? { email } : {} }"
+                      class="text-muted-foreground hover:text-primary underline-offset-4 hover:underline"
+                    >
+                      Need a verification email?
+                    </RouterLink>
+                    <RouterLink
+                      :to="{ name: RouteNames.FORGOT_PASSWORD }"
+                      class="text-muted-foreground hover:text-primary underline-offset-4 hover:underline"
+                    >
+                      Forgot password?
+                    </RouterLink>
+                  </div>
                 </div>
               </div>
 

--- a/src/domains/auth/views/VerifyEmailNoticeView.spec.ts
+++ b/src/domains/auth/views/VerifyEmailNoticeView.spec.ts
@@ -1,0 +1,83 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick, ref } from 'vue'
+
+const resendVerification = vi.fn()
+const routeQuery = vi.hoisted(() => ({ value: {} as Record<string, string> }))
+
+async function mountVerifyEmailNoticeView() {
+  vi.doMock('vue-router', () => ({
+    useRoute: () => ({ query: routeQuery.value }),
+    RouterLink: {
+      props: ['to'],
+      template: '<a href="#" :data-to="JSON.stringify(to)"><slot /></a>',
+    },
+  }))
+  vi.doMock('@/composables/useNeuralNetwork', () => ({ useNeuralNetwork: () => ({ canvasRef: ref(null) }) }))
+  vi.doMock('../api/authApi', () => ({
+    authApi: { resendVerification },
+  }))
+
+  const { default: VerifyEmailNoticeView } = await import('./VerifyEmailNoticeView.vue')
+
+  return mount(VerifyEmailNoticeView, {
+    global: {
+      stubs: {
+        AppLogo: { template: '<div />' },
+        Button: { template: '<button><slot /></button>' },
+        Card: { template: '<div><slot /></div>' },
+        CardContent: { template: '<div><slot /></div>' },
+        CardDescription: { template: '<div><slot /></div>' },
+        CardHeader: { template: '<div><slot /></div>' },
+        CardTitle: { template: '<div><slot /></div>' },
+        ArrowLeft: true,
+        LoaderCircle: true,
+        MailCheck: true,
+        RefreshCw: true,
+        RouterLink: {
+          props: ['to'],
+          template: '<a href="#" :data-to="JSON.stringify(to)"><slot /></a>',
+        },
+      },
+    },
+  })
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  vi.clearAllMocks()
+  routeQuery.value = {}
+  vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+    cb(0)
+    return 1
+  })
+})
+
+describe('VerifyEmailNoticeView', () => {
+  it('collects an email before resending when none is provided in the URL', async () => {
+    resendVerification.mockResolvedValue({ message: 'If the email exists, we sent a verification link.' })
+
+    const wrapper = await mountVerifyEmailNoticeView()
+
+    expect(wrapper.text()).toContain('Enter your email address')
+    expect(wrapper.text()).not.toContain("We've sent a verification link to")
+
+    await wrapper.find('input[type="email"]').setValue('doctor@example.test')
+    await wrapper.find('button').trigger('click')
+    await flushPromises()
+    await nextTick()
+
+    expect(resendVerification).toHaveBeenCalledWith({ email: 'doctor@example.test' })
+    expect(wrapper.text()).toContain('If the email exists, we sent a verification link.')
+  })
+
+  it('shows validation feedback instead of silently doing nothing when email is blank', async () => {
+    const wrapper = await mountVerifyEmailNoticeView()
+
+    await wrapper.find('button').trigger('click')
+    await nextTick()
+
+    expect(resendVerification).not.toHaveBeenCalled()
+    expect(wrapper.text()).toContain('Enter your email address to resend verification.')
+  })
+})

--- a/src/domains/auth/views/VerifyEmailNoticeView.vue
+++ b/src/domains/auth/views/VerifyEmailNoticeView.vue
@@ -2,6 +2,7 @@
 import { ref, computed, onMounted } from 'vue'
 import { useRoute } from 'vue-router'
 import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
 import {
   Card,
   CardContent,
@@ -22,10 +23,12 @@ const { canvasRef } = useNeuralNetwork()
 const email = computed(() =>
   typeof route.query.email === 'string' ? route.query.email : '',
 )
+const resendEmail = ref(email.value)
 
 const isResending = ref(false)
 const resendMessage = ref<string | null>(null)
 const resendError = ref<string | null>(null)
+const emailPromptError = ref<string | null>(null)
 
 const ready = ref(false)
 onMounted(() => {
@@ -36,14 +39,19 @@ onMounted(() => {
 })
 
 async function resend() {
-  if (!email.value) return
+  const targetEmail = resendEmail.value.trim()
+  if (!targetEmail) {
+    emailPromptError.value = 'Enter your email address to resend verification.'
+    return
+  }
 
   resendMessage.value = null
   resendError.value = null
+  emailPromptError.value = null
   isResending.value = true
 
   try {
-    const response = await authApi.resendVerification({ email: email.value })
+    const response = await authApi.resendVerification({ email: targetEmail })
     resendMessage.value = response.message
   } catch (err) {
     if (err instanceof HttpError && err.status === 429) {
@@ -82,9 +90,12 @@ async function resend() {
               <MailCheck class="size-6 text-primary" />
             </div>
             <CardTitle class="text-xl">Check your email</CardTitle>
-            <CardDescription>
+            <CardDescription v-if="email">
               We've sent a verification link to
               <span v-if="email" class="font-medium text-foreground">{{ email }}</span>
+            </CardDescription>
+            <CardDescription v-else>
+              Enter your email address and we'll send a verification link if the account exists.
             </CardDescription>
           </CardHeader>
 
@@ -92,6 +103,23 @@ async function resend() {
             <p class="text-center text-sm text-muted-foreground">
               Click the link in the email to verify your account. If you don't see it, check your spam folder.
             </p>
+
+            <Input
+              v-if="!email"
+              v-model="resendEmail"
+              type="email"
+              autocomplete="email"
+              placeholder="you@example.com"
+              aria-label="Email address"
+            />
+
+            <div
+              v-if="emailPromptError"
+              role="alert"
+              class="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2.5 text-center text-sm text-destructive"
+            >
+              {{ emailPromptError }}
+            </div>
 
             <div
               v-if="resendMessage"


### PR DESCRIPTION
## Summary
- Removes the login-failure-only resend verification link tied to `email_not_verified`.
- Adds a non-enumerating “Need a verification email?” path beside Forgot password.
- Lets the verification notice page collect an email when no query email is present, with blank-email validation.
- Keeps legacy `email_not_verified` login errors generic as `Access denied.`.

## Backend companion
- Companion to backend PR: https://github.com/jomaf1010/clinic-be/pull/124
- Related backend issue: #73

## Tests
- RED confirmed for missing no-query resend path before fix.
- `npm run test -- src/domains/auth/views/LoginView.spec.ts src/domains/auth/views/VerifyEmailNoticeView.spec.ts src/domains/auth/api/authApi.spec.ts src/domains/auth/stores/authStore.spec.ts` — 31 passed
- `npm run build` — passed
- `npm run test` — 571 passed, 1 skipped, 2 existing/unrelated failures:
  - `AppointmentCard.spec.ts` timezone/time display expectation
  - `QueueCard.spec.ts` carryover label expectation

## Security notes
- Login no longer exposes verification state via a conditional resend link.
- Resend path is user-initiated and generic; copy uses “if the account exists”.
- Secret scan clean.
