### PR TITLE
fix: prevent global search dropdown clipping

### DIFF
--- a/src/components/layout/SiteHeader.vue
+++ b/src/components/layout/SiteHeader.vue
@@ -140,7 +140,7 @@ function onFocus() {
 
 <template>
   <header
-    class="glass-topbar-shell sticky top-2 z-50 mx-2 mb-2 flex w-[calc(100%-1rem)] items-center overflow-hidden rounded-2xl"
+    class="glass-topbar-shell sticky top-2 z-50 mx-2 mb-2 flex w-[calc(100%-1rem)] items-center rounded-2xl"
     style="height: calc(var(--header-height) + 0.5rem)"
   >
     <div class="flex h-full w-full items-center gap-3 p-3">


### PR DESCRIPTION
## Summary
- Fix global patient search suggestions being clipped by the sticky topbar
- Let the dropdown render outside the header while preserving the glass topbar styling

## Test Plan
- Browser-verified on local clinicdev that suggestions extend below the topbar and remain viewable
- `make npm cmd="run build"`

## Notes
- Local host `npm run build` hit a node_modules permission issue; Docker dev build passed.