### PR TITLE
fix: align family encounter sidebar with encounter API

### DIFF
--- a/src/domains/consultation/components/VitalsSummary.spec.ts
+++ b/src/domains/consultation/components/VitalsSummary.spec.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const componentPath = join(process.cwd(), 'src/domains/consultation/components/VitalsSummary.vue')
+
+describe('VitalsSummary encounter API wiring', () => {
+  it('uses encounter-centered routes and timeline display summaries for past diagnoses', () => {
+    const source = readFileSync(componentPath, 'utf8')
+
+    expect(source).not.toContain('`/consultations/${encounterId}`')
+    expect(source).toContain('`/encounters/${encounterId}`')
+    expect(source).toContain('EncounterTimelineItem[]')
+    expect(source).toContain('c.display_summary?.diagnoses')
+  })
+})

--- a/src/domains/consultation/components/VitalsSummary.vue
+++ b/src/domains/consultation/components/VitalsSummary.vue
@@ -6,8 +6,8 @@ import { AlertTriangle, CheckCircle2, History, LoaderCircle, TrendingUp, FlaskCo
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { http } from '@/lib/http'
-import type { ConsultationTriage, ConsultationResponse, LabOrderSummary } from '../types/consultation.types'
-import type { EncounterResponse } from '@/domains/encounter/types/encounter.types'
+import type { ConsultationTriage, LabOrderSummary } from '../types/consultation.types'
+import type { EncounterResponse, EncounterTimelineItem } from '@/domains/encounter/types/encounter.types'
 import { classifyBpAsStatus, classifyHr, classifyTemp, classifySpo2, classifyRr, classifyBloodSugar, classifyBmi } from '@/lib/vitals'
 import { useVitalsConfigStore } from '@/stores/vitalsConfigStore'
 import { labOrderApi } from '../api/labOrderApi'
@@ -112,7 +112,7 @@ const isLoadingPreview = ref(false)
 async function fetchPastDiagnoses() {
   if (!props.patientId) return
   try {
-    const res = await http.get<{ data: ConsultationResponse[]; meta: unknown }>(
+    const res = await http.get<{ data: EncounterTimelineItem[]; meta: unknown }>(
       `/patients/${props.patientId}/encounters?per_page=3&page=1`,
     )
     const diagnoses: PastDiagnosis[] = []
@@ -121,10 +121,10 @@ async function fetchPastDiagnoses() {
       if (c.id === props.encounterId) continue
       if (c.status !== 'finalized') continue
       if (count >= 2) break
-      for (const d of c.assessment?.diagnoses ?? []) {
+      for (const d of c.display_summary?.diagnoses ?? []) {
         diagnoses.push({
-          description: d.description,
-          code: d.code,
+          description: d,
+          code: null,
           date: c.finalized_at ?? c.created_at,
           encounterId: c.id,
         })
@@ -141,7 +141,7 @@ async function openConsultationPreview(encounterId: string) {
   isLoadingPreview.value = true
   showPreview.value = true
   try {
-    const res = await http.get<{ data: EncounterResponse }>(`/consultations/${encounterId}`)
+    const res = await http.get<{ data: EncounterResponse }>(`/encounters/${encounterId}`)
     previewConsultation.value = res.data
   } catch {
     showPreview.value = false


### PR DESCRIPTION
## Summary
- finishes the encounter migration in the vitals summary sidebar by replacing the remaining legacy `/consultations/{id}` preview call with `/encounters/{id}`
- reads past diagnoses from encounter timeline `display_summary.diagnoses` instead of the old flattened consultation assessment shape
- adds a regression sentinel so this component stays on encounter-centered routes/data

## Validation
- `TZ=UTC npm run test -- src/domains/consultation/components/VitalsSummary.spec.ts src/domains/encounter/api/encounterApi.spec.ts src/domains/encounter/stores/encounterStore.spec.ts`
- `npm run build`
- Source scan: no remaining `/consultations` API route references under `src/domains/consultation` except the regression assertion

## Dogfood
- Browser dogfood skipped for this isolated worktree because the normal clinicdev frontend serves the main checkout, not this branch. Substituted route/data regression tests plus production build.

Closes #127
