### PR TITLE
Fix narrative HTML sanitization

### DIFF
--- a/src/lib/narrative.security.spec.ts
+++ b/src/lib/narrative.security.spec.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import { buildNarrative, buildVitalsNarrative } from './narrative'
+import type { ConsultationTriage } from '@/domains/consultation/types/consultation.types'
+
+describe('narrative HTML safety', () => {
+  it('escapes user-controlled consultation text while keeping allowed emphasis tags', () => {
+    const html = buildNarrative({
+      id: 'encounter-xss-check',
+      complaint: '<img src=x onerror=alert(1)> Fever',
+      diagnoses: ['<svg onload=alert(2)>Viral URI</svg>'],
+      advice: '<script>alert(3)</script> rest',
+      prescriptionItems: [
+        {
+          drug_name: '<img src=x onerror=alert(4)>Paracetamol',
+          dose: '<script>alert(5)</script>500mg',
+          frequency: 'BID',
+          duration: '<iframe srcdoc=alert(6)>3 days</iframe>',
+        },
+      ],
+    })
+
+    expect(html).toContain('<strong>')
+    expect(html).not.toContain('<img')
+    expect(html).not.toContain('<svg')
+    expect(html).not.toContain('<script')
+    expect(html).not.toContain('<iframe')
+    expect(html).not.toContain('onerror')
+    expect(html).not.toContain('onload')
+    expect(html).toContain('fever')
+  })
+
+  it('sanitizes vitals narrative output rendered through v-html', () => {
+    const current = {
+      vitals: {
+        bp: '<img src=x onerror=alert(1)>120/80',
+        hr: 90,
+        rr: 18,
+        temp: 37,
+        spo2: 98,
+        blood_sugar: 100,
+        weight: 70,
+        height: 170,
+        pain_score: 1,
+      },
+    } satisfies ConsultationTriage
+
+    const previous = {
+      vitals: {
+        bp: '110/70',
+        hr: 80,
+        rr: 18,
+        temp: 37,
+        spo2: 98,
+        blood_sugar: 100,
+        weight: 70,
+        height: 170,
+        pain_score: 1,
+      },
+    } satisfies ConsultationTriage
+
+    const html = buildVitalsNarrative('vitals-xss-check', current, previous)
+
+    expect(html).toContain('<strong>')
+    expect(html).not.toContain('<img')
+    expect(html).not.toContain('onerror')
+  })
+})

--- a/src/lib/narrative.spec.ts
+++ b/src/lib/narrative.spec.ts
@@ -96,14 +96,13 @@ describe('buildNarrative', () => {
       ],
     })
 
-    expect(html).toContain('<strong>&lt;strong onclick="alert(1)"&gt;pain&lt;/strong&gt; &lt;img src=x onerror="alert(2)"&gt; cold</strong>')
-    expect(html).toContain('<strong>&lt;svg onload="alert(3)"&gt;Flu&lt;/svg&gt;</strong>')
-    expect(html).toContain('&lt;script&gt;alert(4)&lt;/script&gt;')
-    expect(html).toContain('<strong>&lt;b onclick="alert(5)"&gt;Amoxicillin&lt;/b&gt;</strong>')
-    expect(html).not.toContain('<img')
-    expect(html).not.toContain('<script>')
+    expect(html).toContain('<strong>pain  cold</strong>')
     expect(html).not.toContain('<svg')
