### PR TITLE
fix: harden logout PHI cleanup and document links

### DIFF
--- a/src/components/layout/NotificationPanel.vue
+++ b/src/components/layout/NotificationPanel.vue
@@ -89,7 +89,7 @@ async function handleDownload(documentId: string) {
   const tab = openNewTab()
   try {
     const url = await documentApi.getSignedUrl(documentId)
-    tab.navigate(url)
+    await tab.navigate(url)
   } catch {
     tab.close()
   }

--- a/src/domains/auth/stores/authStore.spec.ts
+++ b/src/domains/auth/stores/authStore.spec.ts
@@ -119,6 +119,7 @@ function makeMembership(overrides: Partial<Membership> = {}): Membership {
 async function loadStore(api: MockAuthApi) {
   vi.doMock('../api/authApi', () => ({ authApi: api }))
   vi.doMock('@/lib/http', () => ({ setAuthToken: vi.fn() }))
+  vi.doMock('@/lib/db', () => ({ clearOfflineDatabase: vi.fn().mockResolvedValue(undefined) }))
   vi.doMock('@/composables/useTheme', () => ({ useTheme: () => ({ setTheme: vi.fn() }) }))
   vi.doMock('@/composables/useCentrifugo', () => ({ useCentrifugo: () => ({ disconnect: vi.fn() }) }))
   // Avoid loading the real specialty store on me()
@@ -135,6 +136,7 @@ beforeEach(() => {
 afterEach(() => {
   vi.doUnmock('../api/authApi')
   vi.doUnmock('@/lib/http')
+  vi.doUnmock('@/lib/db')
   vi.doUnmock('@/composables/useTheme')
   vi.doUnmock('@/composables/useCentrifugo')
   vi.doUnmock('@/stores/specialtyConfigStore')
@@ -603,10 +605,6 @@ describe('authStore — logout', () => {
     await store.fetchUser()
     expect(store.user).not.toBeNull()
 
-    // Stub indexedDB.deleteDatabase so logout doesn't try to talk to the
-    // real (or fake) IDB.
-    vi.stubGlobal('indexedDB', { deleteDatabase: vi.fn() })
-
     store.setToken('tok')
     await store.logout()
 
@@ -617,22 +615,42 @@ describe('authStore — logout', () => {
     expect(store.isAuthenticated).toBe(false)
   })
 
-  it('still clears local state when broadcast and indexedDB cleanup are unavailable', async () => {
-    const api = makeAuthApi()
+  it('clears local state and PHI drafts even when remote logout fails', async () => {
+    const api = makeAuthApi({ logout: vi.fn().mockRejectedValue(new Error('network down')) })
     const { useAuthStore } = await loadStore(api)
+    const { clearOfflineDatabase } = await import('@/lib/db')
     const store = useAuthStore()
 
     store.user = makeUser({ current_clinic: makeClinicContext() })
     store.memberships = [makeMembership()]
     store.setToken('tok')
+    localStorage.setItem('create-patient', '{"name":"legacy"}')
+    sessionStorage.setItem('create-patient:u1:c1', '{"name":"scoped"}')
+
+    await store.logout()
+
+    expect(api.logout).toHaveBeenCalled()
+    expect(store.token).toBeNull()
+    expect(store.user).toBeNull()
+    expect(store.memberships).toEqual([])
+    expect(localStorage.getItem('create-patient')).toBeNull()
+    expect(sessionStorage.getItem('create-patient:u1:c1')).toBeNull()
+    expect(clearOfflineDatabase).toHaveBeenCalled()
+  })
+
+  it('still clears local state when broadcast and offline cleanup are unavailable', async () => {
+    const api = makeAuthApi()
+    const { useAuthStore } = await loadStore(api)
+    const { clearOfflineDatabase } = await import('@/lib/db')
+    const store = useAuthStore()
+
+    store.user = makeUser({ current_clinic: makeClinicContext() })
+    store.memberships = [makeMembership()]
+    store.setToken('tok')
+    vi.mocked(clearOfflineDatabase).mockRejectedValueOnce(new Error('not supported'))
     vi.stubGlobal('BroadcastChannel', vi.fn(() => {
       throw new Error('not supported')
     }))
-    vi.stubGlobal('indexedDB', {
-      deleteDatabase: vi.fn(() => {
-        throw new Error('not supported')
-      }),
-    })
 
     await store.logout()
 

--- a/src/domains/auth/stores/authStore.ts
+++ b/src/domains/auth/stores/authStore.ts
@@ -3,7 +3,6 @@ import { computed, ref } from 'vue'
 import { useTheme } from '@/composables/useTheme'
 import { useCentrifugo } from '@/composables/useCentrifugo'
 import { clearAppCaches } from '@/lib/appCaches'
-import { clearOfflineDatabase } from '@/lib/db'
 import { setAuthToken } from '@/lib/http'
 import { authApi } from '../api/authApi'
 
@@ -208,6 +207,7 @@ export const useAuthStore = defineStore('auth', () => {
     }
     // Wipe offline IndexedDB to prevent PHI leaking between sessions
     try {
+      const { clearOfflineDatabase } = await import('@/lib/db')
       await clearOfflineDatabase()
     } catch {
       // Not supported or already absent — fine

--- a/src/domains/auth/stores/authStore.ts
+++ b/src/domains/auth/stores/authStore.ts
@@ -3,6 +3,7 @@ import { computed, ref } from 'vue'
 import { useTheme } from '@/composables/useTheme'
 import { useCentrifugo } from '@/composables/useCentrifugo'
 import { clearAppCaches } from '@/lib/appCaches'
+import { clearOfflineDatabase } from '@/lib/db'
 import { setAuthToken } from '@/lib/http'
 import { authApi } from '../api/authApi'
 
@@ -177,8 +178,18 @@ export const useAuthStore = defineStore('auth', () => {
   }
 
   async function logout(): Promise<void> {
-    await authApi.logout()
+    try {
+      await authApi.logout()
+    } catch {
+      // Local logout must still complete even if the server/network fails.
+    }
+
     useCentrifugo().disconnect()
+    token.value = null
+    user.value = null
+    memberships.value = []
+    setAuthToken(null)
+
     try {
       const channel = new BroadcastChannel('auth_token_sync')
       channel.postMessage({ type: 'logged_out' })
@@ -188,17 +199,20 @@ export const useAuthStore = defineStore('auth', () => {
     }
     // Clear PHI draft keys from localStorage
     localStorage.removeItem('create-patient')
+    try {
+      Object.keys(sessionStorage)
+        .filter((key) => key.startsWith('create-patient:'))
+        .forEach((key) => sessionStorage.removeItem(key))
+    } catch {
+      // Session storage may be unavailable — fine
+    }
     // Wipe offline IndexedDB to prevent PHI leaking between sessions
     try {
-      indexedDB.deleteDatabase('clinicapp-offline')
+      await clearOfflineDatabase()
     } catch {
       // Not supported or already absent — fine
     }
     await clearAppCaches()
-    token.value = null
-    user.value = null
-    memberships.value = []
-    setAuthToken(null)
   }
 
   async function silentRefresh(): Promise<boolean> {

--- a/src/domains/billing/components/InvoiceDetailSheet.vue
+++ b/src/domains/billing/components/InvoiceDetailSheet.vue
@@ -212,7 +212,7 @@ async function downloadMedCert(documentId: string) {
   const tab = openNewTab()
   try {
     const url = await documentApi.getSignedUrl(documentId)
-    tab.navigate(url)
+    await tab.navigate(url)
   } catch {
     tab.close()
     toast.error('Failed to get download link')
@@ -283,7 +283,7 @@ async function downloadInvoicePdf() {
   const tab = openNewTab()
   try {
     const url = await documentApi.getSignedUrl(invoiceDoc.value.id)
-    tab.navigate(url)
+    await tab.navigate(url)
   } catch {
     tab.close()
     toast.error('Failed to get download link')

--- a/src/domains/billing/components/InvoiceTable.vue
+++ b/src/domains/billing/components/InvoiceTable.vue
@@ -66,7 +66,7 @@ async function handlePdfClick(e: Event, invoice: InvoiceResponse) {
     const tab = openNewTab()
     try {
       const url = await documentApi.getSignedUrl(doc.id)
-      tab.navigate(url)
+      await tab.navigate(url)
     } catch {
       tab.close()
       toast.error('Failed to download invoice PDF')

--- a/src/domains/consultation/components/LabOrderSection.vue
+++ b/src/domains/consultation/components/LabOrderSection.vue
@@ -526,7 +526,7 @@ async function downloadLabRequest() {
   const tab = openNewTab()
   try {
     const url = await documentApi.getSignedUrl(labRequestDoc.value.id)
-    tab.navigate(url)
+    await tab.navigate(url)
   } catch {
     tab.close()
     toast.error('Failed to get download link')

--- a/src/domains/consultation/components/LabRequestDialog.vue
+++ b/src/domains/consultation/components/LabRequestDialog.vue
@@ -112,7 +112,7 @@ async function download() {
   const tab = openNewTab()
   try {
     const url = await documentApi.getSignedUrl(labRequestDoc.value.id)
-    tab.navigate(url)
+    await tab.navigate(url)
   } catch {
     tab.close()
     toast.error('Failed to get download link')

--- a/src/domains/consultation/components/MedCertDialog.vue
+++ b/src/domains/consultation/components/MedCertDialog.vue
@@ -154,7 +154,7 @@ async function download() {
   const tab = openNewTab()
   try {
     const url = await documentApi.getSignedUrl(medCertDoc.value.id)
-    tab.navigate(url)
+    await tab.navigate(url)
   } catch {
     tab.close()
     toast.error('Failed to get download link')

--- a/src/domains/consultation/components/PrescriptionSection.vue
+++ b/src/domains/consultation/components/PrescriptionSection.vue
@@ -128,7 +128,7 @@ async function downloadPdf() {
   const tab = openNewTab()
   try {
     const url = await documentApi.getSignedUrl(pdfDoc.value.id)
-    tab.navigate(url)
+    await tab.navigate(url)
   } catch {
     tab.close()
     toast.error('Failed to get download link')

--- a/src/domains/consultation/components/tabs/PaymentTab.vue
+++ b/src/domains/consultation/components/tabs/PaymentTab.vue
@@ -149,7 +149,7 @@ async function downloadMedCert() {
   const tab = openNewTab()
   try {
     const url = await documentApi.getSignedUrl(docId)
-    tab.navigate(url)
+    await tab.navigate(url)
   } catch {
     tab.close()
     toast.error('Failed to get medical certificate')
@@ -205,7 +205,7 @@ async function openPrescriptionPdf() {
   const tab = openNewTab()
   try {
     const url = await documentApi.getSignedUrl(docId)
-    tab.navigate(url)
+    await tab.navigate(url)
   } catch {
     tab.close()
     toast.error('Failed to get prescription PDF')

--- a/src/domains/consultation/views/ConsultationFormView.vue
+++ b/src/domains/consultation/views/ConsultationFormView.vue
@@ -178,7 +178,7 @@ async function downloadSummary() {
   const tab = openNewTab()
   try {
     const url = await documentApi.getSignedUrl(summaryDoc.value.id)
-    tab.navigate(url)
+    await tab.navigate(url)
   } catch {
     tab.close()
   }

--- a/src/domains/patient/components/FinalizedConsultationCard.vue
+++ b/src/domains/patient/components/FinalizedConsultationCard.vue
@@ -78,7 +78,7 @@ async function downloadDocument(documentId: string) {
   const tab = openNewTab()
   try {
     const url = await documentApi.getSignedUrl(documentId)
-    tab.navigate(url)
+    await tab.navigate(url)
   } catch {
     tab.close()
     toast.error('Failed to get download link')

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -96,6 +96,11 @@ class AppDatabase extends Dexie {
 
 export const db = new AppDatabase()
 
+export async function clearOfflineDatabase(): Promise<void> {
+  db.close()
+  await Dexie.delete('clinicapp-offline')
+}
+
 // Some users carry a stale IndexedDB from the pre-Dexie raw-IDB era (or an
 // older Dexie shape) whose primary keys don't match what we declare above.
 // Dexie can't upgrade across primary-key changes, so it throws

--- a/src/lib/utils.spec.ts
+++ b/src/lib/utils.spec.ts
@@ -12,14 +12,18 @@
  *     them.
  *   - `cn` is the ubiquitous tailwind-merge wrapper. We sanity-check
  *     dedup/override behaviour so a bad clsx upgrade is caught.
- *
- * `printPdf` and `openNewTab` rely on `window.open`/iframes and aren't
- * covered here — they're DOM-side-effect functions that belong in an
- * e2e or component test. Pure formatters only.
  */
 
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
-import { cn, toYmd, todayYmd, formatRelativeTime, timeAgo } from './utils'
+import { cn, toYmd, todayYmd, formatRelativeTime, timeAgo, openNewTab } from './utils'
+
+const downloadMock = vi.hoisted(() => vi.fn())
+
+vi.mock('@/lib/http', () => ({
+  http: {
+    download: downloadMock,
+  },
+}))
 
 describe('cn', () => {
   it('merges plain classes', () => {
@@ -167,5 +171,37 @@ describe('timeAgo', () => {
 
   it('returns "Just now" for < 60s', () => {
     expect(timeAgo('2026-04-29T11:59:30Z')).toBe('Just now')
+  })
+})
+
+describe('openNewTab', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    downloadMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('downloads signed URLs and navigates only to a blob URL', async () => {
+    const blob = new Blob(['pdf'], { type: 'application/pdf' })
+    const openedWindow = { closed: false, location: { href: '' }, close: vi.fn() }
+    downloadMock.mockResolvedValue(blob)
+    vi.spyOn(window, 'open').mockReturnValue(openedWindow as unknown as Window)
+    const createObjectURL = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:document-1')
+    const revokeObjectURL = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
+
+    const tab = openNewTab()
+    await tab.navigate('https://signed.example.test/private.pdf?token=secret')
+
+    expect(downloadMock).toHaveBeenCalledWith('https://signed.example.test/private.pdf?token=secret')
+    expect(openedWindow.location.href).toBe('blob:document-1')
+    expect(openedWindow.location.href).not.toContain('signed.example.test')
+    expect(createObjectURL).toHaveBeenCalledWith(blob)
+
+    await vi.advanceTimersByTimeAsync(60000)
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:document-1')
   })
 })

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -81,16 +81,18 @@ export function timeAgo(dateString: string): string {
  * Must be called synchronously from a user gesture — open the blank tab first,
  * then set the location after any async work (e.g. fetching a signed URL).
  */
-export function openNewTab(): { navigate: (url: string) => void; close: () => void } {
+export function openNewTab(): { navigate: (url: string) => Promise<void>; close: () => void } {
   const win = window.open('', '_blank')
   return {
-    navigate: (url: string) => {
+    navigate: async (url: string) => {
+      const blob = await http.download(url)
+      const blobUrl = URL.createObjectURL(blob)
       if (win && !win.closed) {
-        win.location.href = url
+        win.location.href = blobUrl
       } else {
-        // Fallback: popup was blocked, try direct navigation
-        window.location.href = url
+        window.open(blobUrl, '_blank')
       }
+      setTimeout(() => URL.revokeObjectURL(blobUrl), 60000)
     },
     close: () => {
       if (win && !win.closed) win.close()
@@ -131,7 +133,7 @@ export function printPdf(url: string): void {
           iframe.contentWindow?.focus()
           iframe.contentWindow?.print()
         } catch {
-          window.open(url, '_blank')
+          window.open(blobUrl, '_blank')
         }
         setTimeout(() => {
           document.body.removeChild(iframe)
@@ -139,7 +141,5 @@ export function printPdf(url: string): void {
         }, 60000)
       }
     })
-    .catch(() => {
-      window.open(url, '_blank')
-    })
+    .catch(() => {})
 }


### PR DESCRIPTION
## Summary
- Make logout local cleanup fail-closed: remote logout errors no longer block token/user/cache/PHI cleanup.
- Close and await Dexie-backed offline DB deletion through a central cleanup helper.
- Open signed PHI documents through downloaded `blob:` URLs instead of navigating tabs/history to the signed storage URL.

## Test Plan
- `TEST_CMD='npx vitest run src/domains/auth/stores/authStore.spec.ts src/lib/utils.spec.ts' docker compose -p fix139141 -f docker-compose.test.yml run --rm frontend-test`
- `TEST_CMD='npm run build' docker compose -p fix139141 -f docker-compose.test.yml run --rm frontend-test`

Closes #139
Closes #140
Closes #141
