### PR TITLE
fix: escape narrative user content

### DIFF
--- a/src/lib/narrative.spec.ts
+++ b/src/lib/narrative.spec.ts
@@ -85,14 +85,25 @@ describe('buildNarrative', () => {
     expect(html.toLowerCase()).toContain('custom')
   })
 
-  it('strips disallowed HTML tags in the input via DOMPurify', () => {
-    const html = buildNarrative({ id: 'x', complaint: '<script>alert(1)</script>cold' })
-    // The script tag and its content should be removed by DOMPurify.
-    // (DOMPurify strips disallowed tags AND their inner content as the safe default,
-    // so `cold` — wrapped inside the `<strong>` along with the script — also goes
-    // when the implementation interpolates the raw user input into the strong tag.)
+  it('escapes user-provided HTML before rendering narrative emphasis', () => {
+    const html = buildNarrative({
+      id: 'x',
+      complaint: '<strong onclick="alert(1)">Pain</strong> <img src=x onerror="alert(2)"> cold',
+      diagnoses: ['<svg onload="alert(3)">Flu</svg>'],
+      advice: 'Rest <script>alert(4)</script>',
+      prescriptionItems: [
+        { drug_name: '<b onclick="alert(5)">Amoxicillin</b>', dose: '<img src=x onerror="alert(6)">500mg', frequency: 'TID', duration: '<script>alert(7)</script>7 days' },
+      ],
+    })
+
+    expect(html).toContain('<strong>&lt;strong onclick="alert(1)"&gt;pain&lt;/strong&gt; &lt;img src=x onerror="alert(2)"&gt; cold</strong>')
+    expect(html).toContain('<strong>&lt;svg onload="alert(3)"&gt;Flu&lt;/svg&gt;</strong>')
+    expect(html).toContain('&lt;script&gt;alert(4)&lt;/script&gt;')
+    expect(html).toContain('<strong>&lt;b onclick="alert(5)"&gt;Amoxicillin&lt;/b&gt;</strong>')
+    expect(html).not.toContain('<img')
     expect(html).not.toContain('<script>')
-    expect(html).not.toContain('alert(1)')
+    expect(html).not.toContain('<svg')
+    expect(html).not.toContain('<b onclick')
   })
 
   it('produces the same output when called twice with the same id', () => {

--- a/src/lib/narrative.ts
+++ b/src/lib/narrative.ts
@@ -65,6 +65,21 @@ function humanizeFrequency(freq: string): string {
   return FREQUENCY_HUMAN[freq] ?? freq.toLowerCase()
 }
 
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+}
+
+function userText(value: string): string {
+  return escapeHtml(value)
+}
+
+function emphasizedUserText(value: string): string {
+  return `<strong>${userText(value)}</strong>`
+}
+
 function joinList(items: string[]): string {
   if (items.length === 1) return items[0]!
   return items.slice(0, -1).join(', ') + ` and ${items[items.length - 1]}`
@@ -72,10 +87,10 @@ function joinList(items: string[]): string {
 
 function buildRxNarrative(items: { drug_name: string; dose: string; frequency: string; duration: string }[]): string {
   const parts = items.map((item) => {
-    let text = `<strong>${item.drug_name}</strong>`
-    if (item.dose) text += ` ${item.dose}`
+    let text = emphasizedUserText(item.drug_name)
+    if (item.dose) text += ` ${userText(item.dose)}`
     text += `, ${humanizeFrequency(item.frequency)}`
-    if (item.duration) text += ` for ${item.duration}`
+    if (item.duration) text += ` for ${userText(item.duration)}`
     return text
   })
   return joinList(parts)
@@ -102,13 +117,13 @@ export function buildNarrative(input: NarrativeInput): string {
   // Complaint
   if (input.complaint) {
     const fn = complaintPhrases[stableIndex(id, complaintPhrases.length)]!
-    parts.push(fn(input.complaint.toLowerCase()))
+    parts.push(fn(userText(input.complaint.toLowerCase())))
   }
 
   // Diagnoses
   const diagnoses = (input.diagnoses ?? []).filter(Boolean)
   if (diagnoses.length) {
-    const joined = joinList(diagnoses.map(d => `<strong>${d}</strong>`))
+    const joined = joinList(diagnoses.map(d => emphasizedUserText(d)))
     const fn = diagnosisPhrases[stableIndex(id + 'd', diagnosisPhrases.length)]!
     parts.push(fn(joined))
   }
@@ -116,7 +131,7 @@ export function buildNarrative(input: NarrativeInput): string {
   // Advice
   if (input.advice) {
     const fn = advicePhrases[stableIndex(id + 'a', advicePhrases.length)]!
-    parts.push(fn(input.advice.toLowerCase()))
+    parts.push(fn(userText(input.advice.toLowerCase())))
   }
 
   // Prescription


### PR DESCRIPTION
## Summary
- escapes user-provided consultation narrative fields before inserting system-owned `<strong>` emphasis
- covers complaint, diagnoses, advice, and prescription drug/dose/duration fields
- keeps DOMPurify as defense-in-depth with only `<strong>` allowed

Fixes #21.

## Tests
- `TEST_CMD='npm run test -- src/lib/narrative.spec.ts' docker compose -p fe-issue21-378 -f docker-compose.test.yml run --rm frontend-test`
- `TEST_CMD='npm run build' docker compose -p fe-issue21-378 -f docker-compose.test.yml run --rm frontend-test`
