### PR TITLE
Add patient profile skeleton polish

### DIFF
--- a/src/domains/obgyn/components/ObgynPregnancyTopbar.vue
+++ b/src/domains/obgyn/components/ObgynPregnancyTopbar.vue
@@ -24,7 +24,7 @@ import RiskClassificationBadge from './RiskClassificationBadge.vue'
 import type { Pregnancy } from '../types/obgyn.types'
 import { computed } from 'vue'
 
-const props = defineProps<{
+const props = withDefaults(defineProps<{
   patientName: string | null
   statusLabel: string
   statusClass: string
@@ -44,7 +44,9 @@ const props = defineProps<{
   canResolvePrimary: boolean
   canResolveMenu: boolean
   showActions?: boolean
-}>()
+}>(), {
+  showActions: true,
+})
 
 const emit = defineEmits<{
   back: []
@@ -153,7 +155,7 @@ const weeksToEdd = computed(() => {
           <span v-if="trimester" class="obgyn-pregnancy-topbar-trimester">
             {{ trimester }} tri
           </span>
-          <span v-if="weeksToEdd !== null" class="hidden text-xs text-muted-foreground xl:inline">
+          <span v-if="weeksToEdd !== null" class="obgyn-pregnancy-topbar-edd hidden text-xs text-muted-foreground xl:inline">
             {{ weeksToEdd }}w to EDD
           </span>
         </div>
@@ -338,22 +340,42 @@ const weeksToEdd = computed(() => {
 }
 
 :global(.dark) .obgyn-pregnancy-topbar {
+  color: rgb(248 250 252);
   background:
-    linear-gradient(135deg, rgb(15 23 42 / 0.38), rgb(15 23 42 / 0.16) 52%, rgb(15 23 42 / 0.28)),
-    rgb(15 23 42 / 0.08);
-  box-shadow: 0 18px 50px -30px rgb(0 0 0 / 0.72), 0 18px 45px rgb(0 0 0 / 0.28);
+    radial-gradient(circle at 10% 0%, rgb(37 99 235 / 0.2), transparent 32%),
+    radial-gradient(circle at 92% 0%, rgb(20 184 166 / 0.18), transparent 36%),
+    linear-gradient(135deg, rgb(15 23 42 / 0.86), rgb(2 6 23 / 0.64) 56%, rgb(15 23 42 / 0.74)),
+    rgb(2 6 23 / 0.7);
+  box-shadow:
+    0 24px 80px -38px rgb(0 0 0 / 0.86),
+    0 18px 48px rgb(0 0 0 / 0.32);
+}
+
+:global(.dark) .obgyn-pregnancy-topbar::before {
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 0.12),
+    inset 0 0 0 1px rgb(148 163 184 / 0.14);
 }
 
 :global(.dark) .obgyn-pregnancy-topbar-icon,
 :global(.dark) .obgyn-pregnancy-topbar-action {
-  border-color: rgb(255 255 255 / 0.1);
-  background: rgb(255 255 255 / 0.08);
-  box-shadow: 0 12px 28px rgb(0 0 0 / 0.24);
+  color: rgb(226 232 240);
+  border-color: rgb(148 163 184 / 0.2);
+  background:
+    linear-gradient(135deg, rgb(15 23 42 / 0.78), rgb(2 6 23 / 0.44)),
+    rgb(15 23 42 / 0.5);
+  box-shadow:
+    0 12px 30px rgb(0 0 0 / 0.32),
+    inset 0 1px 0 rgb(255 255 255 / 0.08);
 }
 
 :global(.dark) .obgyn-pregnancy-topbar-icon:hover,
 :global(.dark) .obgyn-pregnancy-topbar-action:hover {
-  background: rgb(255 255 255 / 0.12);
+  border-color: rgb(96 165 250 / 0.36);
+  background:
+    radial-gradient(circle at 0% 0%, rgb(37 99 235 / 0.22), transparent 42%),
+    linear-gradient(135deg, rgb(15 23 42 / 0.86), rgb(2 6 23 / 0.56)),
+    rgb(15 23 42 / 0.56);
 }
 
 :global(.dark) .obgyn-pregnancy-topbar-action--primary {
@@ -363,6 +385,16 @@ const weeksToEdd = computed(() => {
 }
 
 :global(.dark) .obgyn-pregnancy-topbar-ga {
-  background: rgb(255 255 255 / 0.08);
+  border: 1px solid rgb(148 163 184 / 0.14);
+  background:
+    linear-gradient(135deg, rgb(15 23 42 / 0.74), rgb(2 6 23 / 0.42)),
+    rgb(15 23 42 / 0.5);
+  box-shadow:
+    0 12px 28px rgb(0 0 0 / 0.22),
+    inset 0 1px 0 rgb(255 255 255 / 0.08);
+}
+
+:global(.dark) .obgyn-pregnancy-topbar-edd {
+  color: rgb(203 213 225 / 0.78);
 }
 </style>

--- a/src/domains/obgyn/components/ResolvePregnancyModal.vue
+++ b/src/domains/obgyn/components/ResolvePregnancyModal.vue
@@ -121,7 +121,7 @@ defineExpose({ stopSubmitting })
 
 <template>
   <Dialog :open="props.open" @update:open="(val) => emit('update:open', val)">
-    <DialogContent class="max-h-[85vh] overflow-y-auto sm:max-w-lg">
+    <DialogContent class="resolve-pregnancy-dialog max-h-[85vh] overflow-y-auto sm:max-w-lg">
       <DialogHeader>
         <DialogTitle>Resolve Pregnancy</DialogTitle>
         <DialogDescription>
@@ -147,10 +147,10 @@ defineExpose({ stopSubmitting })
               <label
                 v-for="opt in deliveryOutcomes"
                 :key="opt.value"
-                class="flex cursor-pointer items-start gap-3 rounded-lg border p-3 transition-colors hover:bg-muted/50"
-                :class="{ 'border-primary bg-primary/5': selectedOutcome === opt.value }"
+                class="resolve-outcome-option flex cursor-pointer items-start gap-3 rounded-2xl border p-3 transition-all"
+                :class="{ 'is-selected': selectedOutcome === opt.value }"
               >
-                <RadioGroupItem :value="opt.value" class="mt-0.5" />
+                <RadioGroupItem :value="opt.value" class="resolve-outcome-radio mt-0.5" />
                 <div>
                   <p class="text-sm font-medium">{{ opt.label }}</p>
                   <p class="text-xs text-muted-foreground">{{ opt.description }}</p>
@@ -173,10 +173,10 @@ defineExpose({ stopSubmitting })
               <label
                 v-for="opt in lossOutcomes"
                 :key="opt.value"
-                class="flex cursor-pointer items-start gap-3 rounded-lg border p-3 transition-colors hover:bg-muted/50"
-                :class="{ 'border-primary bg-primary/5': selectedOutcome === opt.value }"
+                class="resolve-outcome-option flex cursor-pointer items-start gap-3 rounded-2xl border p-3 transition-all"
+                :class="{ 'is-selected': selectedOutcome === opt.value }"
               >
-                <RadioGroupItem :value="opt.value" class="mt-0.5" />
+                <RadioGroupItem :value="opt.value" class="resolve-outcome-radio mt-0.5" />
                 <div>
                   <p class="text-sm font-medium">{{ opt.label }}</p>
                   <p class="text-xs text-muted-foreground">{{ opt.description }}</p>
@@ -189,10 +189,7 @@ defineExpose({ stopSubmitting })
         <!-- Outcome Details (shown after selection) -->
         <template v-if="selectedOutcome">
           <!-- Delivery outcome info -->
-          <div
-            v-if="isDeliveryOutcome"
-            class="rounded-md border border-blue-200 bg-blue-50 p-3 text-sm text-blue-800 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300"
-          >
+          <div v-if="isDeliveryOutcome" class="resolve-info-card rounded-2xl border p-3 text-sm">
             <p class="font-medium">A delivery form will be created</p>
             <p class="mt-0.5 text-xs text-blue-600 dark:text-blue-400">
               You'll be redirected to fill in labor, delivery, and neonatal details. The pregnancy will close when the delivery record is finalized.
@@ -260,7 +257,7 @@ defineExpose({ stopSubmitting })
             </template>
 
             <!-- Molar-specific -->
-            <div v-if="isMolar" class="flex items-start gap-2 rounded-md border border-amber-200 bg-amber-50 p-3 dark:border-amber-800 dark:bg-amber-950">
+            <div v-if="isMolar" class="resolve-warning-card flex items-start gap-2 rounded-2xl border p-3">
               <Checkbox
                 :model-value="hcgSurveillance"
                 @update:model-value="(val) => hcgSurveillance = !!val"
@@ -286,7 +283,7 @@ defineExpose({ stopSubmitting })
           </div>
 
           <!-- GTPAL update notice -->
-          <div class="rounded-md border bg-muted/30 p-3 text-xs text-muted-foreground">
+          <div class="resolve-muted-card rounded-2xl border p-3 text-xs text-muted-foreground">
             <p class="font-medium text-foreground">GTPAL will be updated automatically</p>
             <p v-if="isDeliveryOutcome" class="mt-0.5">
               Parity and living children will be updated when the delivery record is finalized.
@@ -325,3 +322,150 @@ defineExpose({ stopSubmitting })
     </DialogContent>
   </Dialog>
 </template>
+
+<style scoped>
+.resolve-pregnancy-dialog {
+  border-color: rgb(148 163 184 / 0.28);
+}
+
+.resolve-outcome-option {
+  border-color: rgb(148 163 184 / 0.2);
+  background:
+    linear-gradient(135deg, rgb(255 255 255 / 0.48), rgb(255 255 255 / 0.2)),
+    rgb(255 255 255 / 0.06);
+  box-shadow:
+    0 12px 28px rgb(15 23 42 / 0.05),
+    inset 0 1px 0 rgb(255 255 255 / 0.26);
+}
+
+.resolve-outcome-option:hover {
+  transform: translateY(-1px);
+  border-color: rgb(37 99 235 / 0.28);
+  background:
+    linear-gradient(135deg, rgb(255 255 255 / 0.66), rgb(255 255 255 / 0.3)),
+    rgb(255 255 255 / 0.12);
+  box-shadow:
+    0 18px 36px rgb(37 99 235 / 0.08),
+    inset 0 1px 0 rgb(255 255 255 / 0.34);
+}
+
+.resolve-outcome-option.is-selected {
+  border-color: rgb(37 99 235 / 0.5);
+  background:
+    radial-gradient(circle at 0% 0%, rgb(37 99 235 / 0.16), transparent 42%),
+    radial-gradient(circle at 100% 0%, rgb(20 184 166 / 0.14), transparent 36%),
+    linear-gradient(135deg, rgb(255 255 255 / 0.76), rgb(255 255 255 / 0.36)),
+    rgb(255 255 255 / 0.12);
+  box-shadow:
+    0 18px 40px rgb(37 99 235 / 0.12),
+    inset 0 0 0 1px rgb(255 255 255 / 0.32);
+}
+
+:deep(.resolve-outcome-radio) {
+  width: 1.25rem;
+  height: 1.25rem;
+  border-color: rgb(100 116 139 / 0.45);
+  background: rgb(255 255 255 / 0.5);
+  box-shadow:
+    0 8px 18px rgb(15 23 42 / 0.08),
+    inset 0 1px 0 rgb(255 255 255 / 0.44);
+}
+
+:deep(.resolve-outcome-radio[data-state='checked']) {
+  border-color: rgb(37 99 235);
+  background: linear-gradient(135deg, rgb(37 99 235), rgb(20 184 166));
+  color: white;
+  box-shadow:
+    0 12px 26px rgb(37 99 235 / 0.22),
+    inset 0 1px 0 rgb(255 255 255 / 0.24);
+}
+
+:deep(.resolve-outcome-radio[data-state='checked'] svg) {
+  width: 0.75rem;
+  height: 0.75rem;
+  fill: white;
+}
+
+.resolve-info-card {
+  border-color: rgb(59 130 246 / 0.24);
+  color: rgb(30 64 175);
+  background:
+    linear-gradient(135deg, rgb(59 130 246 / 0.12), rgb(20 184 166 / 0.08)),
+    rgb(255 255 255 / 0.38);
+}
+
+.resolve-warning-card {
+  border-color: rgb(245 158 11 / 0.28);
+  background:
+    linear-gradient(135deg, rgb(245 158 11 / 0.14), rgb(255 255 255 / 0.22)),
+    rgb(255 255 255 / 0.2);
+}
+
+.resolve-muted-card {
+  border-color: rgb(148 163 184 / 0.2);
+  background: rgb(255 255 255 / 0.22);
+}
+
+:global(.dark) .resolve-outcome-option {
+  color: rgb(248 250 252);
+  border-color: rgb(148 163 184 / 0.18);
+  background:
+    radial-gradient(circle at 0% 0%, rgb(37 99 235 / 0.12), transparent 38%),
+    linear-gradient(135deg, rgb(15 23 42 / 0.84), rgb(2 6 23 / 0.68)),
+    rgb(15 23 42 / 0.72);
+  box-shadow:
+    0 16px 34px rgb(0 0 0 / 0.34),
+    inset 0 1px 0 rgb(255 255 255 / 0.08);
+}
+
+:global(.dark) .resolve-outcome-option p:last-child {
+  color: rgb(203 213 225 / 0.76);
+}
+
+:global(.dark) .resolve-outcome-option:hover,
+:global(.dark) .resolve-outcome-option.is-selected {
+  border-color: rgb(96 165 250 / 0.5);
+  background:
+    radial-gradient(circle at 0% 0%, rgb(37 99 235 / 0.28), transparent 42%),
+    radial-gradient(circle at 100% 0%, rgb(20 184 166 / 0.2), transparent 38%),
+    linear-gradient(135deg, rgb(15 23 42 / 0.92), rgb(2 6 23 / 0.76)),
+    rgb(15 23 42 / 0.78);
+  box-shadow:
+    0 18px 42px rgb(37 99 235 / 0.14),
+    inset 0 1px 0 rgb(255 255 255 / 0.1);
+}
+
+:global(.dark) :deep(.resolve-outcome-radio) {
+  border-color: rgb(203 213 225 / 0.42);
+  background: rgb(15 23 42 / 0.78);
+  box-shadow:
+    0 8px 18px rgb(0 0 0 / 0.32),
+    inset 0 1px 0 rgb(255 255 255 / 0.1);
+}
+
+:global(.dark) :deep(.resolve-outcome-radio[data-state='checked']) {
+  border-color: rgb(96 165 250);
+  background: linear-gradient(135deg, rgb(37 99 235), rgb(20 184 166));
+  color: white;
+}
+
+:global(.dark) .resolve-info-card {
+  border-color: rgb(96 165 250 / 0.22);
+  color: rgb(191 219 254);
+  background:
+    linear-gradient(135deg, rgb(59 130 246 / 0.14), rgb(20 184 166 / 0.08)),
+    rgb(15 23 42 / 0.42);
+}
+
+:global(.dark) .resolve-warning-card {
+  border-color: rgb(245 158 11 / 0.24);
+  background:
+    linear-gradient(135deg, rgb(245 158 11 / 0.14), rgb(15 23 42 / 0.34)),
+    rgb(15 23 42 / 0.36);
+}
+
+:global(.dark) .resolve-muted-card {
+  border-color: rgb(255 255 255 / 0.08);
+  background: rgb(255 255 255 / 0.05);
+}
+</style>

--- a/src/domains/patient/views/PatientDetailView.vue
+++ b/src/domains/patient/views/PatientDetailView.vue
@@ -380,8 +380,140 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <div v-if="isLoading" class="flex flex-1 items-center justify-center pt-16">
-    <LoaderCircle class="size-6 animate-spin text-muted-foreground" />
+  <div
+    v-if="isLoading"
+    class="patient-detail-shell grid flex-1 gap-6 pt-4 xl:grid-cols-[minmax(0,1fr)_360px]"
+  >
+    <main class="patient-detail-main flex min-w-0 flex-col gap-6">
+      <section class="patient-modules-card order-1 surface-card rounded-2xl p-5">
+        <div class="mb-5 space-y-2">
+          <Skeleton class="h-5 w-44 rounded-xl" />
+          <Skeleton class="h-4 w-72 max-w-full rounded-xl" />
+        </div>
+        <div class="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+          <div
+            v-for="n in 4"
+            :key="`module-skeleton-${n}`"
+            class="surface-card-lite rounded-2xl p-4"
+          >
+            <div class="mb-4 flex items-center gap-3">
+              <Skeleton class="size-10 shrink-0 rounded-xl" />
+              <div class="min-w-0 flex-1 space-y-2">
+                <Skeleton class="h-4 w-28 rounded-xl" />
+                <Skeleton class="h-3 w-20 rounded-xl" />
+              </div>
+            </div>
+            <Skeleton class="mb-2 h-2 w-full rounded-full" />
+            <Skeleton class="h-3 w-24 rounded-xl" />
+          </div>
+        </div>
+      </section>
+
+      <section class="patient-timeline-card order-2 surface-card rounded-2xl p-5">
+        <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div class="space-y-2">
+            <Skeleton class="h-5 w-44 rounded-xl" />
+            <Skeleton class="h-4 w-80 max-w-full rounded-xl" />
+          </div>
+          <div class="flex flex-wrap gap-2">
+            <Skeleton class="h-10 w-44 rounded-xl" />
+            <Skeleton class="h-10 w-28 rounded-xl" />
+            <Skeleton class="h-10 w-24 rounded-xl" />
+          </div>
+        </div>
+
+        <div class="mt-6">
+          <div
+            v-for="n in 4"
+            :key="`timeline-skeleton-${n}`"
+            class="patient-timeline-row flex gap-4"
+          >
+            <div class="patient-timeline-marker-col">
+              <Skeleton class="mt-3 size-8 shrink-0 rounded-full" />
+              <div v-if="n < 4" class="patient-timeline-line" />
+            </div>
+            <div
+              class="patient-timeline-skeleton surface-card-lite min-w-0 flex-1 rounded-2xl p-4"
+              :class="n < 4 ? 'mb-3' : ''"
+            >
+              <Skeleton class="mb-3 h-3 w-24 rounded-xl" />
+              <Skeleton class="mb-2 h-5 w-3/4 rounded-xl" />
+              <Skeleton class="mb-4 h-3 w-1/2 rounded-xl" />
+              <div class="flex gap-2">
+                <Skeleton class="h-8 w-24 rounded-xl" />
+                <Skeleton class="h-8 w-20 rounded-xl" />
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <aside class="patient-profile-sidebar xl:self-start">
+      <section class="patient-profile-card surface-card overflow-hidden rounded-2xl">
+        <div class="patient-profile-banner relative">
+          <div class="absolute left-4 top-4">
+            <Skeleton class="size-10 rounded-full" />
+          </div>
+          <div class="absolute right-4 top-4">
+            <Skeleton class="h-9 w-24 rounded-full" />
+          </div>
+          <div class="absolute inset-x-0 -bottom-12 flex justify-center">
+            <Skeleton class="size-28 rounded-full ring-4 ring-white/70 dark:ring-slate-950/50" />
+          </div>
+        </div>
+
+        <div class="px-5 pb-5 pt-16">
+          <div class="flex items-start justify-between gap-3">
+            <div class="min-w-0 flex-1 space-y-3">
+              <Skeleton class="h-7 w-64 max-w-full rounded-xl" />
+              <Skeleton class="h-4 w-36 rounded-xl" />
+              <Skeleton class="h-4 w-44 rounded-xl" />
+            </div>
+            <Skeleton class="size-10 shrink-0 rounded-full" />
+          </div>
+
+          <div class="mt-5 grid gap-2">
+            <Skeleton class="h-11 w-full rounded-full" />
+            <Skeleton class="h-10 w-full rounded-full" />
+          </div>
+
+          <div class="mt-5 space-y-3">
+            <Skeleton class="h-5 w-3/4 rounded-xl" />
+            <Skeleton class="h-5 w-2/3 rounded-xl" />
+            <Skeleton class="h-5 w-full rounded-xl" />
+          </div>
+
+          <div class="patient-profile-stats surface-muted mt-5 grid grid-cols-3 rounded-2xl p-4">
+            <div v-for="n in 3" :key="`stat-skeleton-${n}`" class="space-y-2">
+              <Skeleton class="mx-auto h-7 w-10 rounded-xl" />
+              <Skeleton class="mx-auto h-3 w-16 rounded-xl" />
+            </div>
+          </div>
+
+          <div class="patient-mini-card surface-muted mt-5 rounded-2xl p-4">
+            <div class="flex items-start gap-3">
+              <Skeleton class="size-5 shrink-0 rounded-md" />
+              <div class="flex-1 space-y-2">
+                <Skeleton class="h-4 w-20 rounded-xl" />
+                <Skeleton class="h-4 w-32 rounded-xl" />
+              </div>
+            </div>
+          </div>
+
+          <div class="patient-mini-card surface-muted mt-4 rounded-2xl p-4">
+            <div class="mb-3 flex items-center justify-between gap-4">
+              <div class="flex-1 space-y-2">
+                <Skeleton class="h-4 w-28 rounded-xl" />
+                <Skeleton class="h-3 w-40 rounded-xl" />
+              </div>
+              <Skeleton class="h-4 w-10 rounded-xl" />
+            </div>
+            <Skeleton class="h-2 w-full rounded-full" />
+          </div>
+        </div>
+      </section>
+    </aside>
   </div>
 
   <div

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -350,6 +350,104 @@
     box-shadow: var(--surface-shadow-strong);
   }
 
+  .dark .obgyn-pregnancy-topbar {
+    color: rgb(248 250 252) !important;
+    background:
+      radial-gradient(circle at 12% 0%, rgb(59 130 246 / 0.24), transparent 34%),
+      radial-gradient(circle at 92% 0%, rgb(20 184 166 / 0.18), transparent 38%),
+      linear-gradient(135deg, rgb(15 23 42 / 0.92), rgb(2 6 23 / 0.78) 56%, rgb(15 23 42 / 0.84)),
+      rgb(2 6 23 / 0.82) !important;
+    border-color: rgb(148 163 184 / 0.16) !important;
+    box-shadow:
+      0 28px 90px -42px rgb(0 0 0 / 0.9),
+      inset 0 1px 0 rgb(255 255 255 / 0.1) !important;
+  }
+
+  .dark .obgyn-pregnancy-topbar-icon,
+  .dark .obgyn-pregnancy-topbar-action,
+  .dark .obgyn-pregnancy-topbar-ga {
+    color: rgb(226 232 240) !important;
+    border-color: rgb(148 163 184 / 0.2) !important;
+    background:
+      linear-gradient(135deg, rgb(15 23 42 / 0.84), rgb(2 6 23 / 0.54)),
+      rgb(15 23 42 / 0.62) !important;
+    box-shadow:
+      0 12px 30px rgb(0 0 0 / 0.34),
+      inset 0 1px 0 rgb(255 255 255 / 0.08) !important;
+  }
+
+  .dark .obgyn-pregnancy-topbar-action--primary {
+    color: white !important;
+    border-color: rgb(255 255 255 / 0.16) !important;
+    background: linear-gradient(135deg, rgb(37 99 235), rgb(20 184 166)) !important;
+    box-shadow: 0 18px 42px rgb(37 99 235 / 0.24) !important;
+  }
+
+  .dark .obgyn-pregnancy-topbar-trimester {
+    color: white !important;
+    background: linear-gradient(135deg, rgb(37 99 235), rgb(20 184 166)) !important;
+  }
+
+  .dark .obgyn-pregnancy-topbar-edd,
+  .dark .obgyn-pregnancy-topbar .text-muted-foreground {
+    color: rgb(203 213 225 / 0.78) !important;
+  }
+
+  .dark .resolve-pregnancy-dialog {
+    color: rgb(248 250 252) !important;
+    background:
+      radial-gradient(circle at 18% 0%, rgb(59 130 246 / 0.16), transparent 34%),
+      radial-gradient(circle at 82% 100%, rgb(20 184 166 / 0.1), transparent 36%),
+      linear-gradient(145deg, rgb(15 23 42 / 0.94), rgb(2 6 23 / 0.86) 58%, rgb(15 23 42 / 0.9)),
+      rgb(2 6 23 / 0.86) !important;
+    border-color: rgb(148 163 184 / 0.2) !important;
+    box-shadow: 0 32px 90px -42px rgb(0 0 0 / 0.92) !important;
+  }
+
+  .dark .resolve-outcome-option {
+    color: rgb(248 250 252) !important;
+    border-color: rgb(148 163 184 / 0.18) !important;
+    background:
+      radial-gradient(circle at 0% 0%, rgb(37 99 235 / 0.12), transparent 38%),
+      linear-gradient(135deg, rgb(15 23 42 / 0.88), rgb(2 6 23 / 0.74)),
+      rgb(15 23 42 / 0.78) !important;
+    box-shadow:
+      0 16px 34px rgb(0 0 0 / 0.34),
+      inset 0 1px 0 rgb(255 255 255 / 0.08) !important;
+  }
+
+  .dark .resolve-outcome-option:hover,
+  .dark .resolve-outcome-option.is-selected {
+    border-color: rgb(96 165 250 / 0.5) !important;
+    background:
+      radial-gradient(circle at 0% 0%, rgb(37 99 235 / 0.28), transparent 42%),
+      radial-gradient(circle at 100% 0%, rgb(20 184 166 / 0.2), transparent 38%),
+      linear-gradient(135deg, rgb(15 23 42 / 0.94), rgb(2 6 23 / 0.78)),
+      rgb(15 23 42 / 0.82) !important;
+    box-shadow:
+      0 18px 42px rgb(37 99 235 / 0.14),
+      inset 0 1px 0 rgb(255 255 255 / 0.1) !important;
+  }
+
+  .dark .resolve-outcome-option p:last-child,
+  .dark .resolve-pregnancy-dialog .text-muted-foreground {
+    color: rgb(203 213 225 / 0.78) !important;
+  }
+
+  .dark .resolve-outcome-radio {
+    border-color: rgb(203 213 225 / 0.42) !important;
+    background: rgb(15 23 42 / 0.78) !important;
+    box-shadow:
+      0 8px 18px rgb(0 0 0 / 0.32),
+      inset 0 1px 0 rgb(255 255 255 / 0.1) !important;
+  }
+
+  .dark .resolve-outcome-radio[data-state='checked'] {
+    color: white !important;
+    border-color: rgb(96 165 250) !important;
+    background: linear-gradient(135deg, rgb(37 99 235), rgb(20 184 166)) !important;
+  }
+
   .clinical-solid {
     background: var(--surface-solid);
     border-color: var(--surface-border);


### PR DESCRIPTION
## Summary

Adds a richer patient profile loading skeleton and polishes related OB-GYN dark glass surfaces.

## Changes

- Replaces the patient detail loading spinner with a structured skeleton layout for modules, timeline, and profile sidebar.
- Adds default action visibility handling and dark-mode polish for the OB-GYN pregnancy topbar.
- Refines the resolve-pregnancy modal option cards, info/warning panels, and dark-mode styling.
- Adds global dark-mode overrides for teleported OB-GYN modal/topbar surfaces.

## Validation

- `npx vitest run src/domains/patient/views/PatientListView.spec.ts src/domains/obgyn/components/PrenatalVisitForm.spec.ts src/router/index.spec.ts`
  - Passed: 3 files, 13 tests.
- `TEST_CMD="npm run build" docker compose -p clinicapp-fe-patient-skeleton -f docker-compose.test.yml run --rm frontend-test`
  - Did not complete: stalled after starting `vue-tsc -b && vite build`; container was stopped and removed.
- `npx vue-tsc -b --pretty false`
  - Did not complete locally in a reasonable time; process was stopped.
- `npx vite build`
  - Did not complete locally in a reasonable time after `transforming...`; process was stopped.

Notes: the stalled build/type-check behavior appears to be project-wide on the current frontend state rather than an immediate compile error from this patch; targeted Vue/Vitest compilation for nearby patient, OB-GYN, and router surfaces passed.
