### PR TITLE
fix: harden billing and patient draft safety

### DIFF
--- a/src/composables/useFormDraft.spec.ts
+++ b/src/composables/useFormDraft.spec.ts
@@ -8,7 +8,7 @@
  */
 
 import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest'
-import { defineComponent, h, ref, type Ref } from 'vue'
+import { defineComponent, h, nextTick, ref, type Ref } from 'vue'
 import { mount } from '@vue/test-utils'
 import { useFormDraft } from './useFormDraft'
 
@@ -25,6 +25,7 @@ function makeField<T>(initial: T): FieldRef & { value: T } {
 
 beforeEach(() => {
   localStorage.clear()
+  sessionStorage.clear()
   vi.useFakeTimers()
 })
 
@@ -118,6 +119,52 @@ describe('useFormDraft', () => {
     const stored = JSON.parse(localStorage.getItem('signup') ?? '{}') as Record<string, unknown>
     expect(stored.email).toBe('a@b.co')
     expect(stored.tags).toEqual(['vip'])
+  })
+
+  it('can use sessionStorage for PHI-sensitive drafts', async () => {
+    const email = makeField('')
+
+    mountWithDraft(() => {
+      useFormDraft('create-patient:user:clinic', { email }, undefined, { storage: sessionStorage })
+    })
+
+    email.value = 'patient@example.com'
+    await vi.advanceTimersByTimeAsync(500)
+
+    expect(sessionStorage.getItem('create-patient:user:clinic')).toContain('patient@example.com')
+    expect(localStorage.getItem('create-patient:user:clinic')).toBeNull()
+  })
+
+  it('disables draft persistence while the reactive key is null', async () => {
+    const email = makeField('')
+    const draftKey = ref<string | null>(null)
+
+    mountWithDraft(() => {
+      useFormDraft(draftKey, { email }, undefined, { storage: sessionStorage })
+    })
+
+    email.value = 'patient@example.com'
+    await vi.advanceTimersByTimeAsync(500)
+
+    expect(sessionStorage.length).toBe(0)
+  })
+
+  it('loads the active scoped draft and resets stale values when the key changes', async () => {
+    sessionStorage.setItem('create-patient:user-a:clinic-a', JSON.stringify({ email: 'a@example.com' }))
+    const email = makeField('')
+    const draftKey = ref<string | null>('create-patient:user-a:clinic-a')
+
+    mountWithDraft(() => {
+      useFormDraft(draftKey, { email }, undefined, { storage: sessionStorage })
+    })
+
+    expect(email.value).toBe('a@example.com')
+
+    draftKey.value = 'create-patient:user-b:clinic-b'
+    await nextTick()
+
+    expect(email.value).toBe('')
+    expect(sessionStorage.getItem('create-patient:user-b:clinic-b')).toBeNull()
   })
 
   it.skip('debounces multiple rapid changes into a single write', async () => {

--- a/src/composables/useFormDraft.ts
+++ b/src/composables/useFormDraft.ts
@@ -1,24 +1,72 @@
-import { onMounted, watch, type Ref } from 'vue'
+import { computed, onMounted, watch, type Ref } from 'vue'
 
 interface FieldRef {
   value: unknown
 }
 
+interface FormDraftOptions {
+  storage?: Storage
+}
+
 /**
- * Persists form field values to localStorage with debounced saving.
+ * Persists form field values to storage with debounced saving.
  *
- * @param key        - localStorage key for the draft
+ * @param key        - storage key for the draft; null disables persistence
  * @param fieldRefs  - Record of vee-validate field value refs (from useField)
  * @param extraRefs  - Optional extra refs (e.g. plain ref<string[]> for tags)
  */
 export function useFormDraft(
-  key: string,
+  key: string | Ref<string | null>,
   fieldRefs: Record<string, FieldRef>,
   extraRefs?: Record<string, Ref<unknown>>,
+  options: FormDraftOptions = {},
 ) {
   let debounceTimer: ReturnType<typeof setTimeout> | null = null
 
+  const storage = options.storage ?? localStorage
+  const currentKey = computed(() => typeof key === 'string' ? key : key.value)
+
+  function cloneValue(value: unknown): unknown {
+    if (value === undefined || value === null) return value
+
+    try {
+      if (typeof structuredClone === 'function') return structuredClone(value)
+    } catch {
+      // Vue proxy values can fail structuredClone; fall through to JSON clone.
+    }
+
+    try {
+      return JSON.parse(JSON.stringify(value)) as unknown
+    } catch {
+      return value
+    }
+  }
+
+  function snapshotRefs(refs: Record<string, FieldRef>): Record<string, unknown> {
+    return Object.fromEntries(
+      Object.entries(refs).map(([name, ref]) => [name, cloneValue(ref.value)]),
+    )
+  }
+
+  const initialFieldValues = snapshotRefs(fieldRefs)
+  const initialExtraValues = snapshotRefs(extraRefs ?? {})
+
+  function resetToInitialValues() {
+    for (const [name, value] of Object.entries(initialFieldValues)) {
+      if (fieldRefs[name]) fieldRefs[name].value = cloneValue(value)
+    }
+
+    if (extraRefs) {
+      for (const [name, value] of Object.entries(initialExtraValues)) {
+        if (extraRefs[name]) extraRefs[name].value = cloneValue(value)
+      }
+    }
+  }
+
   function saveDraft() {
+    const draftKey = currentKey.value
+    if (!draftKey) return
+
     const data: Record<string, unknown> = {}
 
     for (const [name, ref] of Object.entries(fieldRefs)) {
@@ -31,12 +79,21 @@ export function useFormDraft(
       }
     }
 
-    localStorage.setItem(key, JSON.stringify(data))
+    storage.setItem(draftKey, JSON.stringify(data))
   }
 
-  function loadDraft() {
-    const raw = localStorage.getItem(key)
-    if (!raw) return
+  function loadDraft(resetIfMissing = false) {
+    const draftKey = currentKey.value
+    if (!draftKey) {
+      if (resetIfMissing) resetToInitialValues()
+      return
+    }
+
+    const raw = storage.getItem(draftKey)
+    if (!raw) {
+      if (resetIfMissing) resetToInitialValues()
+      return
+    }
 
     try {
       const data = JSON.parse(raw) as Record<string, unknown>
@@ -56,11 +113,15 @@ export function useFormDraft(
       }
     } catch {
       // Corrupted draft — ignore
+      if (resetIfMissing) resetToInitialValues()
     }
   }
 
   function clearDraft() {
-    localStorage.removeItem(key)
+    const draftKey = currentKey.value
+    if (!draftKey) return
+
+    storage.removeItem(draftKey)
   }
 
   onMounted(() => {
@@ -78,6 +139,11 @@ export function useFormDraft(
   watch(allRefs, () => {
     if (debounceTimer) clearTimeout(debounceTimer)
     debounceTimer = setTimeout(saveDraft, 500)
+  })
+
+  watch(currentKey, () => {
+    if (debounceTimer) clearTimeout(debounceTimer)
+    loadDraft(true)
   })
 
   return { clearDraft }

--- a/src/domains/auth/stores/authStore.ts
+++ b/src/domains/auth/stores/authStore.ts
@@ -186,8 +186,15 @@ export const useAuthStore = defineStore('auth', () => {
     } catch {
       // BroadcastChannel not supported — fine
     }
-    // Clear PHI draft keys from localStorage
+    // Clear legacy PHI draft keys from persistent storage
     localStorage.removeItem('create-patient')
+    try {
+      Object.keys(sessionStorage)
+        .filter((key) => key.startsWith('create-patient:'))
+        .forEach((key) => sessionStorage.removeItem(key))
+    } catch {
+      // Session storage may be unavailable — fine
+    }
     // Wipe offline IndexedDB to prevent PHI leaking between sessions
     try {
       indexedDB.deleteDatabase('clinicapp-offline')

--- a/src/domains/billing/stores/billingStore.spec.ts
+++ b/src/domains/billing/stores/billingStore.spec.ts
@@ -11,6 +11,17 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { InvoiceListResponse, InvoiceResponse } from '../types/billing.types'
 
+class MockHttpError extends Error {
+  readonly status: number
+
+  constructor(status: number, message: string) {
+    super(message)
+    this.status = status
+  }
+}
+
+vi.mock('@/lib/http', () => ({ HttpError: MockHttpError }))
+
 interface MockBillingApi {
   list: ReturnType<typeof vi.fn>
   get: ReturnType<typeof vi.fn>
@@ -161,15 +172,31 @@ describe('billingStore — fetchInvoice / fetchForEncounter', () => {
     expect(store.currentInvoice?.id).toBe('inv-E')
   })
 
-  it('fetchForEncounter returns null and clears currentInvoice when API rejects', async () => {
+  it('fetchForEncounter returns null and clears currentInvoice when invoice is missing', async () => {
     const api = makeApi({
-      forEncounter: vi.fn().mockRejectedValue(new Error('not found')),
+      forEncounter: vi.fn().mockRejectedValue(new MockHttpError(404, 'not found')),
     })
     const { useBillingStore } = await loadStore(api)
     const store = useBillingStore()
 
     const result = await store.fetchForEncounter('enc-missing')
     expect(result).toBeNull()
+    expect(store.currentInvoice).toBeNull()
+  })
+
+  it('fetchForEncounter propagates non-404 failures and clears stale current invoice', async () => {
+    const api = makeApi({
+      forEncounter: vi.fn()
+        .mockResolvedValueOnce({ data: makeInvoice({ id: 'inv-old' }) })
+        .mockRejectedValueOnce(new MockHttpError(403, 'forbidden')),
+    })
+    const { useBillingStore } = await loadStore(api)
+    const store = useBillingStore()
+
+    await store.fetchForEncounter('enc-old')
+    expect(store.currentInvoice?.id).toBe('inv-old')
+
+    await expect(store.fetchForEncounter('enc-denied')).rejects.toThrow('forbidden')
     expect(store.currentInvoice).toBeNull()
   })
 })

--- a/src/domains/billing/stores/billingStore.ts
+++ b/src/domains/billing/stores/billingStore.ts
@@ -1,6 +1,7 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
 import { toast } from 'vue-sonner'
+import { HttpError } from '@/lib/http'
 import { billingApi } from '../api/billingApi'
 import type {
   BillingSummary,
@@ -54,9 +55,14 @@ export const useBillingStore = defineStore('billing', () => {
       const response = await billingApi.forEncounter(encounterId)
       currentInvoice.value = response.data
       return response.data
-    } catch {
+    } catch (error) {
+      if (error instanceof HttpError && error.status === 404) {
+        currentInvoice.value = null
+        return null
+      }
+
       currentInvoice.value = null
-      return null
+      throw error
     }
   }
 

--- a/src/domains/consultation/components/tabs/PaymentTab.vue
+++ b/src/domains/consultation/components/tabs/PaymentTab.vue
@@ -446,6 +446,7 @@ async function fetchInvoice() {
     const result = await billingStore.fetchForEncounter(props.encounterId)
     invoice.value = result
   } catch {
+    invoice.value = null
     loadError.value = 'Failed to load invoice.'
   } finally {
     isLoading.value = false

--- a/src/domains/consultation/views/ConsultationFormView.vue
+++ b/src/domains/consultation/views/ConsultationFormView.vue
@@ -2,6 +2,7 @@
 import { computed, onMounted, onUnmounted, ref, watch, type Component } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { HttpError } from '@/lib/http'
+import { boldUserHtml } from '@/lib/htmlSafety'
 import {
   Stethoscope,
   Activity,
@@ -378,7 +379,7 @@ const clinicalSummary = computed<string | null>(() => {
   const ls = pdStore.lifestyle
   const fh = pdStore.familyHistory
 
-  const b = (t: string | number) => `<b>${t}</b>`
+  const b = (t: string | number) => boldUserHtml(t)
 
   if (problems.length) {
     const top = problems.slice(0, 3).map((p) => b(p.description)).join(', ')

--- a/src/domains/obgyn/composables/useClinicalSummary.ts
+++ b/src/domains/obgyn/composables/useClinicalSummary.ts
@@ -1,8 +1,9 @@
 import { computed, type Ref } from 'vue'
+import { boldUserHtml } from '@/lib/htmlSafety'
 import { contraceptionLabel } from '../types/obgyn.types'
 import type { GynProfile, Pregnancy, ContraceptiveEntry } from '../types/obgyn.types'
 
-function b(text: string | number) { return `<b>${text}</b>` }
+function b(text: string | number) { return boldUserHtml(text) }
 
 function formatDate(d: string | null): string {
   if (!d) return ''

--- a/src/domains/patient/components/CreatePatientDialog.vue
+++ b/src/domains/patient/components/CreatePatientDialog.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { useForm, useField } from 'vee-validate'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -76,8 +76,15 @@ const bloodType = ref<string>('')
 const isLoading = ref(false)
 const generalError = ref<string | null>(null)
 
+const draftKey = computed(() => {
+  const userId = authStore.user?.id
+  const clinicId = authStore.currentClinic?.id
+  if (!userId || !clinicId) return null
+  return `create-patient:${userId}:${clinicId}`
+})
+
 const { clearDraft } = useFormDraft(
-  'create-patient',
+  draftKey,
   {
     date_of_birth: dateOfBirth,
     sex,
@@ -85,6 +92,8 @@ const { clearDraft } = useFormDraft(
     email,
     note,
   },
+  undefined,
+  { storage: sessionStorage },
 )
 
 watch(

--- a/src/domains/patient/components/specialties/family-medicine/FMPatientSections.vue
+++ b/src/domains/patient/components/specialties/family-medicine/FMPatientSections.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, reactive, computed, onMounted, watch } from 'vue'
+import { boldUserHtml } from '@/lib/htmlSafety'
 import {
   Plus,
   ChevronRight,
@@ -528,7 +529,7 @@ const trendsWidgetDetail = computed(() => {
 const narrativeProblems = computed(() => pdStore.problems)
 const narrativeAllergies = computed(() => pdStore.allergies)
 
-function b(text: string | number) { return `<b>${text}</b>` }
+function b(text: string | number) { return boldUserHtml(text) }
 
 const narrativeSummary = computed(() => {
   const lines: string[] = []

--- a/src/lib/htmlSafety.ts
+++ b/src/lib/htmlSafety.ts
@@ -1,0 +1,10 @@
+export function escapeUserHtml(value: string | number): string {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+}
+
+export function boldUserHtml(value: string | number): string {
+  return `<b>${escapeUserHtml(value)}</b>`
+}

--- a/src/lib/narrative.security.spec.ts
+++ b/src/lib/narrative.security.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { buildNarrative, buildVitalsNarrative } from './narrative'
+import { boldUserHtml, escapeUserHtml } from './htmlSafety'
 import type { ConsultationTriage } from '@/domains/consultation/types/consultation.types'
 
 describe('narrative HTML safety', () => {
@@ -63,5 +64,16 @@ describe('narrative HTML safety', () => {
     expect(html).toContain('<strong>')
     expect(html).not.toContain('<img')
     expect(html).not.toContain('onerror')
+  })
+
+  it('escapes user text before wrapping narrative emphasis tags', () => {
+    const html = boldUserHtml('<img src=x onerror=alert(1)>')
+
+    expect(html).toBe('<b>&lt;img src=x onerror=alert(1)&gt;</b>')
+    expect(html).not.toContain('<img')
+  })
+
+  it('escapes non-emphasized user text', () => {
+    expect(escapeUserHtml('<script>alert(1)</script>')).toBe('&lt;script&gt;alert(1)&lt;/script&gt;')
   })
 })


### PR DESCRIPTION
## Summary
- Treat only 404 invoice lookup responses as “no invoice”; non-404 failures now clear stale invoice state and surface a load error.
- Scope create-patient PHI drafts to authenticated user + current clinic, move them to sessionStorage, and disable draft persistence when scope is unavailable.
- Escape user-controlled clinical narrative text before wrapping it in intentional `<b>` markup used by `v-html` summaries.

## Test Plan
- `TZ=UTC npm run test -- src/composables/useFormDraft.spec.ts src/domains/billing/stores/billingStore.spec.ts src/lib/narrative.security.spec.ts`
- `TZ=UTC npm run test`
- `npm run build`

Closes #136
Closes #137
Closes #138
