### PR TITLE
fix: roll back rejected encounter saves

### DIFF
--- a/src/domains/encounter/stores/encounterStore.spec.ts
+++ b/src/domains/encounter/stores/encounterStore.spec.ts
@@ -229,6 +229,36 @@ describe('encounterStore — saveSection offline queueing', () => {
     expect(queueActionMock).not.toHaveBeenCalled()
     expect(store.saveError).toBe('Failed to save. Please try again.')
   })
+
+  it('rolls back optimistic encounter changes and cache writes when an online update is rejected', async () => {
+    const original = makeEncounter({
+      consultation: {
+        id: 'cons-1',
+        type: 'default',
+        triage: {} as never,
+        bmi: null,
+        assessment: { chief_complaint: 'Original complaint' } as never,
+        treatment_plan: {} as never,
+      },
+    })
+    const api = makeApi({
+      update: vi.fn().mockRejectedValue(new Error('validation failed')),
+    })
+    const { useEncounterStore } = await loadStore(api)
+    const store = useEncounterStore()
+    store.current = original
+
+    await store.saveSection({ assessment: { chief_complaint: 'Rejected complaint' } as never })
+
+    expect(store.current?.consultation?.assessment).toEqual({ chief_complaint: 'Original complaint' })
+    expect(cacheEncounterMock).not.toHaveBeenCalledWith(expect.objectContaining({
+      consultation: expect.objectContaining({
+        assessment: expect.objectContaining({ chief_complaint: 'Rejected complaint' }),
+      }),
+    }))
+    expect(queueActionMock).not.toHaveBeenCalled()
+    expect(store.saveError).toBe('Failed to save. Please try again.')
+  })
 })
 
 describe('encounterStore — finalize', () => {

--- a/src/domains/encounter/stores/encounterStore.ts
+++ b/src/domains/encounter/stores/encounterStore.ts
@@ -136,6 +136,8 @@ export const useEncounterStore = defineStore('encounter', () => {
     isSaving.value = true
     saveError.value = null
 
+    const previous = JSON.parse(JSON.stringify(current.value)) as EncounterResponse
+
     // Optimistically update the nested type-specific data
     const updated = { ...current.value }
 
@@ -184,8 +186,6 @@ export const useEncounterStore = defineStore('encounter', () => {
 
     current.value = updated
 
-    await cacheEncounter(updated as unknown as Record<string, unknown>)
-
     try {
       const response = await encounterApi.update(current.value.id, payload)
       current.value = response.data
@@ -200,10 +200,14 @@ export const useEncounterStore = defineStore('encounter', () => {
           body: payload,
           createdAt: Date.now(),
         })
+        await cacheEncounter(updated as unknown as Record<string, unknown>)
         isOfflineCached.value = true
         saveError.value = null
         toast.info('Saved offline — will sync when back online')
       } else {
+        current.value = previous
+        isOfflineCached.value = false
+        await cacheEncounter(previous as unknown as Record<string, unknown>)
         saveError.value = 'Failed to save. Please try again.'
       }
     } finally {


### PR DESCRIPTION
## Summary
- Fixes #87 by preserving the authoritative encounter snapshot before optimistic section saves.
- Stops writing optimistic online edits to IndexedDB before the backend accepts them.
- Rolls back `current` and rewrites the prior cached encounter when an online save is rejected.
- Keeps the existing offline queue behavior and only caches optimistic data for offline queued saves.

## Tests
- `npm run test -- src/domains/encounter/stores/encounterStore.spec.ts`
- `npm run build`

## Notes
- Rejected online saves still show the existing generic save error.
- Offline saves remain optimistic because they are explicitly queued for later sync.