### PR TITLE
fix: clarify queue display launch flow

### DIFF
--- a/src/domains/queue/views/QueueView.spec.ts
+++ b/src/domains/queue/views/QueueView.spec.ts
@@ -1,0 +1,135 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises } from '@vue/test-utils'
+import { mountWithDeps } from '@/__tests__/helpers/mountWithDeps'
+import QueueView from './QueueView.vue'
+
+const mocks = vi.hoisted(() => ({
+  fetchQueue: vi.fn().mockResolvedValue(undefined),
+  stopPolling: vi.fn(),
+  startPolling: vi.fn(),
+  handleRealtimeEvent: vi.fn(),
+  getDisplayTokenStatus: vi.fn(),
+  connect: vi.fn(),
+  subscribe: vi.fn(),
+  unsubscribe: vi.fn(),
+  isConnected: { __v_isRef: true, value: true },
+}))
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}))
+
+vi.mock('@/domains/auth/stores/authStore', () => ({
+  useAuthStore: () => ({
+    currentClinic: { id: 'clinic-1', role: 'owner' },
+    user: { id: 'user-1' },
+    hasPermission: (permission: string) => permission === 'queue.manage',
+  }),
+}))
+
+vi.mock('../stores/queueStore', () => ({
+  useQueueStore: () => ({
+    visits: [],
+    fetchQueue: mocks.fetchQueue,
+    stopPolling: mocks.stopPolling,
+    startPolling: mocks.startPolling,
+    handleRealtimeEvent: mocks.handleRealtimeEvent,
+    callPatient: vi.fn(),
+    completeVisit: vi.fn(),
+    cancelVisit: vi.fn(),
+  }),
+}))
+
+vi.mock('@/composables/useCentrifugo', () => ({
+  useCentrifugo: () => ({
+    isConnected: mocks.isConnected,
+    connect: mocks.connect,
+    subscribe: mocks.subscribe,
+    unsubscribe: mocks.unsubscribe,
+  }),
+}))
+
+vi.mock('../api/queueApi', () => ({
+  queueApi: {
+    getDisplayTokenStatus: mocks.getDisplayTokenStatus,
+    generateDisplayToken: vi.fn(),
+    revokeDisplayToken: vi.fn(),
+  },
+}))
+
+const STUBS = {
+  Badge: { template: '<span><slot /></span>' },
+  Button: {
+    props: ['disabled'],
+    emits: ['click'],
+    template: '<button type="button" :disabled="disabled" @click="$emit(`click`, $event)"><slot /></button>',
+  },
+  Input: { template: '<input />' },
+  Popover: { template: '<div><slot /></div>' },
+  PopoverTrigger: { template: '<div><slot /></div>' },
+  PopoverContent: { template: '<div><slot /></div>' },
+  Select: { template: '<div><slot /></div>' },
+  SelectContent: { template: '<div><slot /></div>' },
+  SelectItem: { template: '<div><slot /></div>' },
+  SelectTrigger: { template: '<div><slot /></div>' },
+  SelectValue: { template: '<span />' },
+  Dialog: { template: '<div><slot /></div>' },
+  DialogContent: { template: '<div><slot /></div>' },
+  DialogDescription: { template: '<div><slot /></div>' },
+  DialogFooter: { template: '<div><slot /></div>' },
+  DialogHeader: { template: '<div><slot /></div>' },
+  DialogTitle: { template: '<div><slot /></div>' },
+  QueueCard: { template: '<div />' },
+  QueueKanban: { template: '<div />' },
+  WalkInDialog: { template: '<div />' },
+}
+
+describe('QueueView display session controls', () => {
+  beforeEach(() => {
+    sessionStorage.clear()
+    mocks.fetchQueue.mockClear()
+    mocks.stopPolling.mockClear()
+    mocks.startPolling.mockClear()
+    mocks.handleRealtimeEvent.mockClear()
+    mocks.connect.mockClear()
+    mocks.subscribe.mockClear()
+    mocks.unsubscribe.mockClear()
+    mocks.getDisplayTokenStatus.mockResolvedValue({
+      active: true,
+      token: 'queue-token-123',
+      created_at: null,
+      expires_at: null,
+    })
+    vi.spyOn(window, 'open').mockImplementation(() => null)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    sessionStorage.clear()
+  })
+
+  it('describes queue display launch as same-browser only and does not offer URL copying', async () => {
+    const wrapper = mountWithDeps(QueueView, { global: { stubs: STUBS } })
+
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('same-browser display session')
+    expect(wrapper.text()).toContain('Display session is ready')
+    expect(wrapper.text()).toContain('Open the display from this browser')
+    expect(wrapper.text()).toContain('never shown or copied')
+    expect(wrapper.text()).toContain('Open Display')
+    expect(wrapper.text()).not.toContain('Copy App URL')
+    expect(wrapper.text()).not.toContain('https://app.mediflow.ph/queue-display')
+  })
+
+  it('opens display by storing the token in sessionStorage without copying it into the URL', async () => {
+    const wrapper = mountWithDeps(QueueView, { global: { stubs: STUBS } })
+
+    await flushPromises()
+    await wrapper.findAll('button').find((button) => button.text().includes('Open Display'))?.trigger('click')
+
+    expect(sessionStorage.getItem('mediflow.queueDisplay.token')).toBe('queue-token-123')
+    expect(window.open).toHaveBeenCalledWith('http://localhost:3000/queue-display', '_blank')
+    expect(window.open).not.toHaveBeenCalledWith(expect.stringContaining('queue-token-123'), expect.anything())
+  })
+})

