### PR TITLE
fix: remove stale pediatrics consultation todos

### DIFF
--- a/src/domains/consultation/components/specialties/pediatrics/PediatricsAssessmentSection.vue
+++ b/src/domains/consultation/components/specialties/pediatrics/PediatricsAssessmentSection.vue
@@ -247,7 +247,5 @@ function emitSave() {
         Type to search or press Enter to add a custom diagnosis
       </p>
     </div>
-
-    <!-- TODO: Developmental screening section (ASQ-3, M-CHAT) -->
   </div>
 </template>

--- a/src/domains/consultation/components/specialties/pediatrics/PediatricsSections.spec.ts
+++ b/src/domains/consultation/components/specialties/pediatrics/PediatricsSections.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const consultationPedsDir = join(process.cwd(), 'src/domains/consultation/components/specialties/pediatrics')
+const patientPedsSectionsPath = join(process.cwd(), 'src/domains/patient/components/specialties/pediatrics/PediatricsPatientSections.vue')
+const vitalsSummaryPath = join(process.cwd(), 'src/domains/consultation/components/VitalsSummary.vue')
+
+function readSource(path: string) {
+  return readFileSync(path, 'utf8')
+}
+
+describe('pediatrics consultation cleanup', () => {
+  it('does not keep stale growth/development TODOs now surfaced in patient pediatrics flows', () => {
+    const triageSource = readSource(join(consultationPedsDir, 'PediatricsTriageSection.vue'))
+    const assessmentSource = readSource(join(consultationPedsDir, 'PediatricsAssessmentSection.vue'))
+    const patientPedsSource = readSource(patientPedsSectionsPath)
+    const vitalsSource = readSource(vitalsSummaryPath)
+
+    expect(triageSource).not.toContain('TODO: Growth chart section')
+    expect(triageSource).not.toContain('TODO: Developmental screening section')
+    expect(assessmentSource).not.toContain('TODO: Developmental screening section')
+
+    expect(vitalsSource).toContain('<GrowthChartDialog v-if="isPediatrics"')
+    expect(patientPedsSource).toContain('<GrowthChart')
+    expect(patientPedsSource).toContain('Developmental Milestones')
+    expect(patientPedsSource).toContain('Developmental Assessment')
+  })
+})

--- a/src/domains/consultation/components/specialties/pediatrics/PediatricsTriageSection.vue
+++ b/src/domains/consultation/components/specialties/pediatrics/PediatricsTriageSection.vue
@@ -164,8 +164,5 @@ function emitSave() {
         @blur="onBlur"
       />
     </div>
-
-    <!-- TODO: Growth chart section (plot weight/height/head-circumference against WHO growth charts) -->
-    <!-- TODO: Developmental screening section (ASQ-3, M-CHAT) -->
   </div>
 </template>


### PR DESCRIPTION
## Summary
- Remove stale pediatrics consultation TODOs for growth charts and developmental screening.
- Keep the existing surfaced flows intact: GrowthChartDialog from consultation vitals and growth/development sections in patient pediatrics.
- Add a sentinel regression test so these stale TODOs do not return while the replacement flows remain referenced.

## Tests
- `npm run test -- src/domains/consultation/components/specialties/pediatrics/PediatricsSections.spec.ts`
- `npm run build`

Closes #93
