### PR TITLE
fix: honor requiresGuest route guard

### DIFF
--- a/src/router/index.spec.ts
+++ b/src/router/index.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { useAuthStore } from '@/domains/auth/stores/authStore'
 import router, { canAccessRequiredPermission } from './index'
 import { RouteNames } from './routeNames'
 
@@ -30,5 +31,32 @@ describe('sensitive route guards', () => {
   it('does not expose the retired odontogram playground route', () => {
     expect(router.getRoutes().some((route) => route.path === '/odontogram')).toBe(false)
     expect(router.getRoutes().some((route) => route.name === 'odontogram-playground')).toBe(false)
+  })
+
+  it('redirects authenticated users away from every requiresGuest route', async () => {
+    const authStore = useAuthStore()
+    authStore.setToken('test-token')
+    authStore.user = {
+      id: 'user-1',
+      name: 'Doctor Test',
+      email: 'doctor@example.test',
+      email_verified_at: '2026-05-08T00:00:00Z',
+      onboarding_completed: true,
+      current_clinic: {
+        id: 'clinic-1',
+        name: 'Test Clinic',
+        role: 'owner',
+        permissions: [],
+        features: [],
+        plan: 'pro',
+      },
+    } as typeof authStore.user
+    authStore.memberships = [{ clinic_id: 'clinic-1', status: 'active' }] as typeof authStore.memberships
+
+    for (const routeName of [RouteNames.FORGOT_PASSWORD, RouteNames.RESET_PASSWORD]) {
+      await router.push({ name: routeName })
+
+      expect(router.currentRoute.value.name).toBe(RouteNames.HOME)
+    }
   })
 })

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -326,8 +326,14 @@ router.beforeEach(async (to) => {
     }
   }
 
-  // Authenticated on auth pages → redirect based on state
-  if ((to.name === RouteNames.LOGIN || to.name === RouteNames.SIGNUP || to.name === RouteNames.VERIFY_EMAIL_NOTICE || to.name === RouteNames.VERIFY_EMAIL) && authStore.isAuthenticated) {
+  const isAuthPage =
+    to.name === RouteNames.LOGIN ||
+    to.name === RouteNames.SIGNUP ||
+    to.name === RouteNames.VERIFY_EMAIL_NOTICE ||
+    to.name === RouteNames.VERIFY_EMAIL
+
+  // Authenticated on guest-only pages → redirect based on state
+  if ((to.meta.requiresGuest || isAuthPage) && authStore.isAuthenticated) {
     if (authStore.needsOnboarding) {
       return { name: RouteNames.ONBOARDING_CREATE_CLINIC }
     }


### PR DESCRIPTION
## Summary
- Apply the existing authenticated-user redirect behavior to all routes marked `requiresGuest`.
- Keep current auth-page redirect targets for onboarding, clinic selection, and home.
- Add router regression coverage for authenticated users hitting forgot/reset password guest routes.

## Tests
- `npm run test -- src/router/index.spec.ts`
- `npm run build`

Closes #91
