### PR TITLE
fix: keep queue display token out of launch URLs

### DIFF
--- a/src/domains/queue/utils/displayTokenLaunch.spec.ts
+++ b/src/domains/queue/utils/displayTokenLaunch.spec.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildQueueDisplayUrl,
+  readQueueDisplayToken,
+  storeQueueDisplayToken,
+} from './displayTokenLaunch'
+
+class MemoryStorage implements Storage {
+  private values = new Map<string, string>()
+
+  get length(): number {
+    return this.values.size
+  }
+
+  clear(): void {
+    this.values.clear()
+  }
+
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null
+  }
+
+  key(index: number): string | null {
+    return Array.from(this.values.keys())[index] ?? null
+  }
+
+  removeItem(key: string): void {
+    this.values.delete(key)
+  }
+
+  setItem(key: string, value: string): void {
+    this.values.set(key, value)
+  }
+}
+
+describe('queue display token launch handoff', () => {
+  it('builds the public display URL without embedding the bearer token', () => {
+    const url = buildQueueDisplayUrl('https://app.mediflow.ph', 'queue-token-123')
+
+    expect(url).toBe('https://app.mediflow.ph/queue-display')
+    expect(url).not.toContain('queue-token-123')
+  })
+
+  it('stores the bearer token in tab-scoped storage for same-browser launch', () => {
+    const storage = new MemoryStorage()
+
+    storeQueueDisplayToken('queue-token-123', storage)
+
+    expect(readQueueDisplayToken(undefined, storage)).toBe('queue-token-123')
+  })
+
+  it('prefers a legacy route token only when it is a string', () => {
+    const storage = new MemoryStorage()
+    storeQueueDisplayToken('stored-token', storage)
+
+    expect(readQueueDisplayToken('legacy-token', storage)).toBe('legacy-token')
+    expect(readQueueDisplayToken(['bad-token'], storage)).toBe('stored-token')
+  })
+})

--- a/src/domains/queue/utils/displayTokenLaunch.ts
+++ b/src/domains/queue/utils/displayTokenLaunch.ts
@@ -1,0 +1,20 @@
+const QUEUE_DISPLAY_TOKEN_STORAGE_KEY = 'mediflow.queueDisplay.token'
+
+export function buildQueueDisplayUrl(origin: string, _token?: string | null): string {
+  return `${origin}/queue-display`
+}
+
+export function storeQueueDisplayToken(token: string, storage: Storage = window.sessionStorage): void {
+  storage.setItem(QUEUE_DISPLAY_TOKEN_STORAGE_KEY, token)
+}
+
+export function readQueueDisplayToken(
+  routeToken: string | string[] | undefined,
+  storage: Storage = window.sessionStorage,
+): string | null {
+  if (typeof routeToken === 'string' && routeToken.trim() !== '') {
+    return routeToken
+  }
+
+  return storage.getItem(QUEUE_DISPLAY_TOKEN_STORAGE_KEY)
+}

--- a/src/domains/queue/views/QueueDisplayView.vue
+++ b/src/domains/queue/views/QueueDisplayView.vue
@@ -6,6 +6,7 @@ import type { PublicationContext, SubscriptionTokenContext } from 'centrifuge'
 import { Clock, Users, Stethoscope, WifiOff } from 'lucide-vue-next'
 import { queueApi } from '@/domains/queue/api/queueApi'
 import type { QueueVisitResponse } from '@/domains/queue/types/queue.types'
+import { readQueueDisplayToken } from '@/domains/queue/utils/displayTokenLaunch'
 
 // ---------------------------------------------------------------------------
 // Types