--- a/src/domains/queue/views/QueueView.spec.ts
+++ b/src/domains/queue/views/QueueView.spec.ts
@@ -129,7 +129,10 @@ describe('QueueView display session controls', () => {
     await wrapper.findAll('button').find((button) => button.text().includes('Open Display'))?.trigger('click')
 
     expect(sessionStorage.getItem('mediflow.queueDisplay.token')).toBe('queue-token-123')
-    expect(window.open).toHaveBeenCalledWith('http://localhost:3000/queue-display', '_blank')
-    expect(window.open).not.toHaveBeenCalledWith(expect.stringContaining('queue-token-123'), expect.anything())
+
+    const openCall = vi.mocked(window.open).mock.calls[0]
+    expect(openCall?.[1]).toBe('_blank')
+    expect(new URL(openCall?.[0] as string).pathname).toBe('/queue-display')
+    expect(openCall?.[0]).not.toContain('queue-token-123')
   })
 })

--- a/src/domains/queue/views/QueueView.vue
+++ b/src/domains/queue/views/QueueView.vue
@@ -6,7 +6,6 @@ import { toast } from 'vue-sonner'
 import {
   AlertTriangle,
   Columns3,
-  Copy,
   ExternalLink,
   List,
   ListOrdered,
@@ -201,9 +200,9 @@ async function generateDisplayToken() {
   isGeneratingDisplayToken.value = true
   try {
     displayToken.value = await queueApi.generateDisplayToken()
-    toast.success('Display link generated')
+    toast.success('Display session generated')
   } catch {
-    toast.error('Failed to generate display link')
+    toast.error('Failed to generate display session')
   } finally {
     isGeneratingDisplayToken.value = false
   }
@@ -214,18 +213,11 @@ async function revokeDisplayToken() {
   try {
     await queueApi.revokeDisplayToken()
     displayToken.value = { active: false, token: null, created_at: null, expires_at: null }
-    toast.success('Display link revoked')
+    toast.success('Display session revoked')
   } catch {
-    toast.error('Failed to revoke display link')
+    toast.error('Failed to revoke display session')
   } finally {
     isRevokingDisplayToken.value = false
-  }
-}
-
-function copyDisplayUrl() {
-  if (displayUrl.value) {
-    navigator.clipboard.writeText(displayUrl.value)
-    toast.success('Display URL copied without access token')
   }
 }
 
@@ -309,7 +301,7 @@ onUnmounted(() => {
                 <div>
                   <h4 class="text-sm font-medium">Queue Display Screen</h4>
                   <p class="text-xs text-muted-foreground">
-                    Generate a link to show the queue on a TV or tablet in your waiting room.
+                    Generate a same-browser display session for a TV or tablet in your waiting room.
                   </p>
                 </div>
 
@@ -320,24 +312,16 @@ onUnmounted(() => {
 
                 <!-- Newly generated token: launchable once in this browser -->
                 <template v-else-if="hasLaunchableDisplayToken(displayToken)">
-                  <div class="rounded-md border bg-muted/50 p-2">
-                    <p class="break-all text-xs font-mono text-muted-foreground">
-                      {{ displayUrl }}
-                    </p>
-                    <p class="mt-1 text-[11px] text-muted-foreground">
-                      Open from this browser to keep the access token out of the URL and clipboard.
+                  <div class="rounded-md border bg-muted/50 p-3">
+                    <p class="text-sm font-medium">Display session is ready</p>
+                    <p class="mt-1 text-xs text-muted-foreground">
+                      Open the display from this browser. The access token is stored only in this browser session and is never shown or copied.
                     </p>
                   </div>
-                  <div class="flex gap-2">
-                    <Button variant="outline" size="sm" class="flex-1 h-8" @click="copyDisplayUrl">
-                      <Copy class="size-3.5" />
-                      Copy App URL
-                    </Button>
-                    <Button variant="outline" size="sm" class="flex-1 h-8" @click="openDisplayInNewTab">
-                      <ExternalLink class="size-3.5" />
-                      Open
-                    </Button>
-                  </div>
+                  <Button variant="outline" size="sm" class="h-8 w-full" @click="openDisplayInNewTab">
+                    <ExternalLink class="size-3.5" />
+                    Open Display
+                  </Button>
                   <Button
                     variant="destructive"
                     size="sm"
@@ -347,16 +331,16 @@ onUnmounted(() => {
                   >
                     <LoaderCircle v-if="isRevokingDisplayToken" class="size-3.5 animate-spin" />
                     <Trash2 v-else class="size-3.5" />
-                    Revoke Link
+                    Revoke Session
                   </Button>
                 </template>
 
                 <!-- Existing active token: raw token is intentionally not returned again -->
                 <template v-else-if="hasActiveDisplayToken(displayToken)">
                   <div class="rounded-md border bg-muted/50 p-3">
-                    <p class="text-sm font-medium">Display link is active</p>
+                    <p class="text-sm font-medium">Display session is active</p>
                     <p class="mt-1 text-xs text-muted-foreground">
-                      For security, existing display links cannot be shown again. Generate a new link if you need to copy or open it from this browser.
+                      For security, existing display sessions cannot be shown again. Generate a new session if you need to open it from this browser.
                     </p>
                   </div>
                   <Button
@@ -367,7 +351,7 @@ onUnmounted(() => {
                   >
                     <LoaderCircle v-if="isGeneratingDisplayToken" class="size-3.5 animate-spin" />
                     <Monitor v-else class="size-3.5" />
-                    Generate New Link
+                    Generate New Session
                   </Button>
                   <Button
                     variant="destructive"
@@ -378,7 +362,7 @@ onUnmounted(() => {
                   >
                     <LoaderCircle v-if="isRevokingDisplayToken" class="size-3.5 animate-spin" />
                     <Trash2 v-else class="size-3.5" />
-                    Revoke Link
+                    Revoke Session
                   </Button>
                 </template>
 
@@ -392,7 +376,7 @@ onUnmounted(() => {
                   >
                     <LoaderCircle v-if="isGeneratingDisplayToken" class="size-3.5 animate-spin" />
                     <Monitor v-else class="size-3.5" />
-                    Generate Display Link
+                    Generate Display Session
                   </Button>
                 </template>
               </div>


### PR DESCRIPTION
## Summary
- remove the misleading Queue Display “Copy App URL” action
- relabel display link UX as a same-browser display session
- keep the launch URL tokenless and the bearer token in sessionStorage only
- add QueueView regression coverage for no-copy UX and tokenless display launch

## Checks
- `npm test -- src/domains/queue/utils/displayTokenLaunch.spec.ts src/domains/queue/views/QueueView.spec.ts`
- `npm run build`
- independent security/UX review: passed

Closes #119
