### PR TITLE
fix: preserve rejected offline sync actions

### DIFF
--- a/src/composables/useOfflineSync.spec.ts
+++ b/src/composables/useOfflineSync.spec.ts
@@ -21,6 +21,7 @@ interface FakeSyncEngine {
   on: ReturnType<typeof vi.fn>
   flush: ReturnType<typeof vi.fn>
   pendingCount: ReturnType<typeof vi.fn>
+  failedCount: ReturnType<typeof vi.fn>
   /** Internal: dispatch an event manually from the test. */
   __emit: (type: string, payload: unknown) => void
 }
@@ -38,6 +39,7 @@ function makeSyncEngine(): FakeSyncEngine {
     }),
     flush: vi.fn().mockResolvedValue(undefined),
     pendingCount: vi.fn().mockResolvedValue(0),
+    failedCount: vi.fn().mockResolvedValue(0),
     __emit: (type: string, payload: unknown) => {
       for (const cb of handlers.get(type) ?? []) cb(payload)
     },
@@ -83,6 +85,7 @@ describe('useOfflineSync — setup', () => {
         'action-succeeded',
         'queue-drained',
         'queue-stopped',
+        'action-failed',
         'action-discarded',
       ]),
     )
@@ -120,11 +123,20 @@ describe('useOfflineSync — toast side-effects', () => {
     expect(toastMock.success).toHaveBeenCalledWith('Synced 2 offline changes')
   })
 
+  it('action-failed triggers a recovery review toast with the reason', async () => {
+    await loadComposable()
+    syncEngine.__emit('action-failed', { reason: 'HTTP 422: Request failed with status 422' })
+    expect(toastMock.error).toHaveBeenCalledWith(
+      'An offline change needs review',
+      expect.objectContaining({ description: 'HTTP 422: Request failed with status 422' }),
+    )
+  })
+
   it('action-discarded triggers an error toast with the reason', async () => {
     await loadComposable()
     syncEngine.__emit('action-discarded', { reason: 'max retries exceeded' })
     expect(toastMock.error).toHaveBeenCalledWith(
-      'An offline change was dropped',
+      'An offline change was dropped after retrying',
       expect.objectContaining({ description: 'max retries exceeded' }),
     )
   })

--- a/src/composables/useOfflineSync.ts
+++ b/src/composables/useOfflineSync.ts
@@ -15,6 +15,7 @@ import { syncEngine } from '@/lib/sync/SyncEngine'
 
 const isOnline = ref(navigator.onLine)
 const pendingCount = ref(0)
+const failedCount = ref(0)
 
 let listenersInstalled = false
 let refCount = 0
@@ -37,9 +38,13 @@ const unsubStopped = syncEngine.on('queue-stopped', ({ reason, processed }) => {
   }
   void refreshPendingCount()
 })
+const unsubFailed = syncEngine.on('action-failed', ({ reason }) => {
+  toast.error('An offline change needs review', { description: reason })
+  void refreshCounts()
+})
 const unsubDiscarded = syncEngine.on('action-discarded', ({ reason }) => {
-  toast.error('An offline change was dropped', { description: reason })
-  void refreshPendingCount()
+  toast.error('An offline change was dropped after retrying', { description: reason })
+  void refreshCounts()
 })
 
 // The composable unmounts periodically; keep the subscriptions alive for
