### PR TITLE
fix: guard clinic settings route

### DIFF
--- a/src/router/index.spec.ts
+++ b/src/router/index.spec.ts
@@ -19,6 +19,10 @@ describe('sensitive route guards', () => {
     expect(metaFor(RouteNames.BILLING).requiredPermission).toEqual(['billing.view', 'billing.view-own'])
   })
 
+  it('requires clinic management for clinic settings access', () => {
+    expect(metaFor(RouteNames.CLINIC_SETTINGS).requiredPermission).toBe('clinic.manage')
+  })
+
   it('requires owner-level clinic management for subscription access', () => {
     expect(metaFor(RouteNames.SUBSCRIPTION).requiredPermission).toBe('clinic.manage')
   })

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -111,6 +111,7 @@ const router = createRouter({
               path: 'settings',
               name: RouteNames.CLINIC_SETTINGS,
               component: () => import('@/domains/clinic/views/ClinicSettingsView.vue'),
+              meta: { requiredPermission: 'clinic.manage' },
             },
             {
               path: 'medicines',


### PR DESCRIPTION
## Summary
- require `clinic.manage` before direct access to `/clinic/settings`
- add router regression coverage for clinic settings guard
- keep the existing subscription route guard covered as already present on `staging`

## Test Plan
- `TEST_CMD='npm run test -- src/router/index.spec.ts' docker compose -p fe-issues115116-378 -f docker-compose.test.yml run --rm frontend-test`
- `TEST_CMD='npm run build' docker compose -p fe-issues115116-378 -f docker-compose.test.yml run --rm frontend-test`

Closes #115
