### PR TITLE
fix: reconcile auth state after cross-tab refresh

### DIFF
--- a/src/domains/auth/stores/authStore.spec.ts
+++ b/src/domains/auth/stores/authStore.spec.ts
@@ -551,6 +551,43 @@ describe('authStore — silentRefresh', () => {
     expect(ok).toBe(false)
     expect(store.token).toBeNull()
   })
+
+  it('updates the visible user state when an external tab refreshes into another account', async () => {
+    const oldUser = makeUser({ id: 'old-user', email: 'old@example.test', current_clinic: makeClinicContext({ id: 'old-clinic' }) })
+    const newUser = makeUser({ id: 'new-user', email: 'new@example.test', current_clinic: makeClinicContext({ id: 'new-clinic' }) })
+    const api = makeAuthApi({
+      me: vi.fn().mockResolvedValue({ data: newUser, meta: { memberships: [makeMembership({ clinic_id: 'new-clinic' })] } }),
+    })
+    const { useAuthStore } = await loadStore(api)
+    const store = useAuthStore()
+    store.user = oldUser
+    store.memberships = [makeMembership({ clinic_id: 'old-clinic' })]
+    store.setToken('old-token')
+
+    await store.syncExternalSession('new-token')
+
+    expect(store.token).toBe('new-token')
+    expect(store.user?.email).toBe('new@example.test')
+    expect(store.currentClinic?.id).toBe('new-clinic')
+    expect(store.memberships[0]?.clinic_id).toBe('new-clinic')
+  })
+
+  it('clears stale visible user state when external session reconciliation fails', async () => {
+    const api = makeAuthApi({
+      me: vi.fn().mockRejectedValue(new Error('session lookup failed')),
+    })
+    const { useAuthStore } = await loadStore(api)
+    const store = useAuthStore()
+    store.user = makeUser({ id: 'old-user', email: 'old@example.test', current_clinic: makeClinicContext({ id: 'old-clinic' }) })
+    store.memberships = [makeMembership({ clinic_id: 'old-clinic' })]
+    store.setToken('old-token')
+
+    await expect(store.syncExternalSession('new-token')).rejects.toThrow('session lookup failed')
+
+    expect(store.token).toBeNull()
+    expect(store.user).toBeNull()
+    expect(store.memberships).toEqual([])
+  })
 })
 
 describe('authStore — logout', () => {

--- a/src/domains/auth/stores/authStore.ts
+++ b/src/domains/auth/stores/authStore.ts
@@ -66,6 +66,16 @@ export const useAuthStore = defineStore('auth', () => {
     return { max, used, remaining: max === null ? null : Math.max(0, max - used) }
   }
 
+  function broadcastSessionChanged(): void {
+    try {
+      const channel = new BroadcastChannel('auth_token_sync')
+      channel.postMessage({ type: 'session_changed' })
+      channel.close()
+    } catch {
+      // BroadcastChannel not supported — fine
+    }
+  }
+
   function setToken(newToken: string): void {
     token.value = newToken
     setAuthToken(newToken)
@@ -86,11 +96,49 @@ export const useAuthStore = defineStore('auth', () => {
     }
   }
 
-  async function selectClinic(clinicId: string): Promise<void> {
+  interface SyncExternalSessionOptions {
+    reloadOnAccountChange?: boolean
+  }
+
+  async function syncExternalSession(newToken: string, options: SyncExternalSessionOptions = {}): Promise<void> {
+    const previousUserId = user.value?.id ?? null
+    const previousClinicId = currentClinic.value?.id ?? null
+
+    setToken(newToken)
+    try {
+      await fetchUser()
+    } catch (error) {
+      token.value = null
+      user.value = null
+      memberships.value = []
+      setAuthToken(null)
+      if (options.reloadOnAccountChange && typeof window !== 'undefined' && window.location.pathname !== '/login') {
+        window.location.href = '/login'
+      }
+      throw error
+    }
+
+    const nextUserId = user.value?.id ?? null
+    const nextClinicId = currentClinic.value?.id ?? null
+    const accountOrClinicChanged = previousUserId !== null
+      && (previousUserId !== nextUserId || previousClinicId !== nextClinicId)
+
+    if (accountOrClinicChanged) {
+      await clearAppCaches()
+      if (options.reloadOnAccountChange && typeof window !== 'undefined') {
+        window.location.reload()
+      }
+    }
+  }
+
+  async function selectClinic(clinicId: string, options: { broadcast?: boolean } = {}): Promise<void> {
     const response = await authApi.selectClinic(clinicId)
     setToken(response.data.access_token)
     await clearAppCaches()
     await fetchUser()
+    if (options.broadcast !== false) {
+      broadcastSessionChanged()
+    }
   }
 
   async function completeTokenLogin(response: LoginResponse | GoogleAuthResponse): Promise<void> {
@@ -98,13 +146,14 @@ export const useAuthStore = defineStore('auth', () => {
     memberships.value = response.meta.memberships
     const activeMemberships = response.meta.memberships.filter((m) => m.status === 'active')
     if (activeMemberships.length === 1) {
-      await selectClinic(activeMemberships[0]!.clinic_id)
+      await selectClinic(activeMemberships[0]!.clinic_id, { broadcast: false })
     } else if (activeMemberships.length === 0 && response.meta.memberships.length === 0) {
       // No memberships at all — will trigger onboarding
       await fetchUser()
     } else {
       await fetchUser()
     }
+    broadcastSessionChanged()
   }
 
   async function login(credentials: LoginCredentials): Promise<void> {
@@ -157,6 +206,7 @@ export const useAuthStore = defineStore('auth', () => {
       const response = await authApi.refresh()
       setToken(response.data.access_token)
       await fetchUser()
+      broadcastSessionChanged()
       return true
     } catch {
       return false
@@ -183,6 +233,7 @@ export const useAuthStore = defineStore('auth', () => {
     hasFeature,
     getLimit,
     setToken,
+    syncExternalSession,
     fetchUser,
     login,
     googleLogin,

--- a/src/lib/http.spec.ts
+++ b/src/lib/http.spec.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+class FakeBroadcastChannel {
+  static instances: FakeBroadcastChannel[] = []
+
+  readonly name: string
+  private listeners: Array<(event: MessageEvent) => void> = []
+
+  constructor(name: string) {
+    this.name = name
+    FakeBroadcastChannel.instances.push(this)
+  }
+
+  addEventListener(_type: 'message', listener: (event: MessageEvent) => void): void {
+    this.listeners.push(listener)
+  }
+
+  postMessage(): void {}
+
+  close(): void {}
+
+  emit(data: unknown): void {
+    this.listeners.forEach((listener) => listener({ data } as MessageEvent))
+  }
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+describe('http auth channel sync', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.stubEnv('VITE_API_URL', 'https://api.example.test')
+    vi.stubGlobal('BroadcastChannel', FakeBroadcastChannel)
+    FakeBroadcastChannel.instances = []
+  })
+
+  it('reconciles the auth store after another tab changes the shared session', async () => {
+    const syncExternalSession = vi.fn().mockResolvedValue(undefined)
+    vi.doMock('@/domains/auth/stores/authStore', () => ({
+      useAuthStore: () => ({ syncExternalSession }),
+    }))
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ data: { access_token: 'new-tab-token' } }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { getAuthToken } = await import('./http')
+    FakeBroadcastChannel.instances[0]!.emit({ type: 'session_changed' })
+    await vi.waitFor(() => expect(syncExternalSession).toHaveBeenCalled())
+
+    expect(fetchMock).toHaveBeenCalledWith('https://api.example.test/auth/refresh', {
+      method: 'POST',
+      headers: { Accept: 'application/json' },
+      credentials: 'include',
+    })
+    expect(getAuthToken()).toBe('new-tab-token')
+    expect(syncExternalSession).toHaveBeenCalledWith('new-tab-token', { reloadOnAccountChange: true })
+  })
+})

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -42,6 +42,15 @@ class HttpError extends Error {
 
 let refreshPromise: Promise<boolean> | null = null
 
+async function syncAuthStore(newToken: string): Promise<void> {
+  try {
+    const { useAuthStore } = await import('@/domains/auth/stores/authStore')
+    await useAuthStore().syncExternalSession(newToken, { reloadOnAccountChange: true })
+  } catch {
+    // Auth store may not be mounted yet; keep the HTTP token in sync at minimum.
+  }
+}
+
 async function attemptRefresh(): Promise<boolean> {
   // Network errors (TypeError) propagate — callers must distinguish
   // "server rejected refresh" (false) from "server unreachable" (throw)
@@ -55,6 +64,7 @@ async function attemptRefresh(): Promise<boolean> {
   const newToken = result?.data?.access_token
   if (!newToken) return false
   setAuthToken(newToken)
+  await syncAuthStore(newToken)
   authChannel.postMessage({ type: 'session_changed' })
   return true
 }
@@ -76,9 +86,12 @@ authChannel.addEventListener('message', (event) => {
       credentials: 'include',
     })
       .then(r => (r.ok ? r.json() : null))
-      .then((result) => {
+      .then(async (result) => {
         const newToken = result?.data?.access_token
-        if (newToken) setAuthToken(newToken)
+        if (newToken) {
+          setAuthToken(newToken)
+          await syncAuthStore(newToken)
+        }
       })
       .catch(() => { /* keep existing token on network error */ })
   } else if (event.data?.type === 'logged_out') {


### PR DESCRIPTION
## Summary
- Reconcile the full Pinia auth store when another tab refreshes the shared auth session, instead of only replacing the HTTP token.
- Broadcast successful login/clinic-selection/silent-refresh session changes so sibling tabs can refresh their visible shell state.
- Clear stale visible auth state if external session reconciliation cannot fetch `/auth/me`.
- Add regression coverage for BroadcastChannel auth sync and external account replacement.

## Test Plan
- `npm run test -- src/lib/http.spec.ts src/domains/auth/stores/authStore.spec.ts`
- `npm run build`

## Dogfood
- Not run in browser: this isolated worktree is not served by the normal `clinicdev` frontend target. Covered with targeted cross-tab auth unit tests plus production build.

Closes #129
