### PR TITLE
fix: harden frontend checkout and diagnostics

### DIFF
--- a/src/__tests__/viteConfig.test.ts
+++ b/src/__tests__/viteConfig.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest'
+import config from '../../vite.config'
+
+describe('vite production hardening', () => {
+  it('explicitly disables production source maps', () => {
+    expect(config).toMatchObject({
+      build: {
+        sourcemap: false,
+      },
+    })
+  })
+})

--- a/src/domains/obgyn/components/ObGynPatientSections.vue
+++ b/src/domains/obgyn/components/ObGynPatientSections.vue
@@ -60,11 +60,11 @@ function navigateToPregnancy(pregnancyUuid: string) {
     name: RouteNames.PREGNANCY_DETAIL,
     params: { patientId: patientId.value, pregnancyId: pregnancyUuid },
   }
-  console.log('[OB-GYN] Navigating to:', target)
+  if (import.meta.env.DEV) console.log('[OB-GYN] Navigating to:', target)
   router.push(target).then(() => {
-    console.log('[OB-GYN] Navigation succeeded')
+    if (import.meta.env.DEV) console.log('[OB-GYN] Navigation succeeded')
   }).catch((err) => {
-    console.error('[OB-GYN] Navigation failed:', err)
+    if (import.meta.env.DEV) console.error('[OB-GYN] Navigation failed:', err)
   })
 }
 

--- a/src/domains/patient/views/PatientListView.vue
+++ b/src/domains/patient/views/PatientListView.vue
@@ -238,7 +238,7 @@ async function fetchPatients() {
     patients.value = response.data
     pagination.value = response.meta.pagination
   } catch (err) {
-    console.error('[PatientListView] fetchPatients failed:', err)
+    if (import.meta.env.DEV) console.error('[PatientListView] fetchPatients failed:', err)
     error.value = 'Failed to load patients. Please try again.'
   } finally {
     isLoading.value = false
@@ -253,7 +253,7 @@ async function fetchAttentionSummary() {
     const response = await patientApi.attentionSummary(6)
     attentionSummary.value = response.data
   } catch (err) {
-    console.error('[PatientListView] fetchAttentionSummary failed:', err)
+    if (import.meta.env.DEV) console.error('[PatientListView] fetchAttentionSummary failed:', err)
     attentionError.value = 'Failed to load attention items.'
   } finally {
     isAttentionLoading.value = false

--- a/src/domains/subscription/stores/subscriptionStore.spec.ts
+++ b/src/domains/subscription/stores/subscriptionStore.spec.ts
@@ -49,7 +49,7 @@ function makeSubscriptionApi(overrides: Partial<MockSubscriptionApi> = {}): Mock
       meta: { current_page: 2, last_page: 4, per_page: 10, total: 31 },
     }),
     createCheckout: vi.fn().mockResolvedValue({
-      data: { checkout_url: 'https://checkout.example/session', payment_id: 'payment-1' },
+      data: { checkout_url: 'https://checkout.paymongo.com/session', payment_id: 'payment-1' },
     }),
     cancel: vi.fn().mockResolvedValue({ message: 'Subscription will cancel at period end.' }),
     reactivate: vi.fn().mockResolvedValue({ message: 'Subscription reactivated.' }),
@@ -121,7 +121,7 @@ describe('subscriptionStore - actions', () => {
     await store.initiateCheckout()
 
     expect(subscriptionApi.createCheckout).toHaveBeenCalledOnce()
-    expect(window.location.href).toBe('https://checkout.example/session')
+    expect(window.location.href).toBe('https://checkout.paymongo.com/session')
     expect(store.checkoutLoading).toBe(false)
   })
 

--- a/src/domains/subscription/stores/subscriptionStore.test.ts
+++ b/src/domains/subscription/stores/subscriptionStore.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { isTrustedCheckoutUrl } from './subscriptionStore'
+
+describe('isTrustedCheckoutUrl', () => {
+  it('allows PayMongo checkout URLs over HTTPS', () => {
+    expect(isTrustedCheckoutUrl('https://checkout.paymongo.com/checkout?id=cs_123')).toBe(true)
+  })
+
+  it('rejects lookalike checkout hosts', () => {
+    expect(isTrustedCheckoutUrl('https://checkout.paymongo.com.evil.test/checkout')).toBe(false)
+  })
+
+  it('rejects non-HTTPS and malformed checkout URLs', () => {
+    expect(isTrustedCheckoutUrl('http://checkout.paymongo.com/checkout')).toBe(false)
+    expect(isTrustedCheckoutUrl('/billing/success')).toBe(false)
+    expect(isTrustedCheckoutUrl('not a url')).toBe(false)
+  })
+})

--- a/src/domains/subscription/stores/subscriptionStore.ts
+++ b/src/domains/subscription/stores/subscriptionStore.ts
@@ -3,6 +3,17 @@ import { ref } from 'vue'
 import { subscriptionApi } from '../api/subscriptionApi'
 import type { PaymentRecord, SubscriptionStatus } from '../types/subscription.types'
 
+const TRUSTED_CHECKOUT_HOST = 'checkout.paymongo.com'
+
+export function isTrustedCheckoutUrl(value: string): boolean {
+  try {
+    const url = new URL(value)
+    return url.protocol === 'https:' && url.hostname === TRUSTED_CHECKOUT_HOST
+  } catch {
+    return false
+  }
+}
+
 export const useSubscriptionStore = defineStore('subscription', () => {
   const status = ref<SubscriptionStatus | null>(null)
   const payments = ref<PaymentRecord[]>([])
@@ -40,7 +51,7 @@ export const useSubscriptionStore = defineStore('subscription', () => {
     try {
       const response = await subscriptionApi.createCheckout()
       const checkoutUrl = response.data.checkout_url
-      if (!checkoutUrl.startsWith('https://')) {
+      if (!isTrustedCheckoutUrl(checkoutUrl)) {
         throw new Error('Invalid checkout URL returned from server')
       }
       window.location.href = checkoutUrl

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -100,6 +100,9 @@ export default defineConfig({
   define: {
     __COMMIT_HASH__: JSON.stringify(commitHash),
   },
+  build: {
+    sourcemap: false,
+  },
   server: {
     host: '0.0.0.0',
     port: 5173,


### PR DESCRIPTION
## Summary
- Restricts subscription checkout redirects to HTTPS PayMongo checkout URLs
- Explicitly disables Vite production source maps and verifies no .map files are emitted
- Gates remaining production console diagnostics behind DEV
- Confirms committed .env files are ignored/not tracked

## Test Plan
- npm run test -- src/domains/subscription/stores/subscriptionStore.test.ts src/__tests__/viteConfig.test.ts
- TZ=UTC npm run test
- npm run build
- verified dist has no *.map files

Closes #25
