### PR TITLE
fix: reduce realtime dashboard overfetch

### DIFF
--- a/src/composables/realtimeRefresh.spec.ts
+++ b/src/composables/realtimeRefresh.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createDebouncedRefresh, shouldRunFallbackRefresh } from './realtimeRefresh'
+
+describe('realtime refresh helpers', () => {
+  it('coalesces rapid realtime events into one refresh', () => {
+    vi.useFakeTimers()
+    const refresh = vi.fn()
+    const debouncedRefresh = createDebouncedRefresh(refresh, 500)
+
+    debouncedRefresh()
+    debouncedRefresh()
+    debouncedRefresh()
+
+    vi.advanceTimersByTime(499)
+    expect(refresh).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(1)
+    expect(refresh).toHaveBeenCalledTimes(1)
+
+    vi.useRealTimers()
+  })
+
+  it('runs fallback polling only while realtime is disconnected', () => {
+    expect(shouldRunFallbackRefresh(true)).toBe(false)
+    expect(shouldRunFallbackRefresh(false)).toBe(true)
+  })
+})

--- a/src/composables/realtimeRefresh.ts
+++ b/src/composables/realtimeRefresh.ts
@@ -1,0 +1,15 @@
+export function createDebouncedRefresh(refresh: () => void, delayMs: number): () => void {
+  let timer: ReturnType<typeof setTimeout> | null = null
+
+  return () => {
+    if (timer !== null) clearTimeout(timer)
+    timer = setTimeout(() => {
+      timer = null
+      refresh()
+    }, delayMs)
+  }
+}
+
+export function shouldRunFallbackRefresh(isRealtimeConnected: boolean): boolean {
+  return !isRealtimeConnected
+}

--- a/src/domains/billing/views/BillingView.vue
+++ b/src/domains/billing/views/BillingView.vue
@@ -32,6 +32,7 @@ import {
 } from '@/components/ui/dialog'
 import { useAuthStore } from '@/domains/auth/stores/authStore'
 import { useCentrifugo } from '@/composables/useCentrifugo'
+import { createDebouncedRefresh } from '@/composables/realtimeRefresh'
 import { useBillingStore } from '../stores/billingStore'
 import BillingStatCards from '../components/BillingStatCards.vue'
 import InvoiceTable from '../components/InvoiceTable.vue'
@@ -191,11 +192,15 @@ function onInvoiceCreated() {
 
 watch(statusFilter, onStatusChange)
 
+const refreshBillingFromRealtime = createDebouncedRefresh(() => {
+  fetchInvoices(billingStore.currentPage)
+  billingStore.fetchSummary()
+}, 500)
+
 function onBillingEvent(ctx: { data?: { type?: string } }) {
   const type = ctx.data?.type
   if (type?.startsWith('invoice.')) {
-    fetchInvoices(billingStore.currentPage)
-    billingStore.fetchSummary()
+    refreshBillingFromRealtime()
   }
 }
 

--- a/src/domains/dashboard/views/DoctorDashboardView.vue
+++ b/src/domains/dashboard/views/DoctorDashboardView.vue
@@ -22,6 +22,7 @@ import { Button } from '@/components/ui/button'
 import Skeleton from '@/components/ui/skeleton/Skeleton.vue'
 import { RouteNames } from '@/router/routeNames'
 import { useCentrifugo } from '@/composables/useCentrifugo'
+import { createDebouncedRefresh, shouldRunFallbackRefresh } from '@/composables/realtimeRefresh'
 import { queueApi } from '@/domains/queue/api/queueApi'
 import { toast } from 'vue-sonner'
 
@@ -129,7 +130,7 @@ async function fetchStats(): Promise<void> {
 }
 
 // Real-time updates
-const { subscribe, unsubscribe } = useCentrifugo()
+const { isConnected, subscribe, unsubscribe } = useCentrifugo()
 let pollInterval: ReturnType<typeof setInterval> | undefined
 
 function silentRefresh() {
@@ -137,6 +138,8 @@ function silentRefresh() {
     stats.value = response.data
   }).catch(() => {})
 }
+
+const refreshFromRealtime = createDebouncedRefresh(silentRefresh, 1_000)
 
 onMounted(() => {
   fetchStats()
@@ -146,12 +149,13 @@ onMounted(() => {
   if (clinicId) {
     const queueChannel = `clinic:${clinicId}:queue`
     subscribe(queueChannel, () => {
-      silentRefresh()
+      refreshFromRealtime()
     })
   }
 
-  // Fallback poll every 5 minutes in case Centrifugo disconnects
-  pollInterval = setInterval(silentRefresh, 5 * 60 * 1000)
+  pollInterval = setInterval(() => {
+    if (shouldRunFallbackRefresh(isConnected.value)) silentRefresh()
+  }, 5 * 60 * 1000)
 })
 
 onUnmounted(() => {

--- a/src/domains/dashboard/views/OwnerDashboardView.vue
+++ b/src/domains/dashboard/views/OwnerDashboardView.vue
@@ -15,6 +15,7 @@ import { dashboardApi } from '@/domains/dashboard/api/dashboardApi'
 import type { OwnerDashboardStats } from '@/domains/dashboard/api/dashboardApi'
 import { useAuthStore } from '@/domains/auth/stores/authStore'
 import { useCentrifugo } from '@/composables/useCentrifugo'
+import { createDebouncedRefresh, shouldRunFallbackRefresh } from '@/composables/realtimeRefresh'
 import StatCard from '@/domains/dashboard/components/StatCard.vue'
 import OwnerRevenueChart from '@/domains/dashboard/components/OwnerRevenueChart.vue'
 import { use } from 'echarts/core'
@@ -163,7 +164,7 @@ async function fetchStats(): Promise<void> {
 }
 
 // Real-time updates
-const { subscribe, unsubscribe } = useCentrifugo()
+const { isConnected, subscribe, unsubscribe } = useCentrifugo()
 let pollInterval: ReturnType<typeof setInterval> | undefined
 
 function silentRefresh() {
@@ -172,6 +173,8 @@ function silentRefresh() {
   }).catch(() => {})
 }
 
+const refreshFromRealtime = createDebouncedRefresh(silentRefresh, 1_000)
+
 onMounted(() => {
   fetchStats()
   if (isPro.value) fetchDistribution()
@@ -179,12 +182,13 @@ onMounted(() => {
   const clinicId = authStore.currentClinic?.id
   if (clinicId) {
     subscribe(`clinic:${clinicId}:queue`, () => {
-      silentRefresh()
+      refreshFromRealtime()
     })
   }
 
-  // Fallback poll every 5 minutes in case Centrifugo disconnects
-  pollInterval = setInterval(silentRefresh, 5 * 60 * 1000)
+  pollInterval = setInterval(() => {
+    if (shouldRunFallbackRefresh(isConnected.value)) silentRefresh()
+  }, 5 * 60 * 1000)
 })
 
 onUnmounted(() => {


### PR DESCRIPTION
## Summary
- debounce dashboard queue realtime refreshes so bursts of queue publications collapse into one stats request
- run owner/doctor dashboard fallback polling only while Centrifugo is disconnected
- debounce billing invoice realtime refreshes so invoice event bursts collapse into one list + summary refresh

Fixes #18.

## Tests
- `TEST_CMD='npm run test -- src/composables/realtimeRefresh.spec.ts' docker compose -p fe-issue18-378 -f docker-compose.test.yml run --rm frontend-test`
- `TEST_CMD='npm run build' docker compose -p fe-issue18-378 -f docker-compose.test.yml run --rm frontend-test`
