### PR TITLE
fix: initialize Google identity once

### DIFF
--- a/src/domains/auth/components/GoogleSignInButton.spec.ts
+++ b/src/domains/auth/components/GoogleSignInButton.spec.ts
@@ -1,0 +1,74 @@
+import { flushPromises } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mountWithDeps } from '@/__tests__/helpers/mountWithDeps'
+
+class ResizeObserverMock {
+  observe = vi.fn()
+  disconnect = vi.fn()
+}
+
+async function mountButton(props: Record<string, unknown> = {}) {
+  const { default: GoogleSignInButton } = await import('./GoogleSignInButton.vue')
+  const wrapper = mountWithDeps(GoogleSignInButton, { props })
+  await flushPromises()
+  return wrapper
+}
+
+describe('GoogleSignInButton', () => {
+  let initializeSpy: ReturnType<typeof vi.fn>
+  let renderButtonSpy: ReturnType<typeof vi.fn>
+  let credentialCallback: ((response: GoogleCredentialResponse) => void) | undefined
+
+  beforeEach(() => {
+    vi.resetModules()
+    vi.stubEnv('VITE_GOOGLE_CLIENT_ID', 'google-client-id')
+    credentialCallback = undefined
+    initializeSpy = vi.fn((options: { callback: (response: GoogleCredentialResponse) => void }) => {
+      credentialCallback = options.callback
+    })
+    renderButtonSpy = vi.fn()
+
+    window.google = {
+      accounts: {
+        id: {
+          initialize: initializeSpy,
+          renderButton: renderButtonSpy,
+        },
+      },
+    }
+    vi.stubGlobal('ResizeObserver', ResizeObserverMock)
+  })
+
+  it('initializes Google Identity once while allowing button re-renders', async () => {
+    const wrapper = await mountButton({ shape: 'pill' })
+
+    expect(initializeSpy).toHaveBeenCalledTimes(1)
+    expect(renderButtonSpy).toHaveBeenCalledTimes(1)
+
+    await wrapper.setProps({ text: 'signup_with' })
+    await flushPromises()
+
+    expect(initializeSpy).toHaveBeenCalledTimes(1)
+    expect(renderButtonSpy).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps one Google Identity initialization across remounts and routes credentials to the active instance', async () => {
+    const first = await mountButton()
+    first.unmount()
+    const second = await mountButton({ text: 'signup_with' })
+
+    expect(initializeSpy).toHaveBeenCalledTimes(1)
+    expect(renderButtonSpy).toHaveBeenCalledTimes(2)
+
+    credentialCallback?.({ credential: 'jwt-from-google' })
+
+    expect(first.emitted('credential')).toBeUndefined()
+    expect(second.emitted('credential')).toEqual([['jwt-from-google']])
+
+    const emittedBeforeUnmount = second.emitted('credential')
+    second.unmount()
+    credentialCallback?.({ credential: 'late-jwt-from-google' })
+
+    expect(emittedBeforeUnmount).toEqual([['jwt-from-google']])
+  })
+})

--- a/src/domains/auth/components/GoogleSignInButton.vue
+++ b/src/domains/auth/components/GoogleSignInButton.vue
@@ -1,29 +1,19 @@
-<script setup lang="ts">
-import { nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
-
-const props = withDefaults(defineProps<{
-  disabled?: boolean
-  shape?: 'rectangular' | 'pill' | 'circle' | 'square'
-  text?: 'signin_with' | 'signup_with' | 'continue_with'
-  width?: number
-}>(), {
-  disabled: false,
-  shape: 'rectangular',
-  text: 'continue_with',
-  width: 400,
-})
-
-const emit = defineEmits<{
-  credential: [credential: string]
-}>()
-
-const clientId = import.meta.env.VITE_GOOGLE_CLIENT_ID as string | undefined
-const containerRef = ref<HTMLElement | null>(null)
-const buttonRef = ref<HTMLElement | null>(null)
-const ready = ref(false)
-
+<script lang="ts">
 let scriptPromise: Promise<void> | null = null
-let resizeObserver: ResizeObserver | null = null
+let googleIdentityInitialized = false
+let activeCredentialCallback: ((response: GoogleCredentialResponse) => void) | null = null
+
+function initializeGoogleIdentity(clientId: string): void {
+  if (googleIdentityInitialized || !window.google?.accounts?.id) {
+    return
+  }
+
+  window.google.accounts.id.initialize({
+    client_id: clientId,
+    callback: (response) => activeCredentialCallback?.(response),
+  })
+  googleIdentityInitialized = true
+}
 
 function loadGoogleIdentityScript(): Promise<void> {
   if (window.google?.accounts?.id) {
@@ -53,9 +43,45 @@ function loadGoogleIdentityScript(): Promise<void> {
 
   return scriptPromise
 }
+</script>
+
+<script setup lang="ts">
+import { nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+
+const props = withDefaults(defineProps<{
+  disabled?: boolean
+  shape?: 'rectangular' | 'pill' | 'circle' | 'square'
+  text?: 'signin_with' | 'signup_with' | 'continue_with'
+  width?: number
+}>(), {
+  disabled: false,
+  shape: 'rectangular',
+  text: 'continue_with',
+  width: 400,
+})
+
+const emit = defineEmits<{
+  credential: [credential: string]
+}>()
+
+const clientId = import.meta.env.VITE_GOOGLE_CLIENT_ID as string | undefined
+const containerRef = ref<HTMLElement | null>(null)
+const buttonRef = ref<HTMLElement | null>(null)
+const ready = ref(false)
+const handleCredential = (response: GoogleCredentialResponse) => {
+  if (response.credential) {
+    emit('credential', response.credential)
+  }
+}
+
+let resizeObserver: ResizeObserver | null = null
 
 async function renderButton(): Promise<void> {
   if (!clientId || !buttonRef.value || props.disabled) {
+    ready.value = false
+    if (activeCredentialCallback === handleCredential) {
+      activeCredentialCallback = null
+    }
     return
   }
 
@@ -66,15 +92,10 @@ async function renderButton(): Promise<void> {
     return
   }
 
+  activeCredentialCallback = handleCredential
+  initializeGoogleIdentity(clientId)
+
   buttonRef.value.innerHTML = ''
-  window.google.accounts.id.initialize({
-    client_id: clientId,
-    callback: (response) => {
-      if (response.credential) {
-        emit('credential', response.credential)
-      }
-    },
-  })
   window.google.accounts.id.renderButton(buttonRef.value, {
     theme: 'outline',
     size: 'large',
@@ -103,6 +124,9 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
   resizeObserver?.disconnect()
+  if (activeCredentialCallback === handleCredential) {
+    activeCredentialCallback = null
+  }
 })
 
 watch(() => [props.disabled, props.shape, props.text, props.width], () => {


### PR DESCRIPTION
## Summary
- Initialize Google Identity Services once per page lifetime instead of inside every button render
- Route credentials through the currently active button instance and clear that callback on disable/unmount
- Add component coverage for prop-driven re-renders and login/signup remounts

## Test Plan
- TZ=UTC npm run test -- src/domains/auth/components/GoogleSignInButton.spec.ts
- npm run build

Closes #154
