### PR TITLE
fix: harden queue display routes and realtime merges

### DIFF
--- a/src/domains/queue/stores/queueStore.ts
+++ b/src/domains/queue/stores/queueStore.ts
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia'
 import { ref } from 'vue'
 import { queueApi } from '../api/queueApi'
 import type { CreateWalkInPayload, QueueVisitResponse } from '../types/queue.types'
+import { mergeQueueRealtimeEvent } from '../utils/realtimeEvents'
 
 type QueueFilters = { doctor_id?: string; status?: string }
 
@@ -66,27 +67,7 @@ export const useQueueStore = defineStore('queue', () => {
   }
 
   function handleRealtimeEvent(event: { type: string; data: QueueVisitResponse }): void {
-    const { type, data } = event
-    const index = visits.value.findIndex((v) => v.id === data.id)
-
-    switch (type) {
-      case 'queue.visit.created':
-        if (index === -1) {
-          visits.value.push(data)
-        } else {
-          visits.value[index] = data
-        }
-        break
-      case 'queue.visit.called':
-      case 'queue.visit.completed':
-      case 'queue.visit.cancelled':
-        if (index !== -1) {
-          visits.value[index] = data
-        } else {
-          visits.value.push(data)
-        }
-        break
-    }
+    visits.value = mergeQueueRealtimeEvent(visits.value, event)
   }
 
   return {

--- a/src/domains/queue/utils/displayTokenLaunch.spec.ts
+++ b/src/domains/queue/utils/displayTokenLaunch.spec.ts
@@ -54,6 +54,10 @@ describe('queue display token launch handoff', () => {
     storeQueueDisplayToken('stored-token', storage)
 
     expect(readQueueDisplayToken('legacy-token', storage)).toBe('legacy-token')
-    expect(readQueueDisplayToken(['bad-token'], storage)).toBe('stored-token')
+    expect(readQueueDisplayToken(undefined, storage)).toBe('legacy-token')
+
+    const fallbackStorage = new MemoryStorage()
+    storeQueueDisplayToken('stored-token', fallbackStorage)
+    expect(readQueueDisplayToken(['bad-token'], fallbackStorage)).toBe('stored-token')
   })
 })

