### PR TITLE
feat(auth): require reCAPTCHA on login

### DIFF
--- a/src/domains/auth/api/authApi.spec.ts
+++ b/src/domains/auth/api/authApi.spec.ts
@@ -40,7 +40,7 @@ describe('authApi', () => {
     const http = makeHttp()
     const { authApi } = await loadApi(http)
 
-    await authApi.login({ email: 'doctor@example.test', password: 'secret', remember_me: true })
+    await authApi.login({ email: 'doctor@example.test', password: 'secret', remember_me: true, recaptcha_token: 'login-captcha-token' })
     await authApi.signup({
       first_name: 'Doc',
       last_name: 'Tor',
@@ -59,6 +59,7 @@ describe('authApi', () => {
       email: 'doctor@example.test',
       password: btoa('secret'),
       remember_me: true,
+      recaptcha_token: 'login-captcha-token',
     })
     expect(http.post).toHaveBeenNthCalledWith(2, '/auth/signup', expect.objectContaining({
       password: btoa('secret'),

--- a/src/domains/auth/stores/authStore.spec.ts
+++ b/src/domains/auth/stores/authStore.spec.ts
@@ -174,9 +174,9 @@ describe('authStore — login flow', () => {
 
     const { useAuthStore } = await loadStore(api)
     const store = useAuthStore()
-    await store.login({ email: 't@example.com', password: 'secret' })
+    await store.login({ email: 't@example.com', password: 'secret', recaptcha_token: 'recaptcha-token' })
 
-    expect(api.login).toHaveBeenCalledWith({ email: 't@example.com', password: 'secret' })
+    expect(api.login).toHaveBeenCalledWith({ email: 't@example.com', password: 'secret', recaptcha_token: 'recaptcha-token' })
     expect(api.selectClinic).toHaveBeenCalledWith('c1')
     expect(api.me).toHaveBeenCalled()
     expect(store.isAuthenticated).toBe(true)
@@ -200,7 +200,7 @@ describe('authStore — login flow', () => {
 
     const { useAuthStore } = await loadStore(api)
     const store = useAuthStore()
-    await store.login({ email: 't@example.com', password: 'secret' })
+    await store.login({ email: 't@example.com', password: 'secret', recaptcha_token: 'recaptcha-token' })
 
     expect(api.selectClinic).not.toHaveBeenCalled()
     expect(store.needsOnboarding).toBe(true)
@@ -228,7 +228,7 @@ describe('authStore — login flow', () => {
 
     const { useAuthStore } = await loadStore(api)
     const store = useAuthStore()
-    await store.login({ email: 't@example.com', password: 'secret' })
+    await store.login({ email: 't@example.com', password: 'secret', recaptcha_token: 'recaptcha-token' })
 
     expect(api.selectClinic).not.toHaveBeenCalled()
     expect(store.memberships).toHaveLength(2)

--- a/src/domains/auth/types/auth.types.ts
+++ b/src/domains/auth/types/auth.types.ts
@@ -4,6 +4,7 @@ export interface LoginCredentials {
   email: string
   password: string
   remember_me?: boolean
+  recaptcha_token: string
 }
 
 export interface SignupCredentials {

--- a/src/domains/auth/views/LoginView.spec.ts
+++ b/src/domains/auth/views/LoginView.spec.ts
@@ -1,9 +1,11 @@
-import { mount } from '@vue/test-utils'
+import { mount, flushPromises } from '@vue/test-utils'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick, ref } from 'vue'
 
 const push = vi.fn()
 const login = vi.fn()
+const loadRecaptcha = vi.fn()
+const executeRecaptcha = vi.fn()
 
 async function mountLoginView() {
   vi.doMock('vue-router', () => ({
@@ -19,6 +21,9 @@ async function mountLoginView() {
   vi.doMock('@/lib/http', () => ({ HttpError: class HttpError extends Error {} }))
   vi.doMock('@/composables/useNeuralNetwork', () => ({ useNeuralNetwork: () => ({ canvasRef: ref(null) }) }))
   vi.doMock('@/composables/useTheme', () => ({ useTheme: () => ({ isDark: false, toggleTheme: vi.fn() }) }))
+  vi.doMock('@/composables/useRecaptcha', () => ({
+    useRecaptcha: () => ({ load: loadRecaptcha, execute: executeRecaptcha }),
+  }))
   vi.doMock('../components/GoogleSignInButton.vue', () => ({ default: { template: '<button type="button">Google</button>' } }))
   vi.doMock('../components/AuthFeedbackAlert.vue', () => ({ default: { template: '<div><slot /></div>' } }))
 
@@ -28,7 +33,7 @@ async function mountLoginView() {
     global: {
       stubs: {
         AppLogo: { template: '<div />' },
-        Button: { template: '<button><slot /></button>' },
+        Button: { template: '<button type="submit"><slot /></button>' },
         Checkbox: { template: '<input type="checkbox" />' },
         RouterLink: {
           props: ['to'],
@@ -74,6 +79,7 @@ async function mountLoginView() {
 beforeEach(() => {
   vi.resetModules()
   vi.clearAllMocks()
+  executeRecaptcha.mockResolvedValue('recaptcha-token')
   vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
     cb(0)
     return 1
@@ -92,5 +98,31 @@ describe('LoginView verification UX', () => {
     expect(link).toBeTruthy()
     expect(link?.attributes('data-to')).toContain('verify-email-notice')
     expect(link?.attributes('data-to')).toContain('doctor@example.test')
+  })
+})
+
+describe('LoginView reCAPTCHA', () => {
+  it('loads recaptcha on mount and forwards the token to authStore.login', async () => {
+    // Bypass vee-validate so the submit handler runs unconditionally — this
+    // test cares about the recaptcha pipeline, not validation behaviour.
+    vi.doMock('vee-validate', () => ({
+      useForm: () => ({
+        handleSubmit: (cb: (v: { email: string; password: string }) => Promise<void>) => () =>
+          cb({ email: 'doctor@example.test', password: 'secret-password' }),
+        setFieldError: vi.fn(),
+      }),
+      useField: () => ({ value: ref(''), errorMessage: ref('') }),
+    }))
+
+    const wrapper = await mountLoginView()
+    await wrapper.find('form').trigger('submit.prevent')
+    await flushPromises()
+
+    expect(loadRecaptcha).toHaveBeenCalledOnce()
+    expect(executeRecaptcha).toHaveBeenCalledWith('login')
+    expect(login).toHaveBeenCalledWith(expect.objectContaining({
+      email: 'doctor@example.test',
+      recaptcha_token: 'recaptcha-token',
+    }))
   })
 })

--- a/src/domains/auth/views/LoginView.vue
+++ b/src/domains/auth/views/LoginView.vue
@@ -32,6 +32,7 @@ import { loginSchema } from '@/lib/validationRules'
 import { RouteNames } from '@/router/routeNames'
 import { useTheme } from '@/composables/useTheme'
 import { useNeuralNetwork } from '@/composables/useNeuralNetwork'
+import { useRecaptcha } from '@/composables/useRecaptcha'
 import GoogleSignInButton from '../components/GoogleSignInButton.vue'
 import AuthFeedbackAlert from '../components/AuthFeedbackAlert.vue'
 import type { GoogleLinkRequiredResponse, ValidationError } from '../types/auth.types'
@@ -40,6 +41,7 @@ const router = useRouter()
 const authStore = useAuthStore()
 const { canvasRef } = useNeuralNetwork()
 const { isDark, toggleTheme } = useTheme()
+const { load: loadRecaptcha, execute: executeRecaptcha } = useRecaptcha()
 const hasGoogleSignIn = Boolean(import.meta.env.VITE_GOOGLE_CLIENT_ID)
 
 const { handleSubmit, setFieldError } = useForm({
@@ -61,6 +63,7 @@ const linkRequestLoading = ref(false)
 const ready = ref(false)
 onMounted(() => {
   void canvasRef.value
+  loadRecaptcha()
   requestAnimationFrame(() => {
     ready.value = true
   })
@@ -72,7 +75,13 @@ const onSubmit = handleSubmit(async (values) => {
   isLoading.value = true
 
   try {
-    await authStore.login({ email: values.email, password: values.password, remember_me: rememberMe.value })
+    const recaptchaToken = await executeRecaptcha('login')
+    await authStore.login({
+      email: values.email,
+      password: values.password,
+      remember_me: rememberMe.value,
+      recaptcha_token: recaptchaToken,
+    })
     router.push({ name: RouteNames.HOME })
   } catch (err) {
     if (err instanceof HttpError) {


### PR DESCRIPTION
## Summary
- Load reCAPTCHA on `LoginView` mount and execute it with action `login` on form submit, attaching the resulting token to the `authStore.login` payload.
- Update `authStore` login specs to expect the new `recaptcha_token` field.
- Extend the existing `authApi` base64-password test to also assert the recaptcha token reaches `/auth/login`.
- Add a `LoginView reCAPTCHA` describe block alongside the existing `LoginView verification UX` block, sharing the same `mountLoginView` helper and mocking `useRecaptcha` + `vee-validate` so the submit pipeline can be exercised without depending on form validation behaviour.

Mirrors the signup-side recaptcha wiring already on staging — login was the missing half.

## Rebase note (resolved)
Branch was 171 commits stale at push time. Rebased onto current staging with conflicts resolved in this commit:
- `LoginView.vue`: kept staging's `useTheme` line + added the recaptcha composable line side-by-side.
- `authApi.spec.ts`: kept staging's full spec; added `recaptcha_token` to the existing login assertion rather than duplicating the file.
- `LoginView.spec.ts`: kept staging's `verification UX` test and helper; added a new `reCAPTCHA` describe block using the shared `mountLoginView`.
- Dropped two no-op edits from the original worktree (`useRecaptcha.ts` dead-var cleanup, `auth.types.ts` field) that already landed via the signup PR.

## Test plan
- [x] Local: `vitest run` for `LoginView.spec.ts` + `authApi.spec.ts` + `authStore.spec.ts` — 35/35 green.
- [ ] CI: TypeScript build + Vitest pass.
- [ ] Login with `VITE_RECAPTCHA_SITE_KEY` set in staging — verify the network request to `/auth/login` includes `recaptcha_token`.
- [ ] Backend rejects logins without a valid token.