### PR TITLE
Fix OB-GYN prenatal visit payload fields

### DIFF
--- a/src/domains/obgyn/api/obgynApi.ts
+++ b/src/domains/obgyn/api/obgynApi.ts
@@ -43,10 +43,13 @@ export interface CreateVisitPayload {
   gestational_age_weeks?: number | null
   gestational_age_days?: number | null
   concerns?: string | null
-  fetal_movement?: string | null
+  fetal_movement?: 'present' | 'decreased' | 'absent' | null
   danger_signs?: string[]
-  bp_systolic?: number | null
-  bp_diastolic?: number | null
+  systolic_bp?: number | null
+  diastolic_bp?: number | null
+  heart_rate?: number | null
+  respiratory_rate?: number | null
+  temperature?: number | null
   weight?: number | null
   fundal_height?: number | null
   fetal_heart_rate?: number | null

--- a/src/domains/obgyn/components/PrenatalVisitForm.spec.ts
+++ b/src/domains/obgyn/components/PrenatalVisitForm.spec.ts
@@ -1,0 +1,75 @@
+import { shallowMount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick, type ComponentPublicInstance } from 'vue'
+import PrenatalVisitForm from './PrenatalVisitForm.vue'
+import { usePregnancyStore } from '../stores/pregnancyStore'
+import type { Pregnancy, PrenatalVisit } from '../types/obgyn.types'
+
+interface PrenatalVisitFormVm extends ComponentPublicInstance {
+  form: {
+    fetal_movement: 'present' | 'decreased' | 'absent' | ''
+    bp_systolic: number | null
+    bp_diastolic: number | null
+    heart_rate: number | null
+    respiratory_rate: number | null
+    temperature: number | null
+  }
+  handleSubmit: () => Promise<void>
+}
+
+const pregnancy = {
+  id: 'pregnancy-1',
+  edd: null,
+  pre_pregnancy_weight: null,
+} as unknown as Pregnancy
+
+const savedVisit = {
+  id: 'visit-1',
+} as unknown as PrenatalVisit
+
+describe('PrenatalVisitForm', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('submits backend-valid fetal movement and vital field names', async () => {
+    const wrapper = shallowMount(PrenatalVisitForm, {
+      props: {
+        patientId: 'patient-1',
+        pregnancyId: 'pregnancy-1',
+        pregnancy,
+      },
+    })
+    const store = usePregnancyStore()
+    const createVisit = vi.fn().mockResolvedValue(savedVisit)
+    store.createVisit = createVisit
+
+    const vm = wrapper.vm as unknown as PrenatalVisitFormVm
+    vm.form.fetal_movement = 'present'
+    vm.form.bp_systolic = 120
+    vm.form.bp_diastolic = 80
+    vm.form.heart_rate = 72
+    vm.form.respiratory_rate = 16
+    vm.form.temperature = 36.8
+
+    await vm.handleSubmit()
+    await nextTick()
+
+    expect(createVisit).toHaveBeenCalledWith(
+      'patient-1',
+      'pregnancy-1',
+      expect.objectContaining({
+        fetal_movement: 'present',
+        systolic_bp: 120,
+        diastolic_bp: 80,
+        heart_rate: 72,
+        respiratory_rate: 16,
+        temperature: 36.8,
+      }),
+    )
+    const payload = createVisit.mock.calls[0]?.[2]
+    expect(payload).not.toHaveProperty('bp_systolic')
+    expect(payload).not.toHaveProperty('bp_diastolic')
+  })
+})

--- a/src/domains/obgyn/components/PrenatalVisitForm.vue
+++ b/src/domains/obgyn/components/PrenatalVisitForm.vue
@@ -62,7 +62,7 @@ interface FormState {
   visit_date: string
   // Subjective
   concerns: string
-  fetal_movement: 'normal' | 'decreased' | 'not_yet_felt' | ''
+  fetal_movement: 'present' | 'decreased' | 'absent' | ''
   danger_signs: string[]
   // Vitals
   bp_systolic: number | null
@@ -168,8 +168,11 @@ async function handleSubmit(): Promise<void> {
     concerns: form.concerns || null,
     fetal_movement: form.fetal_movement || null,
     danger_signs: form.danger_signs,
-    bp_systolic: form.bp_systolic,
-    bp_diastolic: form.bp_diastolic,
+    systolic_bp: form.bp_systolic,
+    diastolic_bp: form.bp_diastolic,
+    heart_rate: form.heart_rate,
+    respiratory_rate: form.respiratory_rate,
+    temperature: form.temperature,
     weight: form.weight,
     fundal_height: form.fundal_height,
     fetal_heart_rate: form.fetal_heart_rate,
@@ -253,9 +256,9 @@ async function handleSubmit(): Promise<void> {
               <SelectValue placeholder="Select..." />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="normal">Normal</SelectItem>
+              <SelectItem value="present">Present / normal</SelectItem>
               <SelectItem value="decreased">Decreased</SelectItem>
-              <SelectItem value="not_yet_felt">Not yet felt</SelectItem>
+              <SelectItem value="absent">Absent / not yet felt</SelectItem>
             </SelectContent>
           </Select>
         </div>


### PR DESCRIPTION
## Summary
- align prenatal visit fetal movement options with backend enum values
- send prenatal visit BP/vital payload keys using backend field names
- add a focused component test for the submitted payload shape

## Checks
- TZ=UTC npm run test -- src/domains/obgyn/components/PrenatalVisitForm.spec.ts
- npm run build

Closes #133