### PR TITLE
fix: omit blank prenatal fetal movement

### DIFF
--- a/src/domains/obgyn/api/obgynApi.ts
+++ b/src/domains/obgyn/api/obgynApi.ts
@@ -43,7 +43,7 @@ export interface CreateVisitPayload {
   gestational_age_weeks?: number | null
   gestational_age_days?: number | null
   concerns?: string | null
-  fetal_movement?: 'present' | 'decreased' | 'absent' | null
+  fetal_movement?: 'present' | 'decreased' | 'absent'
   danger_signs?: string[]
   systolic_bp?: number | null
   diastolic_bp?: number | null

--- a/src/domains/obgyn/components/PrenatalVisitForm.spec.ts
+++ b/src/domains/obgyn/components/PrenatalVisitForm.spec.ts
@@ -33,14 +33,18 @@ describe('PrenatalVisitForm', () => {
     setActivePinia(createPinia())
   })
 
-  it('submits backend-valid fetal movement and vital field names', async () => {
-    const wrapper = shallowMount(PrenatalVisitForm, {
+  function mountForm() {
+    return shallowMount(PrenatalVisitForm, {
       props: {
         patientId: 'patient-1',
         pregnancyId: 'pregnancy-1',
         pregnancy,
       },
     })
+  }
+
+  it('submits backend-valid fetal movement and vital field names', async () => {
+    const wrapper = mountForm()
     const store = usePregnancyStore()
     const createVisit = vi.fn().mockResolvedValue(savedVisit)
     store.createVisit = createVisit
@@ -71,5 +75,18 @@ describe('PrenatalVisitForm', () => {
     const payload = createVisit.mock.calls[0]?.[2]
     expect(payload).not.toHaveProperty('bp_systolic')
     expect(payload).not.toHaveProperty('bp_diastolic')
+  })
+
+  it('omits blank fetal movement instead of sending backend-invalid null', async () => {
+    const wrapper = mountForm()
+    const store = usePregnancyStore()
+    const createVisit = vi.fn().mockResolvedValue(savedVisit)
+    store.createVisit = createVisit
+
+    await (wrapper.vm as unknown as PrenatalVisitFormVm).handleSubmit()
+    await nextTick()
+
+    const payload = createVisit.mock.calls[0]?.[2]
+    expect(payload).not.toHaveProperty('fetal_movement')
   })
 })

--- a/src/domains/obgyn/components/PrenatalVisitForm.vue
+++ b/src/domains/obgyn/components/PrenatalVisitForm.vue
@@ -166,7 +166,6 @@ async function handleSubmit(): Promise<void> {
     gestational_age_weeks: currentGa.value?.weeks ?? null,
     gestational_age_days: currentGa.value?.days ?? null,
     concerns: form.concerns || null,
-    fetal_movement: form.fetal_movement || null,
     danger_signs: form.danger_signs,
     systolic_bp: form.bp_systolic,
     diastolic_bp: form.bp_diastolic,
@@ -183,6 +182,10 @@ async function handleSubmit(): Promise<void> {
       : [],
     pregnancy_progress: form.pregnancy_progress || null,
     risk_level_update: form.risk_level_update || null,
+  }
+
+  if (form.fetal_movement) {
+    payload.fetal_movement = form.fetal_movement
   }
 
   let result: PrenatalVisit


### PR DESCRIPTION
## Summary
- omit `fetal_movement` from prenatal visit payloads when the select is blank
- tighten the frontend payload type so blank fetal movement is represented by omission, not `null`
- add regression coverage for the blank fetal movement case

## Context
PR #134 was merged while review was still in progress. That PR fixed the selected-value enum and BP/vital field-name mismatch, but its merged head still sends `fetal_movement: null` when the field is left blank. Laravel's prenatal visit request accepts the field as optional, but not nullable, so blank UI submissions can still 422.

## Checks
- `TZ=UTC npm run test -- src/domains/obgyn/components/PrenatalVisitForm.spec.ts` via `docker compose -p pr134review -f docker-compose.test.yml run --rm frontend-test`
- `npm run build` via `docker compose -p pr134review -f docker-compose.test.yml run --rm frontend-test`

Closes #133
