### PR TITLE
fix: reuse checked-in appointment encounter for triage

### DIFF
--- a/src/domains/appointment/stores/appointmentStore.spec.ts
+++ b/src/domains/appointment/stores/appointmentStore.spec.ts
@@ -379,19 +379,31 @@ describe('appointmentStore - mutations', () => {
     expect(store.current?.id).toBe('appt-1')
   })
 
-  it('checkInAppointment uses the nested appointment payload', async () => {
+  it('checkInAppointment uses the nested appointment payload and returns the linked queue visit', async () => {
+    const checkedIn = makeAppointment({ id: 'appt-1', status: 'checked_in' })
     const appointmentApi = makeAppointmentApi({
-      checkIn: vi.fn().mockResolvedValue({ data: { appointment: makeAppointment({ id: 'appt-1', status: 'checked_in' }) } }),
+      checkIn: vi.fn().mockResolvedValue({
+        data: {
+          appointment: checkedIn,
+          queue_visit: {
+            id: 'queue-1',
+            position: 1,
+            status: 'waiting',
+            encounter_id: 'encounter-1',
+          },
+        },
+      }),
     })
     const { useAppointmentStore } = await loadStore(appointmentApi)
     const store = useAppointmentStore()
     store.appointments = [makeAppointment({ id: 'appt-1' })]
     store.current = makeAppointment({ id: 'appt-1' })
 
-    await store.checkInAppointment('appt-1')
+    const result = await store.checkInAppointment('appt-1')
 
     expect(store.appointments[0]?.status).toBe('checked_in')
     expect(store.current?.status).toBe('checked_in')
+    expect(result.queue_visit.encounter_id).toBe('encounter-1')
   })
 
   it('markNoShow updates the matching list item and current appointment', async () => {

--- a/src/domains/appointment/stores/appointmentStore.ts
+++ b/src/domains/appointment/stores/appointmentStore.ts
@@ -5,6 +5,7 @@ import { scheduleApi } from '@/domains/schedule/api/scheduleApi'
 import type {
   AppointmentListFilters,
   AppointmentResponse,
+  CheckInResponse,
   ClinicDoctor,
   CreateAppointmentPayload,
 } from '../types/appointment.types'
@@ -159,11 +160,12 @@ export const useAppointmentStore = defineStore('appointment', () => {
     if (current.value?.id === uuid) current.value = response.data
   }
 
-  async function checkInAppointment(uuid: string): Promise<void> {
+  async function checkInAppointment(uuid: string): Promise<CheckInResponse['data']> {
     const response = await appointmentApi.checkIn(uuid)
     const idx = appointments.value.findIndex((a) => a.id === uuid)
     if (idx !== -1) appointments.value[idx] = response.data.appointment
     if (current.value?.id === uuid) current.value = response.data.appointment
+    return response.data
   }
 
   async function markNoShow(uuid: string): Promise<void> {

--- a/src/domains/appointment/types/appointment.types.ts
+++ b/src/domains/appointment/types/appointment.types.ts
@@ -81,6 +81,7 @@ export interface CheckInResponse {
       id: string
       position: number
       status: string
+      encounter_id: string | null
       [key: string]: unknown
     }
   }

--- a/src/domains/appointment/utils/triageRoute.spec.ts
+++ b/src/domains/appointment/utils/triageRoute.spec.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { buildAppointmentTriageRoute } from './triageRoute'
+
+const PATIENT_ID = 'patient-1'
+
+describe('buildAppointmentTriageRoute', () => {
+  it('opens the checked-in appointment encounter when the backend returns one', () => {
+    expect(buildAppointmentTriageRoute(PATIENT_ID, 'encounter-1')).toEqual({
+      name: 'encounter-detail',
+      params: {
+        patientId: PATIENT_ID,
+        id: 'encounter-1',
+      },
+    })
+  })
+
+  it('falls back to new encounter only when check-in did not return an encounter', () => {
+    expect(buildAppointmentTriageRoute(PATIENT_ID, null)).toEqual({
+      name: 'encounter-new',
+      params: { patientId: PATIENT_ID },
+    })
+  })
+})

--- a/src/domains/appointment/utils/triageRoute.ts
+++ b/src/domains/appointment/utils/triageRoute.ts
@@ -1,0 +1,18 @@
+import { RouteNames } from '@/router/routeNames'
+
+export function buildAppointmentTriageRoute(patientId: string, encounterId: string | null) {
+  if (encounterId) {
+    return {
+      name: RouteNames.ENCOUNTER_DETAIL,
+      params: {
+        patientId,
+        id: encounterId,
+      },
+    }
+  }
+
+  return {
+    name: RouteNames.ENCOUNTER_NEW,
+    params: { patientId },
+  }
+}

--- a/src/domains/appointment/views/AppointmentListView.vue
+++ b/src/domains/appointment/views/AppointmentListView.vue
@@ -5,7 +5,6 @@ import FeatureGate from '@/components/shared/FeatureGate.vue'
 import { toast } from 'vue-sonner'
 import { CalendarDate, getLocalTimeZone, today, type DateValue } from '@internationalized/date'
 import { AlertTriangle, CalendarCheck, CalendarIcon, ClipboardPlus, LayoutDashboard, List, LoaderCircle, Plus, UserRound, X } from 'lucide-vue-next'
-import { RouteNames } from '@/router/routeNames'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Calendar } from '@/components/ui/calendar'
@@ -36,6 +35,7 @@ import {
 import { useAuthStore } from '@/domains/auth/stores/authStore'
 import { useCentrifugo } from '@/composables/useCentrifugo'
 import { useAppointmentStore } from '../stores/appointmentStore'
+import { buildAppointmentTriageRoute } from '../utils/triageRoute'
 import AppointmentBookingWizard from '../components/AppointmentBookingWizard.vue'
 import AppointmentBoard from '../components/AppointmentBoard.vue'
 import AppointmentCalendar from '../components/AppointmentCalendar.vue'
@@ -311,21 +311,20 @@ function refreshVisibleView() {
 const showTriageDialog = ref(false)
 const triagePatientId = ref<string | null>(null)
 const triagePatientName = ref<string | null>(null)
+const triageEncounterId = ref<string | null>(null)
 
 async function handleCheckIn(id: string) {
   try {
-    await store.checkInAppointment(id)
+    const checkInData = await store.checkInAppointment(id)
     toast.success('Patient checked in')
     showDetailSheet.value = false
     refreshVisibleView()
 
-    // Find the appointment to get patient info for triage prompt
-    const appointment = store.appointments.find((a) => a.id === id)
-    if (appointment) {
-      triagePatientId.value = appointment.patient_id
-      triagePatientName.value = appointment.patient_name
-      showTriageDialog.value = true
-    }
+    const appointment = checkInData.appointment
+    triagePatientId.value = appointment.patient_id
+    triagePatientName.value = appointment.patient_name
+    triageEncounterId.value = checkInData.queue_visit.encounter_id
+    showTriageDialog.value = true
   } catch {
     toast.error('Failed to check in')
   }
@@ -334,10 +333,7 @@ async function handleCheckIn(id: string) {
 function goToTriage() {
   if (!triagePatientId.value) return
   showTriageDialog.value = false
-  router.push({
-    name: RouteNames.ENCOUNTER_NEW,
-    params: { patientId: triagePatientId.value },
-  })
+  router.push(buildAppointmentTriageRoute(triagePatientId.value, triageEncounterId.value))
 }
 
 // Cancel confirmation


### PR DESCRIPTION
## Summary
- Fixes #84 by preserving the encounter returned from appointment check-in and using it for the triage prompt.
- Updates appointment check-in store flow to return the backend check-in payload, including the linked queue visit encounter.
- Routes triage to the existing checked-in encounter when available, with the old new-encounter route kept only as a fallback when no encounter is returned.

## Tests
- `TEST_CMD='npm run test -- src/domains/appointment/stores/appointmentStore.spec.ts src/domains/appointment/utils/triageRoute.spec.ts' docker compose -p fe-issue84-378 -f docker-compose.test.yml run --rm frontend-test`
- `TEST_CMD='npm run build' docker compose -p fe-issue84-378 -f docker-compose.test.yml run --rm frontend-test`
