### PR TITLE
fix: align consultation invoice lookup route

### DIFF
--- a/src/domains/billing/api/billingApi.spec.ts
+++ b/src/domains/billing/api/billingApi.spec.ts
@@ -39,17 +39,17 @@ describe('billingApi', () => {
     expect(http.get).toHaveBeenNthCalledWith(2, '/invoices?page=2&per_page=25&status=paid&search=Juan+Dela+Cruz')
   })
 
-  it('loads invoice detail, encounter invoice, summary, and pdf metadata', async () => {
+  it('loads invoice detail, consultation invoice, summary, and pdf metadata', async () => {
     const http = makeHttp()
     const { billingApi } = await loadApi(http)
 
     await billingApi.get('invoice-1')
-    await billingApi.forEncounter('encounter-1')
+    await billingApi.forConsultation('consultation-1')
     await billingApi.summary()
     await billingApi.getPdf('invoice-1')
 
     expect(http.get).toHaveBeenNthCalledWith(1, '/invoices/invoice-1')
-    expect(http.get).toHaveBeenNthCalledWith(2, '/encounters/encounter-1/invoice')
+    expect(http.get).toHaveBeenNthCalledWith(2, '/consultations/consultation-1/invoice')
     expect(http.get).toHaveBeenNthCalledWith(3, '/billing/summary')
     expect(http.get).toHaveBeenNthCalledWith(4, '/invoices/invoice-1/pdf')
   })

--- a/src/domains/billing/api/billingApi.ts
+++ b/src/domains/billing/api/billingApi.ts
@@ -45,8 +45,8 @@ export const billingApi = {
     return http.post<InvoiceDetailResponse>(`/invoices/${id}/request-medcert`)
   },
 
-  forEncounter(encounterId: string): Promise<InvoiceDetailResponse> {
-    return http.get<InvoiceDetailResponse>(`/encounters/${encounterId}/invoice`)
+  forConsultation(consultationId: string): Promise<InvoiceDetailResponse> {
+    return http.get<InvoiceDetailResponse>(`/consultations/${consultationId}/invoice`)
   },
 
   summary(): Promise<BillingSummaryResponse> {

--- a/src/domains/billing/stores/billingStore.spec.ts
+++ b/src/domains/billing/stores/billingStore.spec.ts
@@ -3,7 +3,7 @@
  *
  * Coverage focus per Phase 3 plan:
  *   - Invoice fetch + pagination (page/total/last_page wiring).
- *   - Single-invoice fetch + per-encounter fetch fallback.
+ *   - Single-invoice fetch + per-consultation fetch fallback.
  *   - createInvoice / updateInvoice / recordPayment / voidInvoice — verify
  *     state mutation, list update, isSaving lifecycle.
  *   - Summary fetch.
@@ -19,7 +19,7 @@ interface MockBillingApi {
   recordPayment: ReturnType<typeof vi.fn>
   void: ReturnType<typeof vi.fn>
   requestMedCert: ReturnType<typeof vi.fn>
-  forEncounter: ReturnType<typeof vi.fn>
+  forConsultation: ReturnType<typeof vi.fn>
   summary: ReturnType<typeof vi.fn>
 }
 
@@ -71,7 +71,7 @@ function makeApi(overrides: Partial<MockBillingApi> = {}): MockBillingApi {
     recordPayment: vi.fn().mockResolvedValue({ data: makeInvoice() }),
     void: vi.fn().mockResolvedValue({ data: makeInvoice() }),
     requestMedCert: vi.fn().mockResolvedValue({ data: makeInvoice() }),
-    forEncounter: vi.fn().mockResolvedValue({ data: makeInvoice() }),
+    forConsultation: vi.fn().mockResolvedValue({ data: makeInvoice() }),
     summary: vi.fn().mockResolvedValue({
       data: { total_revenue_this_month: 0, outstanding_balance: 0, invoices_today: 0, paid_today: 0 },
     }),
@@ -137,7 +137,7 @@ describe('billingStore — fetchInvoices', () => {
   })
 })
 
-describe('billingStore — fetchInvoice / fetchForEncounter', () => {
+describe('billingStore — fetchInvoice / fetchForConsultation', () => {
   it('sets currentInvoice on success', async () => {
     const api = makeApi({
       get: vi.fn().mockResolvedValue({ data: makeInvoice({ id: 'inv-X' }) }),
@@ -149,26 +149,26 @@ describe('billingStore — fetchInvoice / fetchForEncounter', () => {
     expect(store.currentInvoice?.id).toBe('inv-X')
   })
 
-  it('fetchForEncounter returns invoice on success', async () => {
+  it('fetchForConsultation returns invoice on success', async () => {
     const api = makeApi({
-      forEncounter: vi.fn().mockResolvedValue({ data: makeInvoice({ id: 'inv-E', encounter_id: 'enc-7' }) }),
+      forConsultation: vi.fn().mockResolvedValue({ data: makeInvoice({ id: 'inv-C', encounter_id: 'consultation-7' }) }),
     })
     const { useBillingStore } = await loadStore(api)
     const store = useBillingStore()
 
-    const result = await store.fetchForEncounter('enc-7')
-    expect(result?.id).toBe('inv-E')
-    expect(store.currentInvoice?.id).toBe('inv-E')
+    const result = await store.fetchForConsultation('consultation-7')
+    expect(result?.id).toBe('inv-C')
+    expect(store.currentInvoice?.id).toBe('inv-C')
   })
 
-  it('fetchForEncounter returns null and clears currentInvoice when API rejects', async () => {
+  it('fetchForConsultation returns null and clears currentInvoice when API rejects', async () => {
     const api = makeApi({
-      forEncounter: vi.fn().mockRejectedValue(new Error('not found')),
+      forConsultation: vi.fn().mockRejectedValue(new Error('not found')),
     })
     const { useBillingStore } = await loadStore(api)
     const store = useBillingStore()
 
-    const result = await store.fetchForEncounter('enc-missing')
+    const result = await store.fetchForConsultation('consultation-missing')
     expect(result).toBeNull()
     expect(store.currentInvoice).toBeNull()
   })

--- a/src/domains/billing/stores/billingStore.ts
+++ b/src/domains/billing/stores/billingStore.ts
@@ -49,9 +49,9 @@ export const useBillingStore = defineStore('billing', () => {
     }
   }
 
-  async function fetchForEncounter(encounterId: string): Promise<InvoiceResponse | null> {
+  async function fetchForConsultation(consultationId: string): Promise<InvoiceResponse | null> {
     try {
-      const response = await billingApi.forEncounter(encounterId)
+      const response = await billingApi.forConsultation(consultationId)
       currentInvoice.value = response.data
       return response.data
     } catch {
@@ -150,7 +150,7 @@ export const useBillingStore = defineStore('billing', () => {
     totalInvoices,
     fetchInvoices,
     fetchInvoice,
-    fetchForEncounter,
+    fetchForConsultation,
     fetchSummary,
     createInvoice,
     updateInvoice,

--- a/src/domains/consultation/components/tabs/PaymentTab.vue
+++ b/src/domains/consultation/components/tabs/PaymentTab.vue
@@ -443,7 +443,7 @@ async function fetchInvoice() {
   isLoading.value = true
   loadError.value = null
   try {
-    const result = await billingStore.fetchForEncounter(props.encounterId)
+    const result = await billingStore.fetchForConsultation(props.encounterId)
     invoice.value = result
   } catch {
     loadError.value = 'Failed to load invoice.'


### PR DESCRIPTION
## Summary
- Fixes #82 by aligning the frontend consultation invoice lookup with the backend `/consultations/{uuid}/invoice` route.
- Renames billing API/store helpers from encounter-oriented naming to consultation-oriented naming.
- Updates PaymentTab to use the corrected consultation invoice lookup path.

## Tests
- `TEST_CMD='npm run test -- src/domains/billing/api/billingApi.spec.ts src/domains/billing/stores/billingStore.spec.ts' docker compose -p fe-issue82-378 -f docker-compose.test.yml run --rm frontend-test`
- `TEST_CMD='npm run build' docker compose -p fe-issue82-378 -f docker-compose.test.yml run --rm frontend-test`