-    expect(html).not.toContain('<b onclick')
+    expect(html).not.toContain('<script')
+    expect(html).not.toContain('<img')
+    expect(html).not.toContain('onclick')
+    expect(html).not.toContain('onerror')
+    expect(html).not.toContain('onload')
   })
 
   it('produces the same output when called twice with the same id', () => {

--- a/src/lib/narrative.ts
+++ b/src/lib/narrative.ts
@@ -62,7 +62,7 @@ const prescriptionIntroPhrases = [
 // -- Helpers ------------------------------------------------------------
 
 function humanizeFrequency(freq: string): string {
-  return FREQUENCY_HUMAN[freq] ?? freq.toLowerCase()
+  return FREQUENCY_HUMAN[freq] ?? userText(freq.toLowerCase())
 }
 
 function escapeHtml(value: string): string {
@@ -73,11 +73,17 @@ function escapeHtml(value: string): string {
 }
 
 function userText(value: string): string {
-  return escapeHtml(value)
+  const textOnly = DOMPurify
+    .sanitize(value, { ALLOWED_TAGS: [], ALLOWED_ATTR: [] })
+    .replace(/<[^>]*>/g, '')
+    .trim()
+
+  return escapeHtml(textOnly)
 }
 
 function emphasizedUserText(value: string): string {
-  return `<strong>${userText(value)}</strong>`
+  const text = userText(value)
+  return text ? `<strong>${text}</strong>` : ''
 }
 
 function joinList(items: string[]): string {
@@ -88,12 +94,13 @@ function joinList(items: string[]): string {
 function buildRxNarrative(items: { drug_name: string; dose: string; frequency: string; duration: string }[]): string {
   const parts = items.map((item) => {
     let text = emphasizedUserText(item.drug_name)
+    if (!text) return ''
     if (item.dose) text += ` ${userText(item.dose)}`
     text += `, ${humanizeFrequency(item.frequency)}`
     if (item.duration) text += ` for ${userText(item.duration)}`
     return text
-  })
-  return joinList(parts)
+  }).filter(Boolean)
+  return parts.length ? joinList(parts) : ''
 }
 
 // -- Main builder -------------------------------------------------------
@@ -116,22 +123,24 @@ export function buildNarrative(input: NarrativeInput): string {
 
   // Complaint
   if (input.complaint) {
+    const complaint = userText(input.complaint.toLowerCase())
     const fn = complaintPhrases[stableIndex(id, complaintPhrases.length)]!
-    parts.push(fn(userText(input.complaint.toLowerCase())))
+    if (complaint) parts.push(fn(complaint))
   }
 
   // Diagnoses
-  const diagnoses = (input.diagnoses ?? []).filter(Boolean)
+  const diagnoses = (input.diagnoses ?? []).map(d => emphasizedUserText(d)).filter(Boolean)
   if (diagnoses.length) {
-    const joined = joinList(diagnoses.map(d => emphasizedUserText(d)))
+    const joined = joinList(diagnoses)
     const fn = diagnosisPhrases[stableIndex(id + 'd', diagnosisPhrases.length)]!
     parts.push(fn(joined))
   }
 
   // Advice
   if (input.advice) {
+    const advice = userText(input.advice.toLowerCase())
     const fn = advicePhrases[stableIndex(id + 'a', advicePhrases.length)]!
-    parts.push(fn(userText(input.advice.toLowerCase())))
+    if (advice) parts.push(fn(advice))
   }
 
   // Prescription
@@ -139,7 +148,7 @@ export function buildNarrative(input: NarrativeInput): string {
   if (rxItems.length) {
     const rxText = buildRxNarrative(rxItems)
     const fn = prescriptionIntroPhrases[stableIndex(id + 'rx', prescriptionIntroPhrases.length)]!
-    parts.push(fn(rxText))
+    if (rxText) parts.push(fn(rxText))
   }
 
   if (!parts.length) return ''


### PR DESCRIPTION
## Summary
- strips user-controlled HTML before narrative emphasis is rendered through v-html
- sanitizes fallback prescription frequency text
- skips empty sanitized narrative/Rx fragments to avoid blank emphasis tags
- adds regression coverage for narrative/vitals XSS payloads

## Verification
- npm run test -- src/lib/narrative.spec.ts src/lib/narrative.security.spec.ts
- TZ=UTC npm run test
- npm run build
- npm audit --omit=dev