### PR TITLE
fix: stop caching authenticated API responses

### DIFF
--- a/src/domains/auth/stores/authStore.ts
+++ b/src/domains/auth/stores/authStore.ts
@@ -2,8 +2,10 @@ import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
 import { useTheme } from '@/composables/useTheme'
 import { useCentrifugo } from '@/composables/useCentrifugo'
+import { clearAppCaches } from '@/lib/appCaches'
 import { setAuthToken } from '@/lib/http'
 import { authApi } from '../api/authApi'
+
 import type { ClinicContext, GoogleAuthResponse, LoginCredentials, LoginResponse, Membership, SignupCredentials, User } from '../types/auth.types'
 
 export const useAuthStore = defineStore('auth', () => {
@@ -87,6 +89,7 @@ export const useAuthStore = defineStore('auth', () => {
   async function selectClinic(clinicId: string): Promise<void> {
     const response = await authApi.selectClinic(clinicId)
     setToken(response.data.access_token)
+    await clearAppCaches()
     await fetchUser()
   }
 
@@ -142,6 +145,7 @@ export const useAuthStore = defineStore('auth', () => {
     } catch {
       // Not supported or already absent — fine
     }
+    await clearAppCaches()
     token.value = null
     user.value = null
     memberships.value = []

--- a/src/lib/appCaches.spec.ts
+++ b/src/lib/appCaches.spec.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { APP_CACHE_NAMES, clearAppCaches } from './appCaches'
+
+const originalCaches = globalThis.caches
+
+describe('clearAppCaches', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    Object.defineProperty(globalThis, 'caches', {
+      configurable: true,
+      value: originalCaches,
+    })
+  })
+
+  it('deletes current and legacy app-owned runtime caches', async () => {
+    const deleteCache = vi.fn().mockResolvedValue(true)
+    Object.defineProperty(globalThis, 'caches', {
+      configurable: true,
+      value: { delete: deleteCache },
+    })
+
+    await clearAppCaches()
+
+    expect(APP_CACHE_NAMES).toContain('mediflow-catalogs')
+    expect(APP_CACHE_NAMES).toContain('mediflow-api')
+    expect(deleteCache).toHaveBeenCalledWith('mediflow-catalogs')
+    expect(deleteCache).toHaveBeenCalledWith('mediflow-api')
+  })
+
+  it('does nothing when Cache Storage is unavailable', async () => {
+    Object.defineProperty(globalThis, 'caches', {
+      configurable: true,
+      value: undefined,
+    })
+
+    await expect(clearAppCaches()).resolves.toBeUndefined()
+  })
+})

--- a/src/lib/appCaches.ts
+++ b/src/lib/appCaches.ts
@@ -1,0 +1,12 @@
+export const APP_CACHE_NAMES = [
+  'mediflow-catalogs',
+  // Legacy broad API cache. Keep deleting it so upgraded clients purge PHI
+  // that may have been stored by older service workers.
+  'mediflow-api',
+] as const
+
+export async function clearAppCaches(): Promise<void> {
+  if (!('caches' in globalThis) || !globalThis.caches) return
+
+  await Promise.all(APP_CACHE_NAMES.map((cacheName) => globalThis.caches.delete(cacheName)))
+}

--- a/src/pwa/workboxRuntimeCaching.spec.ts
+++ b/src/pwa/workboxRuntimeCaching.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { runtimeCaching } from './workboxRuntimeCaching'
+
+function matches(pattern: unknown, path: string, method = 'GET') {
+  if (typeof pattern !== 'function') return false
+  return pattern({
+    url: new URL(`https://api.mediflow.test${path}`),
+    request: { method },
+  })
+}
+
+describe('PWA runtime caching', () => {
+  it('does not include broad authenticated API runtime cache rules', () => {
+    expect(runtimeCaching.some((rule) => rule.options?.cacheName === 'mediflow-api')).toBe(false)
+  })
+
+  it('only runtime-caches explicitly safe catalog API endpoints', () => {
+    const rules = runtimeCaching.filter((rule) => rule.options?.cacheName === 'mediflow-catalogs')
+    expect(rules).toHaveLength(1)
+    const [catalogRule] = rules
+
+    expect(matches(catalogRule.urlPattern, '/api/icd10/search?q=flu')).toBe(true)
+    expect(matches(catalogRule.urlPattern, '/api/system-medicines')).toBe(true)
+    expect(matches(catalogRule.urlPattern, '/api/specialties')).toBe(true)
+
+    expect(matches(catalogRule.urlPattern, '/api/patients')).toBe(false)
+    expect(matches(catalogRule.urlPattern, '/api/encounters/enc-1')).toBe(false)
+    expect(matches(catalogRule.urlPattern, '/api/billing/invoices')).toBe(false)
+    expect(matches(catalogRule.urlPattern, '/api/messages/threads')).toBe(false)
+    expect(matches(catalogRule.urlPattern, '/api/queue/display/token')).toBe(false)
+    expect(matches(catalogRule.urlPattern, '/api/patients', 'POST')).toBe(false)
+  })
+})

--- a/src/pwa/workboxRuntimeCaching.ts
+++ b/src/pwa/workboxRuntimeCaching.ts
@@ -1,0 +1,41 @@
+type RuntimeCacheMatch = {
+  url: URL
+  request: Request
+}
+
+type RuntimeCacheRule = {
+  urlPattern: (match: RuntimeCacheMatch) => boolean
+  handler: 'StaleWhileRevalidate'
+  options: {
+    cacheName: string
+    expiration: {
+      maxEntries: number
+      maxAgeSeconds: number
+    }
+    cacheableResponse: {
+      statuses: number[]
+    }
+  }
+}
+
+function isCatalogApiPath(pathname: string): boolean {
+  return (
+    pathname.startsWith('/api/icd10') ||
+    pathname.startsWith('/api/system-medicines') ||
+    pathname.startsWith('/api/specialties')
+  )
+}
+
+export const runtimeCaching: RuntimeCacheRule[] = [
+  {
+    // Read-only public catalogs only. Authenticated clinic/PHI API responses
+    // must not be persisted in Workbox Cache Storage.
+    urlPattern: ({ url, request }) => request.method === 'GET' && isCatalogApiPath(url.pathname),
+    handler: 'StaleWhileRevalidate',
+    options: {
+      cacheName: 'mediflow-catalogs',
+      expiration: { maxEntries: 200, maxAgeSeconds: 60 * 60 * 24 * 7 },
+      cacheableResponse: { statuses: [0, 200] },
+    },
+  },
+]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,7 @@ import tailwindcss from '@tailwindcss/vite'
 import vue from '@vitejs/plugin-vue'
 import { defineConfig } from 'vite'
 import { VitePWA } from 'vite-plugin-pwa'
+import { runtimeCaching } from './src/pwa/workboxRuntimeCaching'
 
 let commitHash = 'dev'
 try {
@@ -47,39 +48,11 @@ export default defineConfig({
       },
       workbox: {
         globPatterns: ['**/*.{js,css,html,svg,png,ico,woff2}'],
-        // Don't precache the API — runtime caching handles it.
         navigateFallbackDenylist: [/^\/api\//],
         navigateFallback: '/index.html',
-        runtimeCaching: [
-          {
-            // Read-only catalogs — ICD-10 search, system medicines, specialty config.
-            // Stable, cacheable, fine to serve stale while revalidating.
-            urlPattern: ({ url }) =>
-              url.pathname.startsWith('/api/icd10') ||
-              url.pathname.startsWith('/api/system-medicines') ||
-              url.pathname.startsWith('/api/specialties'),
-            handler: 'StaleWhileRevalidate',
-            options: {
-              cacheName: 'mediflow-catalogs',
-              expiration: { maxEntries: 200, maxAgeSeconds: 60 * 60 * 24 * 7 },
-              cacheableResponse: { statuses: [0, 200] },
-            },
-          },
-          {
-            // GET requests for clinic data. Network-first so users see fresh
-            // data when online; cache is the offline fallback. Phase 2's
-            // SyncEngine will own richer per-repository caching.
-            urlPattern: ({ url, request }) =>
-              url.pathname.startsWith('/api/') && request.method === 'GET',
-            handler: 'NetworkFirst',
-            options: {
-              cacheName: 'mediflow-api',
-              networkTimeoutSeconds: 5,
-              expiration: { maxEntries: 500, maxAgeSeconds: 60 * 60 * 24 },
-              cacheableResponse: { statuses: [0, 200] },
-            },
-          },
-        ],
+        // Never runtime-cache authenticated clinic/PHI API data.
+        // Keep only explicitly safe catalog endpoints cacheable.
+        runtimeCaching,
       },
       devOptions: {
         // Keep the virtual:pwa-register module resolvable during dev so


### PR DESCRIPTION
## Summary
- Fixes #85 by removing the broad Workbox `mediflow-api` runtime cache for authenticated `/api/*` GET responses.
- Keeps only explicitly safe read-only catalog endpoints in `mediflow-catalogs`.
- Adds cache purge helpers so legacy `mediflow-api` and catalog caches are cleared on logout and clinic switch.

## Tests
- `npm run test -- src/pwa/workboxRuntimeCaching.spec.ts src/lib/appCaches.spec.ts src/__tests__/viteConfig.test.ts`
- `npm run build`
- Verified generated `dist/sw.js` contains no `mediflow-api` cache and no `NetworkFirst` API runtime cache.

## Risk notes
- Existing upgraded clients may still have old `mediflow-api` entries until logout/clinic switch or browser cache cleanup.
- This intentionally removes offline fallback for authenticated API data until a dedicated encrypted/scope-aware sync cache owns PHI storage.