### PR TITLE
fix(queue): handle one-time display tokens

### DIFF
--- a/src/domains/queue/types/queue.types.ts
+++ b/src/domains/queue/types/queue.types.ts
@@ -56,6 +56,8 @@ export interface QueueDisplayCentrifugoTokens {
 }
 
 export interface QueueDisplayTokenStatus {
-  token: string | null
+  active: boolean
+  token?: string | null
   created_at: string | null
+  expires_at: string | null
 }

--- a/src/domains/queue/utils/displayTokenStatus.test.ts
+++ b/src/domains/queue/utils/displayTokenStatus.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { hasActiveDisplayToken, hasLaunchableDisplayToken } from './displayTokenStatus'
+import type { QueueDisplayTokenStatus } from '../types/queue.types'
+
+const status = (overrides: Partial<QueueDisplayTokenStatus>): QueueDisplayTokenStatus => ({
+  active: false,
+  token: null,
+  created_at: null,
+  expires_at: null,
+  ...overrides,
+})
+
+describe('queue display token status helpers', () => {
+  it('treats generated one-time token responses as launchable', () => {
+    const generated = status({ active: true, token: 'raw-token-once' })
+
+    expect(hasActiveDisplayToken(generated)).toBe(true)
+    expect(hasLaunchableDisplayToken(generated)).toBe(true)
+  })
+
+  it('treats status responses without raw tokens as active but not launchable', () => {
+    const existing = status({ active: true, token: null })
+
+    expect(hasActiveDisplayToken(existing)).toBe(true)
+    expect(hasLaunchableDisplayToken(existing)).toBe(false)
+  })
+
+  it('treats revoked or missing display links as inactive', () => {
+    const missing = status({ active: false, token: null })
+
+    expect(hasActiveDisplayToken(missing)).toBe(false)
+    expect(hasLaunchableDisplayToken(missing)).toBe(false)
+  })
+})

--- a/src/domains/queue/utils/displayTokenStatus.ts
+++ b/src/domains/queue/utils/displayTokenStatus.ts
@@ -1,0 +1,9 @@
+import type { QueueDisplayTokenStatus } from '../types/queue.types'
+
+export function hasLaunchableDisplayToken(status: QueueDisplayTokenStatus): status is QueueDisplayTokenStatus & { token: string } {
+  return typeof status.token === 'string' && status.token.length > 0
+}
+
+export function hasActiveDisplayToken(status: QueueDisplayTokenStatus): boolean {
+  return status.active === true || hasLaunchableDisplayToken(status)
+}

--- a/src/domains/queue/views/QueueView.vue
+++ b/src/domains/queue/views/QueueView.vue
@@ -49,6 +49,7 @@ import { useQueueStore } from '../stores/queueStore'
 import { queueApi } from '../api/queueApi'
 import type { QueueDisplayTokenStatus } from '../types/queue.types'
 import { buildQueueDisplayUrl, storeQueueDisplayToken } from '../utils/displayTokenLaunch'
+import { hasActiveDisplayToken, hasLaunchableDisplayToken } from '../utils/displayTokenStatus'
 import QueueCard from '../components/QueueCard.vue'
 import QueueKanban from '../components/QueueKanban.vue'
 import WalkInDialog from '../components/WalkInDialog.vue'
@@ -70,7 +71,7 @@ const error = ref<string | null>(null)
 const statusFilter = ref<string>('all')
 const viewMode = ref<'list' | 'kanban'>(window.innerWidth < 1024 ? 'list' : 'kanban')
 
-const displayToken = ref<QueueDisplayTokenStatus>({ token: null, created_at: null })
+const displayToken = ref<QueueDisplayTokenStatus>({ active: false, token: null, created_at: null, expires_at: null })
 const isLoadingDisplayToken = ref(false)
 const isGeneratingDisplayToken = ref(false)
 const isRevokingDisplayToken = ref(false)
@@ -212,7 +213,7 @@ async function revokeDisplayToken() {
   isRevokingDisplayToken.value = true
   try {
     await queueApi.revokeDisplayToken()
-    displayToken.value = { token: null, created_at: null }
+    displayToken.value = { active: false, token: null, created_at: null, expires_at: null }
     toast.success('Display link revoked')
   } catch {
     toast.error('Failed to revoke display link')
@@ -317,8 +318,8 @@ onUnmounted(() => {
                   <LoaderCircle class="size-4 animate-spin text-muted-foreground" />
                 </div>
 
-                <!-- Has active token -->
-                <template v-else-if="displayToken.token">
+                <!-- Newly generated token: launchable once in this browser -->
+                <template v-else-if="hasLaunchableDisplayToken(displayToken)">
                   <div class="rounded-md border bg-muted/50 p-2">
                     <p class="break-all text-xs font-mono text-muted-foreground">
                       {{ displayUrl }}
@@ -330,13 +331,44 @@ onUnmounted(() => {
                   <div class="flex gap-2">
                     <Button variant="outline" size="sm" class="flex-1 h-8" @click="copyDisplayUrl">
                       <Copy class="size-3.5" />
-                      Copy
+                      Copy App URL
                     </Button>
                     <Button variant="outline" size="sm" class="flex-1 h-8" @click="openDisplayInNewTab">
                       <ExternalLink class="size-3.5" />
                       Open
                     </Button>
                   </div>
+                  <Button
+                    variant="destructive"
+                    size="sm"
+                    class="h-8 w-full"
+                    :disabled="isRevokingDisplayToken"
+                    @click="revokeDisplayToken"
+                  >
+                    <LoaderCircle v-if="isRevokingDisplayToken" class="size-3.5 animate-spin" />
+                    <Trash2 v-else class="size-3.5" />
+                    Revoke Link
+                  </Button>
+                </template>
+
+                <!-- Existing active token: raw token is intentionally not returned again -->
+                <template v-else-if="hasActiveDisplayToken(displayToken)">
+                  <div class="rounded-md border bg-muted/50 p-3">
+                    <p class="text-sm font-medium">Display link is active</p>
+                    <p class="mt-1 text-xs text-muted-foreground">
+                      For security, existing display links cannot be shown again. Generate a new link if you need to copy or open it from this browser.
+                    </p>
+                  </div>
+                  <Button
+                    size="sm"
+                    class="h-8 w-full"
+                    :disabled="isGeneratingDisplayToken"
+                    @click="generateDisplayToken"
+                  >
+                    <LoaderCircle v-if="isGeneratingDisplayToken" class="size-3.5 animate-spin" />
+                    <Monitor v-else class="size-3.5" />
+                    Generate New Link
+                  </Button>
                   <Button
                     variant="destructive"
                     size="sm"


### PR DESCRIPTION
## Summary
- align queue display UI with the backend one-time raw token contract
- show existing active display links without exposing a raw token
- keep newly generated tokens launchable from the current browser via session storage
- add targeted helper tests for launchable vs active token states

## Test Plan
- `npm test -- src/domains/queue/utils/displayTokenStatus.test.ts`
- `npm run build`

Companion to backend issue jomaf1010/clinic-be#96.
