### PR TITLE
feat(subscription): add Max + Custom plan tiers to UI

### DIFF
--- a/src/components/shared/ProBadgeBanner.vue
+++ b/src/components/shared/ProBadgeBanner.vue
@@ -8,11 +8,18 @@ import { RouteNames } from '@/router/routeNames'
 const router = useRouter()
 const authStore = useAuthStore()
 
-const isPro = computed(() => authStore.isPro)
+const isPaidPlan = computed(() => authStore.isPaidPlan)
 const isOnTrial = computed(() => authStore.isOnTrial)
 const trialDaysLeft = computed(() => authStore.trialDaysLeft)
 const clinicName = computed(() => authStore.currentClinic?.clinic_name ?? 'Your Clinic')
 const isOwner = computed(() => authStore.currentRole === 'owner')
+
+const planLabel = computed(() => {
+  const plan = authStore.currentClinic?.plan
+  if (plan === 'max') return 'Max'
+  if (plan === 'custom') return 'Custom'
+  return 'Pro'
+})
 
 const billingEndFormatted = computed(() => {
   const endsAt = authStore.billingPeriodEnd
@@ -26,16 +33,16 @@ const billingEndFormatted = computed(() => {
 </script>
 
 <template>
-  <!-- Pro (paid) -->
-  <div v-if="isPro && !isOnTrial" class="relative overflow-hidden rounded-xl border border-amber-200/60 bg-gradient-to-r from-amber-50 via-yellow-50 to-amber-50 dark:border-amber-800/40 dark:from-amber-950/40 dark:via-yellow-950/30 dark:to-amber-950/40">
+  <!-- Paid (Pro/Max/Custom) -->
+  <div v-if="isPaidPlan && !isOnTrial" class="relative overflow-hidden rounded-xl border border-amber-200/60 bg-gradient-to-r from-amber-50 via-yellow-50 to-amber-50 dark:border-amber-800/40 dark:from-amber-950/40 dark:via-yellow-950/30 dark:to-amber-950/40">
     <div class="flex items-center gap-4 px-5 py-3">
-      <img src="/images/pro-badge.svg" alt="Pro" class="size-9 shrink-0 drop-shadow-sm" />
+      <img src="/images/pro-badge.svg" :alt="planLabel" class="size-9 shrink-0 drop-shadow-sm" />
       <div class="flex min-w-0 flex-1 flex-col gap-0.5">
         <div class="flex items-center gap-2">
           <span class="text-sm font-semibold text-amber-900 dark:text-amber-100">{{ clinicName }}</span>
           <span class="inline-flex items-center gap-1 rounded-full bg-gradient-to-r from-amber-500 to-yellow-500 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-white shadow-sm">
             <Sparkles class="size-2.5" />
-            Pro
+            {{ planLabel }}
           </span>
         </div>
         <div class="flex items-center gap-3 text-xs text-amber-600/80 dark:text-amber-400/70">
@@ -59,8 +66,8 @@ const billingEndFormatted = computed(() => {
     <div class="pointer-events-none absolute inset-0 bg-gradient-to-r from-transparent via-white/20 to-transparent dark:via-white/5" />
   </div>
 
-  <!-- Trial -->
-  <div v-else-if="isPro && isOnTrial" class="rounded-xl border border-sky-200/60 bg-gradient-to-r from-sky-50/80 to-indigo-50/50 dark:border-sky-800/40 dark:from-sky-950/30 dark:to-indigo-950/20">
+  <!-- Trial (Pro) -->
+  <div v-else-if="isOnTrial" class="rounded-xl border border-sky-200/60 bg-gradient-to-r from-sky-50/80 to-indigo-50/50 dark:border-sky-800/40 dark:from-sky-950/30 dark:to-indigo-950/20">
     <div class="flex items-center gap-4 px-5 py-3">
       <img src="/images/pro-badge.svg" alt="Pro" class="size-9 shrink-0 opacity-70" />
       <div class="flex min-w-0 flex-1 flex-col gap-0.5">

--- a/src/domains/auth/stores/authStore.spec.ts
+++ b/src/domains/auth/stores/authStore.spec.ts
@@ -95,7 +95,7 @@ function makeClinicContext(overrides: Partial<ClinicContext> = {}): ClinicContex
     is_in_grace_period: false,
     features: ['messages'],
     limits: {
-      team_members: { max: 10, used: 1 },
+      doctors: { max: 10, used: 1 },
       pdf_generation_daily: { max: null, used: 0 },
     },
     ...overrides,
@@ -391,7 +391,7 @@ describe('authStore — permission + feature helpers', () => {
       data: makeUser({
         current_clinic: makeClinicContext({
           limits: {
-            team_members: { max: 10, used: 3 },
+            doctors: { max: 10, used: 3 },
             pdf_generation_daily: { max: null, used: 5 },
           },
         }),
@@ -403,7 +403,7 @@ describe('authStore — permission + feature helpers', () => {
     const store = useAuthStore()
     await store.fetchUser()
 
-    expect(store.getLimit('team_members')).toEqual({ max: 10, used: 3, remaining: 7 })
+    expect(store.getLimit('doctors')).toEqual({ max: 10, used: 3, remaining: 7 })
     // null max → unlimited (remaining null)
     expect(store.getLimit('pdf_generation_daily')).toEqual({ max: null, used: 5, remaining: null })
   })
@@ -413,7 +413,7 @@ describe('authStore — permission + feature helpers', () => {
       data: makeUser({
         current_clinic: makeClinicContext({
           limits: {
-            team_members: { max: 2, used: 5 },
+            doctors: { max: 2, used: 5 },
           } as ClinicContext['limits'],
         }),
       }),
@@ -424,7 +424,7 @@ describe('authStore — permission + feature helpers', () => {
     const store = useAuthStore()
     await store.fetchUser()
 
-    expect(store.getLimit('team_members')).toEqual({ max: 2, used: 5, remaining: 0 })
+    expect(store.getLimit('doctors')).toEqual({ max: 2, used: 5, remaining: 0 })
     expect(store.getLimit('pdf_generation_daily')).toEqual({ max: null, used: 0, remaining: null })
   })
 })
@@ -468,6 +468,37 @@ describe('authStore — trial / grace / cancel derivations', () => {
     await store.fetchUser()
 
     expect(store.isPro).toBe(false)
+    expect(store.isMax).toBe(false)
+    expect(store.isPaidPlan).toBe(false)
+  })
+
+  it('isMax / isPaidPlan reflect Max tier', async () => {
+    const meResp: MeResponse = {
+      data: makeUser({ current_clinic: makeClinicContext({ plan: 'max' }) }),
+      meta: { memberships: [makeMembership()] },
+    }
+    const api = makeAuthApi({ me: vi.fn().mockResolvedValue(meResp) })
+    const { useAuthStore } = await loadStore(api)
+    const store = useAuthStore()
+    await store.fetchUser()
+
+    expect(store.isPro).toBe(false)
+    expect(store.isMax).toBe(true)
+    expect(store.isPaidPlan).toBe(true)
+  })
+
+  it('isCustom / isPaidPlan reflect Custom tier', async () => {
+    const meResp: MeResponse = {
+      data: makeUser({ current_clinic: makeClinicContext({ plan: 'custom' }) }),
+      meta: { memberships: [makeMembership()] },
+    }
+    const api = makeAuthApi({ me: vi.fn().mockResolvedValue(meResp) })
+    const { useAuthStore } = await loadStore(api)
+    const store = useAuthStore()
+    await store.fetchUser()
+
+    expect(store.isCustom).toBe(true)
+    expect(store.isPaidPlan).toBe(true)
   })
 
   it('trialDaysLeft computes ceil(diff/day) and clamps at zero', async () => {

--- a/src/domains/auth/stores/authStore.ts
+++ b/src/domains/auth/stores/authStore.ts
@@ -32,6 +32,14 @@ export const useAuthStore = defineStore('auth', () => {
   )
 
   const isPro = computed(() => currentClinic.value?.plan === 'pro')
+  const isMax = computed(() => currentClinic.value?.plan === 'max')
+  const isCustom = computed(() => currentClinic.value?.plan === 'custom')
+  // True for any paid tier (or trial, which carries pro features). Use this
+  // for feature-availability checks; use isPro/isMax for plan-specific UI.
+  const isPaidPlan = computed(() => {
+    const plan = currentClinic.value?.plan
+    return plan === 'pro' || plan === 'max' || plan === 'custom'
+  })
 
   const isOnTrial = computed(() => currentClinic.value?.is_trial ?? false)
 
@@ -59,7 +67,7 @@ export const useAuthStore = defineStore('auth', () => {
     return currentClinic.value?.features?.includes(feature) ?? false
   }
 
-  function getLimit(key: 'team_members' | 'pdf_generation_daily') {
+  function getLimit(key: 'doctors' | 'pdf_generation_daily') {
     const limit = currentClinic.value?.limits?.[key]
     const max = limit?.max ?? null
     const used = limit?.used ?? 0
@@ -240,6 +248,9 @@ export const useAuthStore = defineStore('auth', () => {
     currentClinic,
     currentRole,
     isPro,
+    isMax,
+    isCustom,
+    isPaidPlan,
     isOnTrial,
     trialDaysLeft,
     billingPeriodEnd,

--- a/src/domains/auth/types/auth.types.ts
+++ b/src/domains/auth/types/auth.types.ts
@@ -25,6 +25,8 @@ export interface ValidationError {
   errors: Record<string, string[]>
 }
 
+export type ClinicPlan = 'free' | 'pro' | 'max' | 'custom'
+
 export interface Membership {
   id: string
   clinic_id: string
@@ -32,7 +34,7 @@ export interface Membership {
   logo_url: string | null
   role: string
   status: string
-  plan: 'free' | 'pro'
+  plan: ClinicPlan
   is_trial: boolean
 }
 
@@ -72,7 +74,7 @@ export interface ClinicContext {
   role: string
   membership_id: string
   permissions: string[]
-  plan: 'free' | 'pro'
+  plan: ClinicPlan
   is_trial: boolean
   trial_ends_at: string | null
   billing_period_ends_at: string | null
@@ -80,7 +82,7 @@ export interface ClinicContext {
   is_in_grace_period: boolean
   features: string[]
   limits: {
-    team_members: PlanLimit
+    doctors: PlanLimit
     pdf_generation_daily: PlanLimit
   }
 }

--- a/src/domains/dashboard/views/OwnerDashboardView.vue
+++ b/src/domains/dashboard/views/OwnerDashboardView.vue
@@ -38,7 +38,7 @@ const router = useRouter()
 const authStore = useAuthStore()
 
 const hasAppointments = computed(() => authStore.hasFeature('appointments'))
-const isPro = computed(() => authStore.isPro)
+const isPro = computed(() => authStore.isPaidPlan)
 const todayCount = computed(() => stats.value?.my_upcoming_appointments.filter(a => a.date === todayDate).length ?? 0)
 
 const stats = ref<OwnerDashboardStats | null>(null)

--- a/src/domains/subscription/api/subscriptionApi.ts
+++ b/src/domains/subscription/api/subscriptionApi.ts
@@ -1,5 +1,6 @@
 import { http } from '@/lib/http'
 import type {
+  CheckoutPlan,
   CheckoutResponse,
   MessageResponse,
   PaymentHistoryResponse,
@@ -7,8 +8,8 @@ import type {
 } from '../types/subscription.types'
 
 export const subscriptionApi = {
-  createCheckout(): Promise<CheckoutResponse> {
-    return http.post<CheckoutResponse>('/subscription/checkout', { plan: 'pro' })
+  createCheckout(plan: CheckoutPlan = 'pro'): Promise<CheckoutResponse> {
+    return http.post<CheckoutResponse>('/subscription/checkout', { plan })
   },
 
   getStatus(): Promise<SubscriptionStatusResponse> {

--- a/src/domains/subscription/components/PricingCard.spec.ts
+++ b/src/domains/subscription/components/PricingCard.spec.ts
@@ -47,9 +47,24 @@ describe('PricingCard', () => {
     const wrapper = mountCard()
 
     expect(wrapper.text()).toContain('MediFlow Pro')
-    expect(wrapper.text()).toContain('PHP 1,299')
-    expect(wrapper.text()).toContain('Messages & Chat')
-    expect(wrapper.text()).toContain('Unlimited Team Members')
+    expect(wrapper.text()).toContain('PHP 1,499')
+    expect(wrapper.text()).toContain('Messages, appointments')
+    expect(wrapper.text()).toContain('Up to 2 practising doctors')
+  })
+
+  it('renders Max price and feature list when variant=max', () => {
+    const authStore = useAuthStore()
+    authStore.user = { current_clinic: { is_trial: false, trial_ends_at: null } } as any
+    const wrapper = mountWithDeps(PricingCard, {
+      noPinia: true,
+      props: { variant: 'max' },
+      global: { stubs: STUBS },
+    })
+
+    expect(wrapper.text()).toContain('MediFlow Max')
+    expect(wrapper.text()).toContain('PHP 4,999')
+    expect(wrapper.text()).toContain('Up to 6 practising doctors')
+    expect(wrapper.text()).toContain('Upgrade to Max')
   })
 
   it('emits upgrade when the upgrade button is clicked', async () => {

--- a/src/domains/subscription/components/PricingCard.vue
+++ b/src/domains/subscription/components/PricingCard.vue
@@ -1,57 +1,103 @@
 <script setup lang="ts">
-import { Crown, Check, Loader2 } from 'lucide-vue-next'
+import { computed } from 'vue'
+import { Crown, Check, Loader2, Sparkles } from 'lucide-vue-next'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
 import { useAuthStore } from '@/domains/auth/stores/authStore'
+import type { CheckoutPlan } from '../types/subscription.types'
 
-defineProps<{
+const props = withDefaults(defineProps<{
+  variant?: CheckoutPlan
   loading?: boolean
-}>()
+  featured?: boolean
+}>(), {
+  variant: 'pro',
+  loading: false,
+  featured: false,
+})
 
 const emit = defineEmits<{
-  upgrade: []
+  upgrade: [plan: CheckoutPlan]
 }>()
 
 const authStore = useAuthStore()
 
-const features = [
-  'Messages & Chat',
-  'Appointments & Schedule',
-  'Lab Orders & Services',
-  'Audit Logs',
-  'Custom Roles',
-  'Queue Display (TV)',
-  'Unlimited PDF Generation',
-  'Unlimited Team Members',
-]
+const meta = computed(() => {
+  if (props.variant === 'max') {
+    return {
+      title: 'MediFlow Max',
+      tagline: 'Multi-doctor clinics, up to 6 practising doctors.',
+      price: 'PHP 4,999',
+      icon: Sparkles,
+      features: [
+        'Everything in Pro',
+        'Up to 6 practising doctors (owner + 5)',
+        'Multi-doctor scheduling and queue routing',
+        'Per-doctor activity and revenue reports',
+        'Priority email and chat support',
+      ],
+    }
+  }
+  return {
+    title: 'MediFlow Pro',
+    tagline: 'Solo practice, up to 2 practising doctors.',
+    price: 'PHP 1,499',
+    icon: Crown,
+    features: [
+      'Patients, consultations, queue, billing, prescriptions',
+      'Up to 2 practising doctors (owner + 1)',
+      'Messages, appointments, schedules',
+      'Lab orders + lab services catalog',
+      'Specialty workflows (FM, IM, Peds, OB-GYN, Dental)',
+      'Audit logs, custom roles, queue display',
+      'Unlimited PDFs, no watermark',
+      'Unlimited non-doctor staff',
+    ],
+  }
+})
+
+const ctaLabel = computed(() => {
+  if (authStore.isOnTrial && props.variant === 'pro') return 'Subscribe Now'
+  return `Upgrade to ${props.variant === 'max' ? 'Max' : 'Pro'}`
+})
 </script>
 
 <template>
-  <Card class="border-amber-200 dark:border-amber-800/50">
+  <Card
+    :class="featured
+      ? 'border-amber-200 dark:border-amber-800/50 shadow-md'
+      : ''"
+  >
     <CardHeader class="text-center pb-2">
-      <div class="mx-auto mb-2 flex size-12 items-center justify-center rounded-full bg-amber-100 dark:bg-amber-900/30">
-        <Crown class="size-6 text-amber-600 dark:text-amber-400" />
+      <div
+        class="mx-auto mb-2 flex size-12 items-center justify-center rounded-full"
+        :class="variant === 'max'
+          ? 'bg-gradient-to-br from-amber-100 to-teal-100 dark:from-amber-900/30 dark:to-teal-900/30'
+          : 'bg-amber-100 dark:bg-amber-900/30'"
+      >
+        <component :is="meta.icon" class="size-6 text-amber-600 dark:text-amber-400" />
       </div>
-      <CardTitle class="text-xl">MediFlow Pro</CardTitle>
-      <CardDescription>
-        Unlock all premium features for your clinic
-      </CardDescription>
+      <CardTitle class="text-xl">{{ meta.title }}</CardTitle>
+      <CardDescription>{{ meta.tagline }}</CardDescription>
     </CardHeader>
     <CardContent class="space-y-6">
       <div class="text-center">
-        <span class="text-4xl font-bold">PHP 1,299</span>
+        <span class="text-4xl font-bold">{{ meta.price }}</span>
         <span class="text-muted-foreground">/month</span>
       </div>
 
       <div class="grid gap-2">
-        <div v-for="feat in features" :key="feat" class="flex items-center gap-2 text-sm">
-          <Check class="size-4 text-green-600 dark:text-green-400 shrink-0" />
+        <div v-for="feat in meta.features" :key="feat" class="flex items-start gap-2 text-sm">
+          <Check class="size-4 text-green-600 dark:text-green-400 shrink-0 mt-0.5" />
           <span>{{ feat }}</span>
         </div>
       </div>
 
       <div class="text-center">
-        <p v-if="authStore.isOnTrial" class="mb-3 text-sm text-amber-600 dark:text-amber-400 font-medium">
+        <p
+          v-if="authStore.isOnTrial && variant === 'pro'"
+          class="mb-3 text-sm text-amber-600 dark:text-amber-400 font-medium"
+        >
           Your trial ends in {{ authStore.trialDaysLeft }} day{{ authStore.trialDaysLeft === 1 ? '' : 's' }}.
           Subscribe to keep Pro features.
         </p>
@@ -59,11 +105,11 @@ const features = [
           class="w-full gap-2"
           size="lg"
           :disabled="loading"
-          @click="emit('upgrade')"
+          @click="emit('upgrade', variant)"
         >
           <Loader2 v-if="loading" class="size-4 animate-spin" />
-          <Crown v-else class="size-4" />
-          {{ authStore.isOnTrial ? 'Subscribe Now' : 'Upgrade to Pro' }}
+          <component :is="meta.icon" v-else class="size-4" />
+          {{ ctaLabel }}
         </Button>
       </div>
     </CardContent>

--- a/src/domains/subscription/stores/subscriptionStore.ts
+++ b/src/domains/subscription/stores/subscriptionStore.ts
@@ -1,7 +1,7 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
 import { subscriptionApi } from '../api/subscriptionApi'
-import type { PaymentRecord, SubscriptionStatus } from '../types/subscription.types'
+import type { CheckoutPlan, PaymentRecord, SubscriptionStatus } from '../types/subscription.types'
 
 const TRUSTED_CHECKOUT_HOST = 'checkout.paymongo.com'
 
@@ -46,10 +46,10 @@ export const useSubscriptionStore = defineStore('subscription', () => {
     }
   }
 
-  async function initiateCheckout(): Promise<void> {
+  async function initiateCheckout(plan: CheckoutPlan = 'pro'): Promise<void> {
     checkoutLoading.value = true
     try {
-      const response = await subscriptionApi.createCheckout()
+      const response = await subscriptionApi.createCheckout(plan)
       const checkoutUrl = response.data.checkout_url
       if (!isTrustedCheckoutUrl(checkoutUrl)) {
         throw new Error('Invalid checkout URL returned from server')

--- a/src/domains/subscription/types/subscription.types.ts
+++ b/src/domains/subscription/types/subscription.types.ts
@@ -5,8 +5,12 @@ export interface CheckoutResponse {
   }
 }
 
+import type { ClinicPlan } from '@/domains/auth/types/auth.types'
+
+export type CheckoutPlan = 'pro' | 'max'
+
 export interface SubscriptionStatus {
-  plan: 'free' | 'pro'
+  plan: ClinicPlan
   is_trial: boolean
   trial_ends_at: string | null
   trial_days_left: number | null

--- a/src/domains/subscription/views/PaymentSuccessView.vue
+++ b/src/domains/subscription/views/PaymentSuccessView.vue
@@ -21,7 +21,7 @@ async function pollForConfirmation() {
 
     try {
       await authStore.fetchUser()
-      if (authStore.isPro && !authStore.isOnTrial) {
+      if (authStore.isPaidPlan && !authStore.isOnTrial) {
         confirmed.value = true
         processing.value = false
         return
@@ -32,7 +32,8 @@ async function pollForConfirmation() {
 
     try {
       const statusRes = await subscriptionApi.getStatus()
-      if (statusRes.data.plan === 'pro' && !statusRes.data.is_trial) {
+      const plan = statusRes.data.plan
+      if ((plan === 'pro' || plan === 'max') && !statusRes.data.is_trial) {
         confirmed.value = true
         processing.value = false
         await authStore.fetchUser()
@@ -75,7 +76,7 @@ onMounted(() => {
           </h2>
           <p class="mt-1 text-sm text-muted-foreground">
             <template v-if="confirmed">
-              Your clinic is now on the Pro plan. All premium features are unlocked.
+              Your clinic is now on a paid plan. All premium features are unlocked.
             </template>
             <template v-else>
               Your payment is being processed. Your plan will be updated shortly.

--- a/src/domains/subscription/views/SubscriptionView.vue
+++ b/src/domains/subscription/views/SubscriptionView.vue
@@ -21,14 +21,17 @@ import {
   Receipt,
   Pill,
   ClipboardList,
-  Loader2,
+  Diamond,
+  Mail,
 } from 'lucide-vue-next'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { useAuthStore } from '@/domains/auth/stores/authStore'
 import { useSubscriptionStore } from '../stores/subscriptionStore'
+import PricingCard from '../components/PricingCard.vue'
 import BillingHistory from '../components/BillingHistory.vue'
 import CancelSubscriptionDialog from '../components/CancelSubscriptionDialog.vue'
+import type { CheckoutPlan } from '../types/subscription.types'
 
 const authStore = useAuthStore()
 const subscriptionStore = useSubscriptionStore()
@@ -44,6 +47,21 @@ const billingEndFormatted = computed(() => {
     month: 'long',
     day: 'numeric',
   })
+})
+
+const planLabel = computed(() => {
+  const plan = status.value?.plan
+  if (plan === 'max') return 'Max'
+  if (plan === 'pro') return 'Pro'
+  if (plan === 'custom') return 'Custom'
+  return 'Free'
+})
+
+const planIcon = computed(() => {
+  const plan = status.value?.plan
+  if (plan === 'max') return Sparkles
+  if (plan === 'custom') return Diamond
+  return Crown
 })
 
 const allFeatures = [
@@ -65,6 +83,14 @@ const allFeatures = [
   { key: 'future', label: 'Future Features', icon: Sparkles, free: false },
 ]
 
+function startCheckout(plan: CheckoutPlan): void {
+  subscriptionStore.initiateCheckout(plan)
+}
+
+function contactSales(): void {
+  window.location.href = 'mailto:hello@mediflow.ph?subject=MediFlow%20Custom%20Plan%20Inquiry'
+}
+
 onMounted(() => {
   subscriptionStore.fetchStatus()
   subscriptionStore.fetchHistory()
@@ -80,12 +106,66 @@ onMounted(() => {
         <p class="mt-1 text-sm text-muted-foreground">Manage your clinic's plan and billing</p>
       </div>
 
-      <!-- 2-col layout -->
+      <!-- Pricing cards for Free clinics (owner only — staff just see the status row below) -->
+      <div v-if="status && status.plan === 'free' && !status.is_trial && isOwner" class="mb-8">
+        <div class="grid gap-6 lg:grid-cols-3">
+          <PricingCard
+            variant="pro"
+            featured
+            :loading="subscriptionStore.checkoutLoading"
+            @upgrade="startCheckout"
+          />
+          <PricingCard
+            variant="max"
+            :loading="subscriptionStore.checkoutLoading"
+            @upgrade="startCheckout"
+          />
+          <!-- Custom · Clinic groups (contact sales, no self-serve) -->
+          <div class="rounded-xl border border-indigo-200/60 bg-gradient-to-br from-indigo-50/40 to-white p-6 flex flex-col dark:from-indigo-950/30 dark:to-card">
+            <div class="mx-auto mb-2 flex size-12 items-center justify-center rounded-full bg-gradient-to-br from-indigo-100 to-purple-100 dark:from-indigo-900/30 dark:to-purple-900/30">
+              <Diamond class="size-6 text-indigo-600 dark:text-indigo-400" />
+            </div>
+            <h3 class="text-xl font-semibold text-center">MediFlow Custom</h3>
+            <p class="mt-1 text-sm text-muted-foreground text-center">Clinic groups, multi-location, bespoke needs.</p>
+            <div class="my-6 text-center">
+              <span class="text-3xl font-bold">Let's talk</span>
+            </div>
+            <div class="grid gap-2 flex-1">
+              <div class="flex items-start gap-2 text-sm">
+                <Check class="size-4 text-green-600 dark:text-green-400 shrink-0 mt-0.5" />
+                <span>Everything in Max</span>
+              </div>
+              <div class="flex items-start gap-2 text-sm">
+                <Check class="size-4 text-green-600 dark:text-green-400 shrink-0 mt-0.5" />
+                <span>Unlimited doctors and locations</span>
+              </div>
+              <div class="flex items-start gap-2 text-sm">
+                <Check class="size-4 text-green-600 dark:text-green-400 shrink-0 mt-0.5" />
+                <span>Custom integrations and API access</span>
+              </div>
+              <div class="flex items-start gap-2 text-sm">
+                <Check class="size-4 text-green-600 dark:text-green-400 shrink-0 mt-0.5" />
+                <span>Dedicated success manager + SLA</span>
+              </div>
+              <div class="flex items-start gap-2 text-sm">
+                <Check class="size-4 text-green-600 dark:text-green-400 shrink-0 mt-0.5" />
+                <span>Onboarding and migration help</span>
+              </div>
+            </div>
+            <Button variant="outline" size="lg" class="mt-6 w-full gap-2" @click="contactSales">
+              <Mail class="size-4" />
+              Contact sales
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      <!-- 2-col layout for current-status display -->
       <div class="grid gap-6 lg:grid-cols-5">
-        <!-- Left column (3/5) -->
+        <!-- Left column -->
         <div class="flex flex-col gap-6 lg:col-span-2">
-          <!-- Free Plan Card -->
-          <div v-if="status && status.plan === 'free' && !status.is_trial" class="rounded-xl border bg-card p-6">
+          <!-- Free Plan summary card (non-owners only — owners see the pricing grid above) -->
+          <div v-if="status && status.plan === 'free' && !status.is_trial && !isOwner" class="rounded-xl border bg-card p-6">
             <div class="flex items-start gap-4">
               <div class="flex size-12 shrink-0 items-center justify-center rounded-xl bg-muted">
                 <Crown class="size-6 text-muted-foreground" />
@@ -96,29 +176,22 @@ onMounted(() => {
                   <Badge variant="secondary">Free</Badge>
                 </div>
                 <p class="mt-1 text-sm text-muted-foreground">
-                  Upgrade to Pro to unlock all premium features
+                  Ask the clinic owner to upgrade for premium features.
                 </p>
-                <div v-if="isOwner" class="mt-4">
-                  <Button
-                    size="sm"
-                    class="gap-1.5 bg-gradient-to-r from-amber-500 to-yellow-500 text-white shadow-sm hover:from-amber-600 hover:to-yellow-600"
-                    :disabled="subscriptionStore.checkoutLoading"
-                    @click="subscriptionStore.initiateCheckout()"
-                  >
-                    <Loader2 v-if="subscriptionStore.checkoutLoading" class="size-3.5 animate-spin" />
-                    <Crown v-else class="size-3.5" />
-                    Upgrade to Pro — PHP 1,299/mo
-                  </Button>
-                </div>
               </div>
             </div>
           </div>
 
-          <!-- Pro Status Card (premium feel, same theme as dashboard banner) -->
-          <div v-if="status && (status.plan === 'pro' || status.is_trial)" class="relative overflow-hidden rounded-xl border border-amber-200/60 bg-gradient-to-br from-amber-50 via-yellow-50 to-amber-50/80 dark:border-amber-800/40 dark:from-amber-950/40 dark:via-yellow-950/30 dark:to-amber-950/40">
+          <!-- Paid plan / trial status card -->
+          <div
+            v-if="status && (status.plan === 'pro' || status.plan === 'max' || status.plan === 'custom' || status.is_trial)"
+            class="relative overflow-hidden rounded-xl border border-amber-200/60 bg-gradient-to-br from-amber-50 via-yellow-50 to-amber-50/80 dark:border-amber-800/40 dark:from-amber-950/40 dark:via-yellow-950/30 dark:to-amber-950/40"
+          >
             <div class="relative z-10 p-6">
               <div class="flex items-start gap-4">
-                <img src="/images/pro-badge.svg" alt="Pro" class="size-12 shrink-0 drop-shadow-md" />
+                <div class="flex size-12 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-amber-200 to-yellow-200 dark:from-amber-700/40 dark:to-yellow-700/40">
+                  <component :is="planIcon" class="size-6 text-amber-700 dark:text-amber-300" />
+                </div>
                 <div class="flex-1">
                   <div class="flex items-center gap-2.5">
                     <h2 class="text-lg font-bold text-amber-900 dark:text-amber-100">
@@ -126,11 +199,10 @@ onMounted(() => {
                     </h2>
                     <span class="inline-flex items-center gap-1 rounded-full bg-gradient-to-r from-amber-500 to-yellow-500 px-2.5 py-0.5 text-[11px] font-bold uppercase tracking-wider text-white shadow-sm">
                       <Sparkles class="size-3" />
-                      Pro
+                      {{ planLabel }}
                     </span>
                   </div>
 
-                  <!-- Billing info -->
                   <div class="mt-3 flex flex-wrap items-center gap-x-5 gap-y-2 text-sm">
                     <div v-if="status.is_trial && status.trial_days_left !== null" class="flex items-center gap-1.5 text-sky-700 dark:text-sky-400">
                       <Clock class="size-3.5" />
@@ -143,7 +215,7 @@ onMounted(() => {
                       <span v-else>Renews <strong>{{ billingEndFormatted }}</strong></span>
                     </div>
 
-                    <div v-if="billingEndFormatted && !status.is_trial && !status.cancel_at_period_end" class="flex items-center gap-1.5 text-amber-700/80 dark:text-amber-400/70">
+                    <div v-if="billingEndFormatted && !status.is_trial && !status.cancel_at_period_end && status.next_billing_amount > 0" class="flex items-center gap-1.5 text-amber-700/80 dark:text-amber-400/70">
                       <Receipt class="size-3.5" />
                       <span>PHP {{ status.next_billing_amount.toLocaleString() }}/mo</span>
                     </div>
@@ -151,7 +223,7 @@ onMounted(() => {
 
                   <div v-if="status.is_in_grace_period" class="mt-3 flex items-center gap-1.5 text-sm text-red-600 dark:text-red-400">
                     <AlertTriangle class="size-3.5" />
-                    <span class="font-medium">Billing overdue — renew to keep Pro features</span>
+                    <span class="font-medium">Billing overdue — renew to keep {{ planLabel }} features</span>
                   </div>
 
                   <div v-if="status.cancel_at_period_end" class="mt-3">
@@ -160,8 +232,11 @@ onMounted(() => {
                     </Badge>
                   </div>
 
-                  <!-- Actions (owner only) -->
-                  <div v-if="isOwner && status.plan === 'pro' && !status.is_trial && billingEndFormatted" class="mt-4 flex gap-2">
+                  <!-- Actions (owner only, paid Pro/Max only) -->
+                  <div
+                    v-if="isOwner && (status.plan === 'pro' || status.plan === 'max') && !status.is_trial && billingEndFormatted"
+                    class="mt-4 flex gap-2"
+                  >
                     <template v-if="status.cancel_at_period_end">
                       <Button
                         size="sm"
@@ -177,16 +252,16 @@ onMounted(() => {
                     </template>
                   </div>
 
-                  <!-- Trial upgrade (owner only) -->
+                  <!-- Trial upgrade prompt (owner only) -->
                   <div v-if="isOwner && status.is_trial" class="mt-4">
                     <Button
                       size="sm"
                       class="gap-1.5 bg-gradient-to-r from-amber-500 to-yellow-500 text-white shadow-sm hover:from-amber-600 hover:to-yellow-600"
                       :disabled="subscriptionStore.checkoutLoading"
-                      @click="subscriptionStore.initiateCheckout()"
+                      @click="startCheckout('pro')"
                     >
                       <Crown class="size-3.5" />
-                      Subscribe — PHP 1,299/mo
+                      Subscribe — PHP 1,499/mo
                     </Button>
                   </div>
                 </div>
@@ -195,7 +270,6 @@ onMounted(() => {
             <div class="pointer-events-none absolute inset-0 bg-gradient-to-br from-transparent via-white/10 to-amber-100/30 dark:via-white/5 dark:to-amber-900/20" />
           </div>
 
-          <!-- Billing History -->
           <BillingHistory
             v-if="subscriptionStore.payments.length > 0"
             :payments="subscriptionStore.payments"
@@ -205,7 +279,7 @@ onMounted(() => {
           />
         </div>
 
-        <!-- Right column (2/5) — Features -->
+        <!-- Right column — Features + Limits -->
         <div class="lg:col-span-3">
           <div class="rounded-xl border bg-card p-6">
             <h3 class="text-sm font-semibold">Your Plan Includes</h3>
@@ -216,18 +290,18 @@ onMounted(() => {
                 v-for="feat in allFeatures"
                 :key="feat.key"
                 class="flex items-center gap-2.5 rounded-lg px-2 py-2 transition-colors"
-                :class="(feat.key === 'future' ? authStore.isPro : authStore.hasFeature(feat.key))
+                :class="(feat.key === 'future' ? authStore.isPaidPlan : authStore.hasFeature(feat.key))
                   ? ''
                   : 'opacity-40'"
               >
                 <div
                   class="flex size-7 shrink-0 items-center justify-center rounded-md"
-                  :class="(feat.key === 'future' ? authStore.isPro : authStore.hasFeature(feat.key))
+                  :class="(feat.key === 'future' ? authStore.isPaidPlan : authStore.hasFeature(feat.key))
                     ? 'bg-green-100 dark:bg-green-900/30'
                     : 'bg-muted'"
                 >
                   <Check
-                    v-if="feat.key === 'future' ? authStore.isPro : authStore.hasFeature(feat.key)"
+                    v-if="feat.key === 'future' ? authStore.isPaidPlan : authStore.hasFeature(feat.key)"
                     class="size-3.5 text-green-600 dark:text-green-400"
                   />
                   <component
@@ -236,14 +310,14 @@ onMounted(() => {
                     class="size-3.5 text-muted-foreground"
                   />
                 </div>
-                <span class="flex-1 text-sm" :class="(feat.key === 'future' ? authStore.isPro : authStore.hasFeature(feat.key)) ? 'font-medium' : 'text-muted-foreground'">
+                <span class="flex-1 text-sm" :class="(feat.key === 'future' ? authStore.isPaidPlan : authStore.hasFeature(feat.key)) ? 'font-medium' : 'text-muted-foreground'">
                   {{ feat.label }}
                 </span>
                 <Badge
                   v-if="!feat.free"
                   variant="outline"
                   class="shrink-0 text-[10px]"
-                  :class="(feat.key === 'future' ? authStore.isPro : authStore.hasFeature(feat.key))
+                  :class="(feat.key === 'future' ? authStore.isPaidPlan : authStore.hasFeature(feat.key))
                     ? 'border-amber-300 bg-amber-50 text-amber-600 dark:border-amber-700 dark:bg-amber-900/20 dark:text-amber-400'
                     : 'border-muted'"
                 >
@@ -267,12 +341,19 @@ onMounted(() => {
                 </div>
                 <div class="flex items-center justify-between text-sm">
                   <div class="flex items-center gap-2">
-                    <Users class="size-4 text-muted-foreground" />
-                    <span>Team Members</span>
+                    <Stethoscope class="size-4 text-muted-foreground" />
+                    <span>Practising Doctors</span>
                   </div>
                   <span class="font-medium tabular-nums">
-                    {{ authStore.getLimit('team_members').max === null ? 'Unlimited' : `${authStore.getLimit('team_members').used}/${authStore.getLimit('team_members').max}` }}
+                    {{ authStore.getLimit('doctors').max === null ? 'Unlimited' : `${authStore.getLimit('doctors').used}/${authStore.getLimit('doctors').max}` }}
                   </span>
+                </div>
+                <div class="flex items-center justify-between text-sm">
+                  <div class="flex items-center gap-2">
+                    <Users class="size-4 text-muted-foreground" />
+                    <span>Non-doctor Staff</span>
+                  </div>
+                  <span class="font-medium tabular-nums">Unlimited</span>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- Introduce `ClinicPlan = 'free' | 'pro' | 'max' | 'custom'` and wire it through the auth + subscription stores. Add `isMax`, `isCustom`, and a catch-all `isPaidPlan` helper; replace the `team_members` plan limit with `doctors` to match the new tier shape.
- `PricingCard` now takes a `variant: 'pro' | 'max'` prop with tier-specific copy, price (PHP 1,499 / 4,999), icon, and CTA. Checkout calls accept the chosen plan end-to-end.
- `SubscriptionView` renders a 3-card pricing grid for Free owners (Pro / Max / Contact-sales Custom), keeps a status-only card for non-owners and other plans, and adds a "Practising Doctors" row to the limits panel alongside an unlimited "Non-doctor Staff" line.
- `ProBadgeBanner`, `OwnerDashboardView`, and `PaymentSuccessView` all migrate off `isPro` to `isPaidPlan` so Max/Custom clinics see the right state.
- Specs updated: `authStore.spec.ts` covers `isMax` / `isCustom` / `isPaidPlan` and the renamed `doctors` limit; `PricingCard.spec.ts` covers the new `variant=max` rendering.

## Backend dependency
This ships the UI assuming the API now exposes `plan: 'max' | 'custom'` on `ClinicContext` / `SubscriptionStatus` and a `limits.doctors` shape. Should land **after** the matching backend rework on staging — otherwise paid clinics will read `undefined` for the doctors limit and the new variants won't surface.

## Test plan
- [ ] Free-tier owner: `/subscription` shows three cards (Pro, Max, Custom). Pro and Max trigger PayMongo checkout with the right `plan`; Custom opens the mailto.
- [ ] Free-tier non-owner: only the "Your clinic is on Free" status card; no pricing grid.
- [ ] Pro / Max / Custom tenant: status card shows the right label + icon, ProBadgeBanner says Pro/Max/Custom, dashboard treats them all as paid.
- [ ] Limits panel: "Practising Doctors" shows used/max for Free + Pro, "Unlimited" for Max/Custom; "Non-doctor Staff" always shows "Unlimited".
- [ ] `make npm cmd="run test:unit"` — auth + subscription specs pass.
- [ ] `make npm cmd="run build"` — clean.