--- a/src/domains/queue/utils/displayTokenLaunch.ts
+++ b/src/domains/queue/utils/displayTokenLaunch.ts
@@ -13,6 +13,7 @@ export function readQueueDisplayToken(
   storage: Storage = window.sessionStorage,
 ): string | null {
   if (typeof routeToken === 'string' && routeToken.trim() !== '') {
+    storeQueueDisplayToken(routeToken, storage)
     return routeToken
   }
 

--- a/src/domains/queue/utils/realtimeEvents.spec.ts
+++ b/src/domains/queue/utils/realtimeEvents.spec.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import type { QueueVisitResponse } from '../types/queue.types'
+import { mergeQueueRealtimeEvent } from './realtimeEvents'
+
+function makeVisit(overrides: Partial<QueueVisitResponse> = {}): QueueVisitResponse {
+  return {
+    id: 'visit-1',
+    clinic_id: 'clinic-1',
+    patient_id: 'patient-1',
+    patient_name: 'Juan Dela Cruz',
+    patient_sex: 'male',
+    patient_avatar_url: null,
+    doctor_id: 'doctor-1',
+    doctor_name: 'Maria Santos',
+    appointment_id: null,
+    encounter_id: null,
+    status: 'waiting',
+    type: 'walk_in',
+    priority: 0,
+    position: 1,
+    reason: 'Consultation',
+    checked_in_at: '2026-05-06T01:00:00.000Z',
+    called_at: null,
+    completed_at: null,
+    notes: null,
+    created_at: '2026-05-06T01:00:00.000Z',
+    updated_at: '2026-05-06T01:00:00.000Z',
+    ...overrides,
+  }
+}
+
+describe('mergeQueueRealtimeEvent', () => {
+  it('adds new queue visits and replaces existing visits for known events', () => {
+    const first = makeVisit({ id: 'visit-1', position: 1 })
+    const replacement = makeVisit({ id: 'visit-1', position: 2 })
+    const called = makeVisit({ id: 'visit-2', status: 'in_progress' })
+
+    const created = mergeQueueRealtimeEvent([], { type: 'queue.visit.created', data: first })
+    const replaced = mergeQueueRealtimeEvent(created, { type: 'queue.visit.created', data: replacement })
+    const withCalled = mergeQueueRealtimeEvent(replaced, { type: 'queue.visit.called', data: called })
+
+    expect(withCalled).toHaveLength(2)
+    expect(withCalled[0]?.position).toBe(2)
+    expect(withCalled[1]?.status).toBe('in_progress')
+  })
+
+  it('ignores unknown queue realtime events', () => {
+    const visits = [makeVisit()]
+
+    expect(mergeQueueRealtimeEvent(visits, { type: 'queue.visit.unknown', data: makeVisit({ id: 'visit-2' }) })).toBe(visits)
+  })
+})

--- a/src/domains/queue/utils/realtimeEvents.ts
+++ b/src/domains/queue/utils/realtimeEvents.ts
@@ -1,0 +1,27 @@
+import type { QueueVisitResponse } from '../types/queue.types'
+
+export interface QueueRealtimeEvent {
+  type: string
+  data: QueueVisitResponse
+}
+
+export function mergeQueueRealtimeEvent(
+  visits: QueueVisitResponse[],
+  event: QueueRealtimeEvent,
+): QueueVisitResponse[] {
+  const { type, data } = event
+  const index = visits.findIndex((visit) => visit.id === data.id)
+
+  switch (type) {
+    case 'queue.visit.created':
+    case 'queue.visit.called':
+    case 'queue.visit.completed':
+    case 'queue.visit.cancelled':
+      if (index === -1) {
+        return [...visits, data]
+      }
+      return visits.map((visit, visitIndex) => (visitIndex === index ? data : visit))
+    default:
+      return visits
+  }
+}

--- a/src/domains/queue/views/QueueDisplayView.vue
+++ b/src/domains/queue/views/QueueDisplayView.vue
@@ -7,6 +7,7 @@ import { Clock, Users, Stethoscope, WifiOff } from 'lucide-vue-next'
 import { queueApi } from '@/domains/queue/api/queueApi'
 import type { QueueVisitResponse } from '@/domains/queue/types/queue.types'
 import { readQueueDisplayToken } from '@/domains/queue/utils/displayTokenLaunch'
+import { mergeQueueRealtimeEvent } from '@/domains/queue/utils/realtimeEvents'
 
 // ---------------------------------------------------------------------------
 // Types
@@ -64,34 +65,6 @@ function updateTime(): void {
 }
 
 let clockInterval: ReturnType<typeof setInterval> | null = null
-
-// ---------------------------------------------------------------------------
-// Realtime event handler (mirrors queueStore.handleRealtimeEvent)
-// ---------------------------------------------------------------------------
-
-function handleRealtimeEvent(event: RealtimeEvent): void {
-  const { type, data } = event
-  const index = visits.value.findIndex((v) => v.id === data.id)
-
-  switch (type) {
-    case 'queue.visit.created':
-      if (index === -1) {
-        visits.value.push(data)
-      } else {
-        visits.value[index] = data
-      }
-      break
-    case 'queue.visit.called':
-    case 'queue.visit.completed':
-    case 'queue.visit.cancelled':
-      if (index !== -1) {
-        visits.value[index] = data
-      } else {
-        visits.value.push(data)
-      }
-      break
-  }
-}
 
 // ---------------------------------------------------------------------------
 // Centrifuge
@@ -213,7 +186,7 @@ function initCentrifuge(
   sub.on('publication', (ctx: PublicationContext) => {
     const event = ctx.data as RealtimeEvent
     if (event && event.type && event.data) {
-      handleRealtimeEvent(event)
+      visits.value = mergeQueueRealtimeEvent(visits.value, event)
     }
   })
 
@@ -242,6 +215,12 @@ async function bootstrap(): Promise<void> {
   isLoading.value = true
   displayError.value = null
 
+  // Remove legacy path tokens before any network request so invalid or failed
+  // bootstraps do not leave bearer tokens in the visible URL/history.
+  if (route.params.token) {
+    window.history.replaceState(null, '', '/queue-display')
+  }
+
   if (!token) {
     isLoading.value = false
     displayError.value = 'INVALID_TOKEN'
@@ -253,9 +232,6 @@ async function bootstrap(): Promise<void> {
     clinicName.value = data.clinic_name
     visits.value = data.visits
     isLoading.value = false
-
-    // Remove legacy path tokens from the URL so they don't linger in browser history or referrer headers
-    window.history.replaceState(null, '', '/queue-display')
 
     initCentrifuge(
       data.centrifugo.connection_token,

--- a/src/router/index.spec.ts
+++ b/src/router/index.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { useAuthStore } from '@/domains/auth/stores/authStore'
 import router, { canAccessRequiredPermission } from './index'
 import { RouteNames } from './routeNames'
@@ -39,6 +39,14 @@ describe('sensitive route guards', () => {
     expect(metaFor(RouteNames.SCHEDULE).requiredFeature).toBe('schedule')
   })
 
+  it('requires permissions and features for direct-access operational routes', () => {
+    expect(metaFor(RouteNames.APPOINTMENT_LIST).requiredPermission).toBe('appointments.view')
+    expect(metaFor(RouteNames.APPOINTMENT_LIST).requiredFeature).toBe('appointments')
+    expect(metaFor(RouteNames.QUEUE).requiredPermission).toBe('queue.view')
+    expect(metaFor(RouteNames.MESSAGES).requiredPermission).toBe('messages.view')
+    expect(metaFor(RouteNames.MESSAGES).requiredFeature).toBe('messages')
+  })
+
   it('requires clinic management for clinic settings access', () => {
     expect(metaFor(RouteNames.CLINIC_SETTINGS).requiredPermission).toBe('clinic.manage')
   })
@@ -50,6 +58,14 @@ describe('sensitive route guards', () => {
   it('requires clinic management for template list and editor routes', () => {
     expect(metaFor(RouteNames.CLINIC_TEMPLATES).requiredPermission).toBe('clinic.manage')
     expect(metaFor(RouteNames.TEMPLATE_EDITOR).requiredPermission).toBe('clinic.manage')
+  })
+
+  it('requires matching permissions and features for clinic inventory/service tabs', () => {
+    expect(metaFor(RouteNames.CLINIC_CONSUMABLES).requiredPermission).toBe('consumables.view')
+    expect(metaFor(RouteNames.CLINIC_CONSUMABLES).requiredFeature).toBe('consumables')
+    expect(metaFor(RouteNames.CLINIC_LAB_SERVICES).requiredPermission).toBe('lab-services.view')
+    expect(metaFor(RouteNames.CLINIC_LAB_SERVICES).requiredFeature).toBe('lab_services')
+    expect(metaFor(RouteNames.CLINIC_SERVICES).requiredPermission).toBe('lab-services.view')
   })
 
   it('does not expose the retired odontogram playground route', () => {
@@ -82,5 +98,20 @@ describe('sensitive route guards', () => {
 
       expect(router.currentRoute.value.name).toBe(RouteNames.HOME)
     }
+  })
+
+  it('scrubs legacy queue display path tokens before authenticated refresh can fetch user state', async () => {
+    const authStore = useAuthStore()
+    authStore.setToken('test-token')
+    authStore.user = null
+    authStore.memberships = [] as typeof authStore.memberships
+    sessionStorage.removeItem('mediflow.queueDisplay.token')
+    const fetchUser = vi.spyOn(authStore, 'fetchUser')
+
+    await router.push('/queue-display/legacy-token')
+
+    expect(fetchUser).not.toHaveBeenCalled()
+    expect(router.currentRoute.value.fullPath).toBe('/queue-display')
+    expect(sessionStorage.getItem('mediflow.queueDisplay.token')).toBe('legacy-token')
   })
 })

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -16,6 +16,7 @@ import HomeView from '@/views/HomeView.vue'
 import { RouteNames } from './routeNames'
 import { useAuthStore } from '@/domains/auth/stores/authStore'
 import { HttpError } from '@/lib/http'
+import { storeQueueDisplayToken } from '@/domains/queue/utils/displayTokenLaunch'
 
 export function canAccessRequiredPermission(
   requiredPermission: string | string[] | undefined,
@@ -93,7 +94,7 @@ const router = createRouter({
           path: 'appointments',
           name: RouteNames.APPOINTMENT_LIST,
           component: () => import('@/domains/appointment/views/AppointmentListView.vue'),
-          meta: { requiredFeature: 'appointments' },
+          meta: { requiredPermission: 'appointments.view', requiredFeature: 'appointments' },
         },
         {
           path: 'clinic',
@@ -125,16 +126,19 @@ const router = createRouter({
               path: 'consumables',
               name: RouteNames.CLINIC_CONSUMABLES,
               component: () => import('@/domains/consumable/views/ConsumableListView.vue'),
+              meta: { requiredPermission: 'consumables.view', requiredFeature: 'consumables' },
             },
             {
               path: 'lab-services',
               name: RouteNames.CLINIC_LAB_SERVICES,
               component: () => import('@/domains/labService/views/LabServiceListView.vue'),
+              meta: { requiredPermission: 'lab-services.view', requiredFeature: 'lab_services' },
             },
             {
               path: 'services',
               name: RouteNames.CLINIC_SERVICES,
               component: () => import('@/domains/service/views/ServiceListView.vue'),
+              meta: { requiredPermission: 'lab-services.view' },
             },
             {
               path: 'templates',
@@ -178,12 +182,13 @@ const router = createRouter({
           path: 'queue',
           name: RouteNames.QUEUE,
           component: () => import('@/domains/queue/views/QueueView.vue'),
+          meta: { requiredPermission: 'queue.view' },
         },
         {
           path: 'messages',
           name: RouteNames.MESSAGES,
           component: () => import('@/domains/message/views/MessagesView.vue'),
-          meta: { requiredFeature: 'messages' },
+          meta: { requiredPermission: 'messages.view', requiredFeature: 'messages' },
         },
         {
           path: 'billing',
@@ -304,12 +309,20 @@ router.onError((error) => {
 router.beforeEach(async (to) => {
   const authStore = useAuthStore()
 
+  // Legacy queue-display links may carry a bearer token in the path. Move the
+  // token into tab-scoped storage and strip it before any guard-triggered API
+  // calls, including authenticated refreshes that fetch /auth/me.
+  if (to.name === RouteNames.QUEUE_DISPLAY && typeof to.params.token === 'string' && to.params.token.trim() !== '') {
+    storeQueueDisplayToken(to.params.token)
+    return { name: RouteNames.QUEUE_DISPLAY, replace: true }
+  }
+
   if (to.meta.devOnly && !import.meta.env.DEV) {
     return { name: RouteNames.HOME }
   }
 
   // Page refresh: token exists but user not yet loaded
-  if (authStore.isAuthenticated && !authStore.user) {
+  if (authStore.isAuthenticated && !authStore.user && to.name !== RouteNames.QUEUE_DISPLAY) {
     try {
       await authStore.fetchUser()
     } catch (error) {


### PR DESCRIPTION
## Summary
- scrub legacy `/queue-display/:token` URLs into tab-scoped storage before auth guard/API refresh work can run
- centralize queue realtime event merging for staff queue and public queue display so updates replace existing visits instead of duplicating them
- tighten protected route metadata for direct-access operational/admin areas and lock the expectations with router specs

## Validation
- `TEST_CMD='npx vitest run src/router/index.spec.ts src/domains/queue/stores/queueStore.spec.ts src/domains/queue/utils/displayTokenLaunch.spec.ts src/domains/queue/utils/realtimeEvents.spec.ts' docker compose -p fix142144 -f docker-compose.test.yml run --rm frontend-test`
- `TEST_CMD='npm run build' docker compose -p fix142144 -f docker-compose.test.yml run --rm frontend-test`
- Independent diff review passed with no blocking security or logic findings.

Closes #142
Closes #143
Closes #144
