### PR TITLE
fix: guard schedule route

### DIFF
--- a/src/router/index.spec.ts
+++ b/src/router/index.spec.ts
@@ -19,6 +19,11 @@ describe('sensitive route guards', () => {
     expect(metaFor(RouteNames.BILLING).requiredPermission).toEqual(['billing.view', 'billing.view-own'])
   })
 
+  it('requires schedule permission and feature access for the schedule route', () => {
+    expect(metaFor(RouteNames.SCHEDULE).requiredPermission).toBe('schedule.view')
+    expect(metaFor(RouteNames.SCHEDULE).requiredFeature).toBe('schedule')
+  })
+
   it('requires clinic management for clinic settings access', () => {
     expect(metaFor(RouteNames.CLINIC_SETTINGS).requiredPermission).toBe('clinic.manage')
   })

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -170,7 +170,7 @@ const router = createRouter({
           path: 'schedule',
           name: RouteNames.SCHEDULE,
           component: () => import('@/domains/schedule/views/ScheduleView.vue'),
-          meta: { requiredFeature: 'schedule' },
+          meta: { requiredPermission: 'schedule.view', requiredFeature: 'schedule' },
         },
         {
           path: 'queue',


### PR DESCRIPTION
## Summary
- add `schedule.view` route-level guard to `/schedule` while preserving schedule feature gating
- add focused router regression coverage
- #115 and #118 were re-triaged and already fixed on current `origin/staging`

## Checks
- `npm test -- src/router/index.spec.ts`
- `npm run build`
- independent review: passed

Closes #120
