### PR TITLE
fix: improve auth form accessibility validation

### DIFF
--- a/src/components/ui/input/PasswordInput.spec.ts
+++ b/src/components/ui/input/PasswordInput.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { mountWithDeps } from '@/__tests__/helpers/mountWithDeps'
+import PasswordInput from './PasswordInput.vue'
+
+describe('PasswordInput', () => {
+  it('exposes a keyboard-focusable password reveal control with an accessible label', async () => {
+    const wrapper = mountWithDeps(PasswordInput, {
+      global: {
+        stubs: {
+          Eye: true,
+          EyeOff: true,
+        },
+      },
+    })
+
+    const button = wrapper.get('button[type="button"]')
+
+    expect(button.attributes('tabindex')).toBeUndefined()
+    expect(button.attributes('aria-label')).toBe('Show password')
+    expect(wrapper.get('input').attributes('type')).toBe('password')
+
+    await button.trigger('click')
+
+    expect(button.attributes('aria-label')).toBe('Hide password')
+    expect(wrapper.get('input').attributes('type')).toBe('text')
+  })
+})

--- a/src/components/ui/input/PasswordInput.vue
+++ b/src/components/ui/input/PasswordInput.vue
@@ -39,8 +39,8 @@ const showPassword = ref(false)
     >
     <button
       type="button"
-      tabindex="-1"
-      class="absolute right-3.5 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+      :aria-label="showPassword ? 'Hide password' : 'Show password'"
+      class="absolute right-3.5 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:ring-offset-2"
       @click="showPassword = !showPassword"
     >
       <EyeOff v-if="showPassword" class="size-4" />

--- a/src/lib/validationRules.spec.ts
+++ b/src/lib/validationRules.spec.ts
@@ -230,10 +230,13 @@ describe('schema adapters', () => {
 })
 
 describe('composed schemas', () => {
-  it('loginSchema enforces required email and password', () => {
-    expect(loginSchema.email('')).toBe('Email is required.')
+  it('loginSchema enforces required email, email format, and password', () => {
+    const emailRules = loginSchema.email
+
+    expect(emailRules[0]('')).toBe('Email is required.')
+    expect(emailRules[1]('not-email')).toBe('Email must be a valid email address.')
+    expect(emailRules[1]('user@example.com')).toBe(true)
     expect(loginSchema.password('')).toBe('Password is required.')
-    expect(loginSchema.email('user@example.com')).toBe(true)
     expect(loginSchema.password('hunter2')).toBe(true)
   })
 

--- a/src/lib/validationRules.ts
+++ b/src/lib/validationRules.ts
@@ -152,7 +152,7 @@ export function oneOf(label: string, options: string[]) {
  * Pass directly to `useForm({ validationSchema: loginSchema })`.
  */
 export const loginSchema = {
-  email: required('Email'),
+  email: [required('Email'), email('Email')],
   password: required('Password'),
 }
 


### PR DESCRIPTION
## Summary
- make the shared password reveal button keyboard-focusable with show/hide accessible labels
- align login email validation with signup/forgot-password by enforcing email format client-side
- add regression coverage for the password input accessibility contract and login schema email format

## Tests
- `npm run test -- src/components/ui/input/PasswordInput.spec.ts src/lib/validationRules.spec.ts`
- `npm run build`

Closes #113