@@ -23,7 +24,7 @@ interface RealtimeEvent {
 // ---------------------------------------------------------------------------
 
 const route = useRoute()
-const token = route.params.token as string
+const token = readQueueDisplayToken(route.params.token)
 
 const clinicName = ref('')
 const visits = ref<QueueVisitResponse[]>([])
@@ -106,6 +107,7 @@ let latestConnectionToken = ''
 let latestSubscriptionToken = ''
 
 async function fetchFreshTokens(): Promise<void> {
+  if (!token) throw new Error('INVALID_TOKEN')
   const tokens = await queueApi.refreshDisplayTokens(token)
   latestConnectionToken = tokens.connection_token
   latestSubscriptionToken = tokens.subscription_token
@@ -132,6 +134,7 @@ function clearTokenRefreshTimer(): void {
 }
 
 function startPollingFallback(): void {
+  if (!token) return
   if (pollTimer !== null) return
   pollTimer = setInterval(async () => {
     try {
@@ -239,13 +242,19 @@ async function bootstrap(): Promise<void> {
   isLoading.value = true
   displayError.value = null
 
+  if (!token) {
+    isLoading.value = false
+    displayError.value = 'INVALID_TOKEN'
+    return
+  }
+
   try {
     const data = await queueApi.getDisplay(token)
     clinicName.value = data.clinic_name
     visits.value = data.visits
     isLoading.value = false
 
-    // Remove token from URL so it doesn't linger in browser history or referrer headers
+    // Remove legacy path tokens from the URL so they don't linger in browser history or referrer headers
     window.history.replaceState(null, '', '/queue-display')
 
     initCentrifuge(

--- a/src/domains/queue/views/QueueView.vue
+++ b/src/domains/queue/views/QueueView.vue
@@ -48,6 +48,7 @@ import { useAuthStore } from '@/domains/auth/stores/authStore'
 import { useQueueStore } from '../stores/queueStore'
 import { queueApi } from '../api/queueApi'
 import type { QueueDisplayTokenStatus } from '../types/queue.types'
+import { buildQueueDisplayUrl, storeQueueDisplayToken } from '../utils/displayTokenLaunch'
 import QueueCard from '../components/QueueCard.vue'
 import QueueKanban from '../components/QueueKanban.vue'
 import WalkInDialog from '../components/WalkInDialog.vue'
@@ -181,7 +182,7 @@ async function confirmCancel() {
 
 const displayUrl = computed(() => {
   if (!displayToken.value.token) return null
-  return `${window.location.origin}/queue-display/${displayToken.value.token}`
+  return buildQueueDisplayUrl(window.location.origin, displayToken.value.token)
 })
 
 async function loadDisplayToken() {
@@ -223,12 +224,13 @@ async function revokeDisplayToken() {
 function copyDisplayUrl() {
   if (displayUrl.value) {
     navigator.clipboard.writeText(displayUrl.value)
-    toast.success('Link copied to clipboard')
+    toast.success('Display URL copied without access token')
   }
 }
 
 function openDisplayInNewTab() {
-  if (displayUrl.value) {
+  if (displayUrl.value && displayToken.value.token) {
+    storeQueueDisplayToken(displayToken.value.token)
     window.open(displayUrl.value, '_blank')
   }
 }
@@ -320,6 +322,9 @@ onUnmounted(() => {
                   <div class="rounded-md border bg-muted/50 p-2">
                     <p class="break-all text-xs font-mono text-muted-foreground">
                       {{ displayUrl }}
+                    </p>
+                    <p class="mt-1 text-[11px] text-muted-foreground">
+                      Open from this browser to keep the access token out of the URL and clipboard.
                     </p>
                   </div>
                   <div class="flex gap-2">

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -280,7 +280,7 @@ const router = createRouter({
       meta: { requiresAuth: true },
     },
     {
-      path: '/queue-display/:token',
+      path: '/queue-display/:token?',
       name: RouteNames.QUEUE_DISPLAY,
       component: () => import('@/domains/queue/views/QueueDisplayView.vue'),
       meta: { requiresAuth: false },


### PR DESCRIPTION
## Summary
- changes the queue display launch URL to `/queue-display` so the bearer token is not embedded in the browser path
- hands the token to same-browser display tabs through tab-scoped session storage before opening the display screen
- keeps legacy `/queue-display/:token` links readable but strips them back to `/queue-display`
- adds unit coverage for the tokenless launch URL and token handoff helper

Closes #16

## Tests
- `TEST_CMD='npm run test -- src/domains/queue/utils/displayTokenLaunch.spec.ts' docker compose -p fe-issue16-378 -f docker-compose.test.yml run --rm frontend-test`
- `TEST_CMD='npm run build' docker compose -p fe-issue16-378 -f docker-compose.test.yml run --rm frontend-test`
