### PR TITLE
Fix encounter optimistic lock header

### DIFF
--- a/src/domains/encounter/api/encounterApi.spec.ts
+++ b/src/domains/encounter/api/encounterApi.spec.ts
@@ -68,6 +68,20 @@ describe('encounterApi', () => {
     expect(http.patch).toHaveBeenCalledWith('/encounters/encounter-1', payload)
   })
 
+  it('sends optimistic-lock header when updating with an expected timestamp', async () => {
+    const http = makeHttp()
+    const { encounterApi } = await loadApi(http)
+    const payload = { assessment: { chief_complaint: 'Headache' } }
+
+    await encounterApi.update('encounter-1', payload, '2026-04-30T00:00:00Z')
+
+    expect(http.patch).toHaveBeenCalledWith(
+      '/encounters/encounter-1',
+      payload,
+      { 'X-Expected-Updated-At': '2026-04-30T00:00:00Z' },
+    )
+  })
+
   it('delegates encounter lifecycle actions', async () => {
     const http = makeHttp()
     const { encounterApi } = await loadApi(http)

--- a/src/domains/encounter/api/encounterApi.ts
+++ b/src/domains/encounter/api/encounterApi.ts
@@ -28,7 +28,10 @@ export const encounterApi = {
     return http.get<EncounterDetailResponse>(`/encounters/${id}`)
   },
 
-  update(id: string, payload: UpdateEncounterPayload): Promise<UpdateEncounterResponse> {
+  update(id: string, payload: UpdateEncounterPayload, expectedUpdatedAt?: string): Promise<UpdateEncounterResponse> {
+    if (expectedUpdatedAt) {
+      return http.patch<UpdateEncounterResponse>(`/encounters/${id}`, payload, { 'X-Expected-Updated-At': expectedUpdatedAt })
+    }
     return http.patch<UpdateEncounterResponse>(`/encounters/${id}`, payload)
   },
 

--- a/src/domains/encounter/stores/encounterStore.spec.ts
+++ b/src/domains/encounter/stores/encounterStore.spec.ts
@@ -194,6 +194,21 @@ describe('encounterStore — loadForPatient request-id race', () => {
 })
 
 describe('encounterStore — saveSection offline queueing', () => {
+  it('passes the current encounter timestamp as optimistic-lock token when saving', async () => {
+    const api = makeApi({
+      update: vi.fn().mockResolvedValue({ data: makeEncounter({ updated_at: '2026-04-30T01:00:00Z' }) }),
+    })
+    const { useEncounterStore } = await loadStore(api)
+    const store = useEncounterStore()
+    store.current = makeEncounter({ updated_at: '2026-04-30T00:00:00Z' })
+
+    const payload = { assessment: { chief_complaint: 'Headache' } as never }
+    await store.saveSection(payload)
+
+    expect(api.update).toHaveBeenCalledWith('enc-1', payload, '2026-04-30T00:00:00Z')
+    expect(store.current?.updated_at).toBe('2026-04-30T01:00:00Z')
+  })
+
   it('queues a pending action when navigator is offline and update fails', async () => {
     const api = makeApi({
       update: vi.fn().mockRejectedValue(new Error('offline')),
@@ -210,6 +225,7 @@ describe('encounterStore — saveSection offline queueing', () => {
       type: 'update-encounter',
       method: 'PATCH',
       url: '/encounters/enc-1',
+      headers: { 'X-Expected-Updated-At': '2026-04-30T00:00:00Z' },
     }))
     expect(store.isOfflineCached).toBe(true)
     expect(store.saveError).toBeNull()

--- a/src/domains/encounter/stores/encounterStore.ts
+++ b/src/domains/encounter/stores/encounterStore.ts
@@ -137,6 +137,7 @@ export const useEncounterStore = defineStore('encounter', () => {
     saveError.value = null
 
     const previous = JSON.parse(JSON.stringify(current.value)) as EncounterResponse
+    const expectedUpdatedAt = previous.updated_at
 
     // Optimistically update the nested type-specific data
     const updated = { ...current.value }
@@ -187,7 +188,7 @@ export const useEncounterStore = defineStore('encounter', () => {
     current.value = updated
 
     try {
-      const response = await encounterApi.update(current.value.id, payload)
+      const response = await encounterApi.update(current.value.id, payload, expectedUpdatedAt)
       current.value = response.data
       isOfflineCached.value = false
       await cacheEncounter(response.data as unknown as Record<string, unknown>)
@@ -198,6 +199,7 @@ export const useEncounterStore = defineStore('encounter', () => {
           url: `/encounters/${current.value.id}`,
           method: 'PATCH',
           body: payload,
+          headers: { 'X-Expected-Updated-At': expectedUpdatedAt },
           createdAt: Date.now(),
         })
         await cacheEncounter(updated as unknown as Record<string, unknown>)

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -36,6 +36,7 @@ export interface PendingAction {
   url: string
   method: 'POST' | 'PATCH' | 'DELETE'
   body?: unknown
+  headers?: Record<string, string>
   createdAt: number
   /** Number of failed attempts so far. Incremented on every 5xx/network error. */
   attemptCount?: number

--- a/src/lib/offlineDb.spec.ts
+++ b/src/lib/offlineDb.spec.ts
@@ -21,10 +21,11 @@ describe('offlineDb queueAction', () => {
 
   it('coalesces multiple pending encounter updates behind the original lock token', async () => {
     const { db, queueAction } = await importOfflineDb()
+    const url = '/encounters/offline-db-spec-lock-token'
 
     await queueAction({
       type: 'update-encounter',
-      url: '/encounters/enc-1',
+      url,
       method: 'PATCH',
       body: {
         triage: { chief_complaint: 'Cough', temperature_c: 38 },
@@ -34,7 +35,7 @@ describe('offlineDb queueAction', () => {
     })
     await queueAction({
       type: 'update-encounter',
-      url: '/encounters/enc-1',
+      url,
       method: 'PATCH',
       body: {
         triage: { temperature_c: 37.5 },
@@ -44,12 +45,12 @@ describe('offlineDb queueAction', () => {
       createdAt: 1_700_000_000_500,
     })
 
-    const queued = await db.pendingActions.toArray()
+    const queued = (await db.pendingActions.toArray()).filter((action) => action.url === url)
 
     expect(queued).toHaveLength(1)
     expect(queued[0]).toEqual(expect.objectContaining({
       type: 'update-encounter',
-      url: '/encounters/enc-1',
+      url,
       method: 'PATCH',
       headers: { 'X-Expected-Updated-At': '2026-04-30T00:00:00Z' },
       body: {
@@ -61,10 +62,11 @@ describe('offlineDb queueAction', () => {
 
   it('keeps unrelated pending actions as separate queue entries', async () => {
     const { db, queueAction } = await importOfflineDb()
+    const urls = ['/encounters/offline-db-spec-unrelated-1', '/encounters/offline-db-spec-unrelated-2']
 
     await queueAction({
       type: 'update-encounter',
-      url: '/encounters/enc-1',
+      url: urls[0],
       method: 'PATCH',
       body: { assessment: { diagnosis: 'URI' } },
       headers: { 'X-Expected-Updated-At': '2026-04-30T00:00:00Z' },
@@ -72,13 +74,14 @@ describe('offlineDb queueAction', () => {
     })
     await queueAction({
       type: 'update-encounter',
-      url: '/encounters/enc-2',
+      url: urls[1],
       method: 'PATCH',
       body: { assessment: { diagnosis: 'Well' } },
       headers: { 'X-Expected-Updated-At': '2026-04-30T00:00:00Z' },
       createdAt: 2,
     })
 
-    await expect(db.pendingActions.count()).resolves.toBe(2)
+    const queued = (await db.pendingActions.toArray()).filter((action) => urls.includes(action.url))
+    expect(queued).toHaveLength(2)
   })
 })

--- a/src/lib/offlineDb.spec.ts
+++ b/src/lib/offlineDb.spec.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { resetIndexedDb } from '@/__tests__/helpers/mockDexie'
+
+const openedDbs: Array<{ close: () => void }> = []
+
+async function importOfflineDb() {
+  const [{ db }, offlineDb] = await Promise.all([
+    import('./db'),
+    import('./offlineDb'),
+  ])
+  openedDbs.push(db)
+  return { db, ...offlineDb }
+}
+
+describe('offlineDb queueAction', () => {
+  beforeEach(async () => {
+    while (openedDbs.length > 0) openedDbs.pop()?.close()
+    vi.resetModules()
+    await resetIndexedDb()
+  })
+
+  it('coalesces multiple pending encounter updates behind the original lock token', async () => {
+    const { db, queueAction } = await importOfflineDb()
+
+    await queueAction({
+      type: 'update-encounter',
+      url: '/encounters/enc-1',
+      method: 'PATCH',
+      body: {
+        triage: { chief_complaint: 'Cough', temperature_c: 38 },
+      },
+      headers: { 'X-Expected-Updated-At': '2026-04-30T00:00:00Z' },
+      createdAt: 1_700_000_000_000,
+    })
+    await queueAction({
+      type: 'update-encounter',
+      url: '/encounters/enc-1',
+      method: 'PATCH',
+      body: {
+        triage: { temperature_c: 37.5 },
+        assessment: { diagnosis: 'URI' },
+      },
+      headers: { 'X-Expected-Updated-At': '2026-04-30T00:05:00Z' },
+      createdAt: 1_700_000_000_500,
+    })
+
+    const queued = await db.pendingActions.toArray()
+
+    expect(queued).toHaveLength(1)
+    expect(queued[0]).toEqual(expect.objectContaining({
+      type: 'update-encounter',
+      url: '/encounters/enc-1',
+      method: 'PATCH',
+      headers: { 'X-Expected-Updated-At': '2026-04-30T00:00:00Z' },
+      body: {
+        triage: { chief_complaint: 'Cough', temperature_c: 37.5 },
+        assessment: { diagnosis: 'URI' },
+      },
+    }))
+  })
+
+  it('keeps unrelated pending actions as separate queue entries', async () => {
+    const { db, queueAction } = await importOfflineDb()
+
+    await queueAction({
+      type: 'update-encounter',
+      url: '/encounters/enc-1',
+      method: 'PATCH',
+      body: { assessment: { diagnosis: 'URI' } },
+      headers: { 'X-Expected-Updated-At': '2026-04-30T00:00:00Z' },
+      createdAt: 1,
+    })
+    await queueAction({
+      type: 'update-encounter',
+      url: '/encounters/enc-2',
+      method: 'PATCH',
+      body: { assessment: { diagnosis: 'Well' } },
+      headers: { 'X-Expected-Updated-At': '2026-04-30T00:00:00Z' },
+      createdAt: 2,
+    })
+
+    await expect(db.pendingActions.count()).resolves.toBe(2)
+  })
+})

--- a/src/lib/offlineDb.ts
+++ b/src/lib/offlineDb.ts
@@ -26,10 +26,48 @@ export async function getCachedLabOrder(encounterId: string): Promise<Record<str
 
 // --- Pending Actions (offline mutation queue) ---
 
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function mergePendingBody(current: unknown, next: unknown): unknown {
+  if (!isPlainRecord(current) || !isPlainRecord(next)) return next
+
+  const merged: Record<string, unknown> = { ...current }
+  for (const [key, value] of Object.entries(next)) {
+    merged[key] = isPlainRecord(merged[key]) && isPlainRecord(value)
+      ? mergePendingBody(merged[key], value)
+      : value
+  }
+  return merged
+}
+
+async function coalesceEncounterUpdate(action: Omit<PendingAction, 'id'>): Promise<boolean> {
+  if (action.type !== 'update-encounter' || action.method !== 'PATCH') return false
+
+  const matches = await db.pendingActions
+    .where('type')
+    .equals('update-encounter')
+    .filter((pending) => pending.method === 'PATCH' && pending.url === action.url)
+    .toArray()
+  const existing = matches[matches.length - 1]
+
+  if (!existing?.id) return false
+
+  await db.pendingActions.update(existing.id, {
+    body: mergePendingBody(existing.body, action.body),
+    // Keep the original optimistic-lock header. The coalesced payload is still
+    // one logical offline edit against the server version the user started from.
+    headers: existing.headers ?? action.headers,
+  })
+  return true
+}
+
 export async function queueAction(action: PendingAction): Promise<void> {
   // Dexie auto-assigns `id` via the `++id` primary-key spec — strip any
   // caller-supplied id so we never collide with an existing row.
   const { id: _ignored, ...rest } = action
+  if (await coalesceEncounterUpdate(rest as Omit<PendingAction, 'id'>)) return
   await db.pendingActions.add(rest as PendingAction)
 }
 

--- a/src/lib/sync/EncounterRepository.ts
+++ b/src/lib/sync/EncounterRepository.ts
@@ -80,13 +80,14 @@ class EncounterRepositoryImpl implements Repository<EncounterLike> {
         url: `/encounters/${data.id}`,
         method: 'PATCH',
         body: this.toPayload(data),
+        headers: this.lockHeaders(data),
         createdAt: Date.now(),
       })
       return merged as unknown as EncounterLike
     }
 
     try {
-      const response = await encounterApi.update(data.id, this.toPayload(data))
+      const response = await encounterApi.update(data.id, this.toPayload(data), data.updated_at)
       const fresh = response.data as EncounterLike
       await db.encounters.put(this.toStorage(fresh))
       return fresh
@@ -98,6 +99,7 @@ class EncounterRepositoryImpl implements Repository<EncounterLike> {
         url: `/encounters/${data.id}`,
         method: 'PATCH',
         body: this.toPayload(data),
+        headers: this.lockHeaders(data),
         createdAt: Date.now(),
       })
       void syncEngine.flush()
@@ -132,6 +134,10 @@ class EncounterRepositoryImpl implements Repository<EncounterLike> {
     // narrow — keeps the wire contract honest. Refine per consumer.
     const { id: _id, updated_at: _u, created_at: _c, ...rest } = data
     return rest as UpdateEncounterPayload
+  }
+
+  private lockHeaders(data: Partial<EncounterLike>): Record<string, string> | undefined {
+    return data.updated_at ? { 'X-Expected-Updated-At': data.updated_at } : undefined
   }
 }
 

--- a/src/lib/sync/EncounterRepository.ts
+++ b/src/lib/sync/EncounterRepository.ts
@@ -1,4 +1,5 @@
 import { db } from '../db'
+import { queueAction } from '../offlineDb'
 import { encounterApi } from '@/domains/encounter/api/encounterApi'
 import type {
   EncounterResponse,
@@ -75,7 +76,7 @@ class EncounterRepositoryImpl implements Repository<EncounterLike> {
     await db.encounters.put(merged)
 
     if (!navigator.onLine) {
-      await db.pendingActions.add({
+      await queueAction({
         type: 'update-encounter',
         url: `/encounters/${data.id}`,
         method: 'PATCH',
@@ -94,7 +95,7 @@ class EncounterRepositoryImpl implements Repository<EncounterLike> {
     } catch {
       // Network dropped mid-save — queue the mutation and keep the local
       // optimistic state. SyncEngine will flush it when online again.
-      await db.pendingActions.add({
+      await queueAction({
         type: 'update-encounter',
         url: `/encounters/${data.id}`,
         method: 'PATCH',

--- a/src/lib/sync/SyncEngine.spec.ts
+++ b/src/lib/sync/SyncEngine.spec.ts
@@ -48,6 +48,28 @@ describe('SyncEngine', () => {
     httpDelete.mockReset()
   })
 
+  it('passes queued mutation headers through to the HTTP client', async () => {
+    const { db, syncEngine } = await importSyncModules()
+    await db.pendingActions.add({
+      type: 'update-encounter',
+      url: '/encounters/enc-1',
+      method: 'PATCH',
+      body: { assessment: { chief_complaint: 'offline edit' } },
+      headers: { 'X-Expected-Updated-At': '2026-04-30T00:00:00Z' },
+      createdAt: 1_700_000_000_000,
+    })
+    httpPatch.mockResolvedValueOnce({ data: { id: 'enc-1' } })
+
+    await syncEngine.flush()
+
+    expect(httpPatch).toHaveBeenCalledWith(
+      '/encounters/enc-1',
+      { assessment: { chief_complaint: 'offline edit' } },
+      { 'X-Expected-Updated-At': '2026-04-30T00:00:00Z' },
+    )
+    await expect(db.pendingActions.count()).resolves.toBe(0)
+  })
+
   it('moves 4xx clinical mutations to failed actions instead of silently discarding them', async () => {
     const { db, syncEngine } = await importSyncModules()
     const action: PendingAction = {

--- a/src/lib/sync/SyncEngine.ts
+++ b/src/lib/sync/SyncEngine.ts
@@ -113,9 +113,9 @@ class SyncEngineImpl {
     try {
       const method = action.method.toLowerCase() as 'post' | 'patch' | 'delete'
       if (method === 'delete') {
-        await http.delete(action.url)
+        await http.delete(action.url, action.headers)
       } else {
-        await http[method](action.url, action.body)
+        await http[method](action.url, action.body, action.headers)
       }
       return 'succeeded'
     } catch (err) {


### PR DESCRIPTION
## Summary
- send X-Expected-Updated-At on encounter PATCH saves using the loaded encounter timestamp
- carry queued mutation headers through offline sync for encounter updates
- add API, store, and sync tests for the optimistic-lock header

Closes #130

## Tests
- npm run test -- src/domains/encounter/api/encounterApi.spec.ts src/domains/encounter/stores/encounterStore.spec.ts src/lib/sync/SyncEngine.spec.ts
- npm run build