@@ -47,11 +52,24 @@ const unsubDiscarded = syncEngine.on('action-discarded', ({ reason }) => {
 void unsubSucceeded
 void unsubDrained
 void unsubStopped
+void unsubFailed
 void unsubDiscarded
+
+async function refreshCounts(): Promise<void> {
+  await Promise.all([refreshPendingCount(), refreshFailedCount()])
+}
 
 async function refreshPendingCount(): Promise<void> {
   try {
     pendingCount.value = await syncEngine.pendingCount()
+  } catch {
+    // best-effort
+  }
+}
+
+async function refreshFailedCount(): Promise<void> {
+  try {
+    failedCount.value = await syncEngine.failedCount()
   } catch {
     // best-effort
   }
@@ -82,7 +100,7 @@ export function useOfflineSync() {
   onMounted(() => {
     refCount++
     installListeners()
-    void refreshPendingCount()
+    void refreshCounts()
     // If we mounted in an online state with a backlog, get started.
     if (navigator.onLine) {
       void syncEngine.flush()
@@ -100,7 +118,10 @@ export function useOfflineSync() {
   return {
     isOnline,
     pendingCount,
+    failedCount,
     flushQueue: () => syncEngine.flush(),
     refreshPendingCount,
+    refreshFailedCount,
+    refreshCounts,
   }
 }

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -43,12 +43,24 @@ export interface PendingAction {
   nextAttemptAt?: number
   /** Last captured error for diagnostics. Not used by retry logic. */
   lastError?: string
+  /** API response body for failed offline mutation recovery. */
+  lastErrorDetails?: unknown
+}
+
+export interface FailedAction extends Omit<PendingAction, 'id'> {
+  id?: number
+  originalActionId?: number
+  failedAt: number
+  status: number
+  reason: string
+  details?: unknown
 }
 
 class AppDatabase extends Dexie {
   encounters!: Table<CachedEncounter, string>
   labOrders!: Table<CachedLabOrder, string>
   pendingActions!: Table<PendingAction, number>
+  failedActions!: Table<FailedAction, number>
 
   constructor() {
     super('clinicapp-offline')
@@ -68,6 +80,15 @@ class AppDatabase extends Dexie {
       encounters: 'id',
       labOrders: 'encounter_id',
       pendingActions: '++id, createdAt, type, nextAttemptAt',
+    })
+
+    // v3 — retain permanently rejected offline mutations for user recovery
+    // instead of silently deleting clinical edits that the API rejected.
+    this.version(3).stores({
+      encounters: 'id',
+      labOrders: 'encounter_id',
+      pendingActions: '++id, createdAt, type, nextAttemptAt',
+      failedActions: '++id, failedAt, type, status',
     })
   }
 }

--- a/src/lib/offlineDb.ts
+++ b/src/lib/offlineDb.ts
@@ -1,6 +1,6 @@
-import { db, type PendingAction } from './db'
+import { db, type FailedAction, type PendingAction } from './db'
 
-export type { PendingAction }
+export type { FailedAction, PendingAction }
 
 // --- Encounters ---
 
@@ -44,4 +44,23 @@ export async function removePendingAction(key: number): Promise<void> {
 
 export async function getPendingActionCount(): Promise<number> {
   return db.pendingActions.count()
+}
+
+// --- Failed Actions (offline mutation recovery queue) ---
+
+export async function recordFailedAction(action: FailedAction): Promise<number> {
+  const { id: _ignored, ...rest } = action
+  return db.failedActions.add(rest as FailedAction)
+}
+
+export async function getFailedActions(): Promise<FailedAction[]> {
+  return db.failedActions.orderBy('failedAt').toArray()
+}
+
+export async function getFailedActionCount(): Promise<number> {
+  return db.failedActions.count()
+}
+
+export async function removeFailedAction(key: number): Promise<void> {
+  await db.failedActions.delete(key)
 }

--- a/src/lib/sync/SyncEngine.spec.ts
+++ b/src/lib/sync/SyncEngine.spec.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { resetIndexedDb } from '@/__tests__/helpers/mockDexie'
+import type { PendingAction } from '../db'
+
+class MockHttpError extends Error {
+  readonly status: number
+  readonly data?: unknown
+
+  constructor(status: number, message: string, data?: unknown) {
+    super(message)
+    this.name = 'HttpError'
+    this.status = status
+    this.data = data
+  }
+}
+
+const httpPatch = vi.fn()
+const httpPost = vi.fn()
+const httpDelete = vi.fn()
+const openedDbs: Array<{ close: () => void }> = []
+
+async function importSyncModules() {
+  vi.doMock('../http', () => ({
+    HttpError: MockHttpError,
+    http: {
+      patch: httpPatch,
+      post: httpPost,
+      delete: httpDelete,
+    },
+  }))
+
+  const [{ db }, { syncEngine }] = await Promise.all([
+    import('../db'),
+    import('./SyncEngine'),
+  ])
+
+  openedDbs.push(db)
+  return { db, syncEngine }
+}
+
+describe('SyncEngine', () => {
+  beforeEach(async () => {
+    while (openedDbs.length > 0) openedDbs.pop()?.close()
+    vi.resetModules()
+    await resetIndexedDb()
+    httpPatch.mockReset()
+    httpPost.mockReset()
+    httpDelete.mockReset()
+  })
+
+  it('moves 4xx clinical mutations to failed actions instead of silently discarding them', async () => {
+    const { db, syncEngine } = await importSyncModules()
+    const action: PendingAction = {
+      type: 'update-encounter',
+      url: '/encounters/enc-1',
+      method: 'PATCH',
+      body: { assessment: { chief_complaint: 'offline edit' } },
+      createdAt: 1_700_000_000_000,
+    }
+    await db.pendingActions.add(action)
+    httpPatch.mockRejectedValueOnce(new MockHttpError(422, 'Request failed with status 422', {
+      message: 'Chief complaint is required',
+      errors: { chief_complaint: ['Required'] },
+    }))
+    const failedHandler = vi.fn()
+    syncEngine.on('action-failed', failedHandler)
+
+    await syncEngine.flush()
+
+    await expect(db.pendingActions.count()).resolves.toBe(0)
+    const failedActions = await db.failedActions.toArray()
+    expect(failedActions).toHaveLength(1)
+    expect(failedActions[0]).toEqual(expect.objectContaining({
+      type: 'update-encounter',
+      url: '/encounters/enc-1',
+      method: 'PATCH',
+      body: { assessment: { chief_complaint: 'offline edit' } },
+      status: 422,
+      reason: 'HTTP 422: Request failed with status 422',
+    }))
+    expect(failedActions[0]?.details).toEqual({
+      message: 'Chief complaint is required',
+      errors: { chief_complaint: ['Required'] },
+    })
+    expect(failedHandler).toHaveBeenCalledWith(expect.objectContaining({
+      failedAction: expect.objectContaining({ status: 422, type: 'update-encounter' }),
+    }))
+  })
+
+  it('pauses sync on 401 and keeps the pending mutation for re-authenticated retry', async () => {
+    const { db, syncEngine } = await importSyncModules()
+    await db.pendingActions.add({
+      type: 'update-lab-order-item',
+      url: '/lab-orders/order-1/items/item-1',
+      method: 'PATCH',
+      body: { result: 'pending' },
+      createdAt: 1_700_000_000_001,
+    })
+    httpPatch.mockRejectedValueOnce(new MockHttpError(401, 'Unauthorized'))
+    const stoppedHandler = vi.fn()
+    syncEngine.on('queue-stopped', stoppedHandler)
+
+    await syncEngine.flush()
+
+    await expect(db.pendingActions.count()).resolves.toBe(1)
+    const failedForAction = await db.failedActions.where('type').equals('update-lab-order-item').toArray()
+    expect(failedForAction).toHaveLength(0)
+    expect(stoppedHandler).toHaveBeenCalledWith({ reason: 'auth', processed: 0 })
+  })
+})

--- a/src/lib/sync/SyncEngine.ts
+++ b/src/lib/sync/SyncEngine.ts
@@ -1,4 +1,4 @@
-import { db, type PendingAction } from '../db'
+import { db, type FailedAction, type PendingAction } from '../db'
 import { http, HttpError } from '../http'
 import type { ActionOutcome, SyncEventHandler, SyncEventMap, SyncEventType } from './types'
 
@@ -73,6 +73,16 @@ class SyncEngineImpl {
         await db.pendingActions.delete(id)
         this.emit('action-succeeded', { action })
         processed++
+      } else if (outcome === 'failed') {
+        const latestAction = await db.pendingActions.get(id)
+        const failedAction = await this.recordFailedAction(latestAction ?? action)
+        await db.pendingActions.delete(id)
+        this.emit('action-failed', {
+          action,
+          failedAction,
+          reason: failedAction.reason,
+        })
+        processed++
       } else if (outcome === 'discard') {
         await db.pendingActions.delete(id)
         this.emit('action-discarded', {
@@ -85,6 +95,9 @@ class SyncEngineImpl {
         // Stop processing so later actions don't starve behind this one's
         // backoff window.
         this.emit('queue-stopped', { reason: 'backoff', processed })
+        return
+      } else if (outcome === 'auth') {
+        this.emit('queue-stopped', { reason: 'auth', processed })
         return
       } else {
         // 'abort' — stop cleanly, don't touch the row.
@@ -116,14 +129,24 @@ class SyncEngineImpl {
       return 'abort'
     }
 
-    // 4xx is a permanent client error — the server said "this request is
-    // invalid". Retrying the same body won't help. Log and discard so the
-    // queue doesn't clog forever.
+    // 401 means the browser/session must re-authenticate before this queued
+    // clinical mutation can be retried. Keep it in pendingActions untouched.
+    if (err.status === 401) {
+      await db.pendingActions.update(action.id as number, {
+        lastError: 'HTTP 401: authentication required',
+      })
+      return 'auth'
+    }
+
+    // 4xx means the server rejected this exact offline mutation. Retrying the
+    // same body will not help, but deleting it would silently lose clinical
+    // data, so move it to failedActions for recovery/review.
     if (err.status >= 400 && err.status < 500) {
       await db.pendingActions.update(action.id as number, {
         lastError: `HTTP ${err.status}: ${err.message}`,
+        lastErrorDetails: err.data,
       })
-      return 'discard'
+      return 'failed'
     }
 
     // 5xx — server is struggling. Schedule exponential backoff.
@@ -150,8 +173,38 @@ class SyncEngineImpl {
     return 'retry'
   }
 
+  private async recordFailedAction(action: PendingAction): Promise<FailedAction> {
+    const failedAction: FailedAction = {
+      type: action.type,
+      url: action.url,
+      method: action.method,
+      body: action.body,
+      createdAt: action.createdAt,
+      attemptCount: action.attemptCount,
+      nextAttemptAt: action.nextAttemptAt,
+      lastError: action.lastError,
+      lastErrorDetails: action.lastErrorDetails,
+      originalActionId: action.id,
+      failedAt: Date.now(),
+      status: this.parseStatus(action.lastError),
+      reason: action.lastError ?? 'HTTP 400: rejected offline mutation',
+      details: action.lastErrorDetails,
+    }
+    const id = await db.failedActions.add(failedAction)
+    return { ...failedAction, id }
+  }
+
+  private parseStatus(error?: string): number {
+    const match = error?.match(/^HTTP (\d{3})/)
+    return match ? Number(match[1]) : 400
+  }
+
   async pendingCount(): Promise<number> {
     return db.pendingActions.count()
+  }
+
+  async failedCount(): Promise<number> {
+    return db.failedActions.count()
   }
 
   on<T extends SyncEventType>(event: T, handler: SyncEventHandler<T>): () => void {

--- a/src/lib/sync/types.ts
+++ b/src/lib/sync/types.ts
@@ -1,21 +1,24 @@
-import type { PendingAction } from '../db'
+import type { FailedAction, PendingAction } from '../db'
 
 /**
  * Decision returned by SyncEngine's per-action runner.
  *
  *   - 'succeeded' → remove from queue, continue
  *   - 'retry' → leave in queue with updated retry metadata, continue
- *   - 'abort' → stop processing entirely (network dropped, rate-limited, etc.)
- *   - 'discard' → remove from queue (permanent 4xx), continue with next
+ *   - 'abort' → stop processing entirely (network dropped, etc.)
+ *   - 'auth' → pause sync until the user re-authenticates
+ *   - 'failed' → move rejected clinical mutation to failedActions, continue
+ *   - 'discard' → remove from queue (retry budget exhausted), continue
  */
-export type ActionOutcome = 'succeeded' | 'retry' | 'abort' | 'discard'
+export type ActionOutcome = 'succeeded' | 'retry' | 'abort' | 'auth' | 'failed' | 'discard'
 
 export interface SyncEventMap {
   'action-succeeded': { action: PendingAction }
   'action-discarded': { action: PendingAction; reason: string }
+  'action-failed': { action: PendingAction; failedAction: FailedAction; reason: string }
   'action-retrying': { action: PendingAction; nextAttemptAt: number }
   'queue-drained': { processed: number }
-  'queue-stopped': { reason: 'offline' | 'error' | 'backoff'; processed: number }
+  'queue-stopped': { reason: 'offline' | 'error' | 'backoff' | 'auth'; processed: number }
   'conflict-detected': { entity: string; id: string; localUpdatedAt: string; remoteUpdatedAt: string }
 }
 


### PR DESCRIPTION
## Summary
- Fixes #88 by moving rejected 4xx offline clinical mutations into a durable `failedActions` IndexedDB store instead of silently deleting them.
- Pauses sync on `401` while preserving the pending mutation for retry after re-authentication.
- Emits `action-failed`, exposes failed sync counts, and shows a review-needed toast instead of a dropped-change toast for preserved failures.

## Tests
- `npm run test -- src/lib/sync/SyncEngine.spec.ts src/composables/useOfflineSync.spec.ts`
- `npm run build`

Closes #88
