### PR TITLE
fix: stop GSI button resize render loop

### DIFF
--- a/src/domains/auth/components/GoogleSignInButton.spec.ts
+++ b/src/domains/auth/components/GoogleSignInButton.spec.ts
@@ -1,17 +1,34 @@
 import { flushPromises } from '@vue/test-utils'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { mountWithDeps } from '@/__tests__/helpers/mountWithDeps'
 
+let resizeCallback: ResizeObserverCallback | undefined
+
 class ResizeObserverMock {
+  constructor(cb: ResizeObserverCallback) {
+    resizeCallback = cb
+  }
   observe = vi.fn()
   disconnect = vi.fn()
 }
 
 async function mountButton(props: Record<string, unknown> = {}) {
   const { default: GoogleSignInButton } = await import('./GoogleSignInButton.vue')
-  const wrapper = mountWithDeps(GoogleSignInButton, { props })
+  const wrapper = mountWithDeps(GoogleSignInButton, { props, attachTo: document.body })
   await flushPromises()
   return wrapper
+}
+
+function setContainerWidth(wrapper: { element: Element }, width: number) {
+  Object.defineProperty(wrapper.element, 'clientWidth', {
+    configurable: true,
+    value: width,
+  })
+}
+
+async function fireResize() {
+  resizeCallback?.([], {} as ResizeObserver)
+  await flushPromises()
 }
 
 describe('GoogleSignInButton', () => {
@@ -23,6 +40,7 @@ describe('GoogleSignInButton', () => {
     vi.resetModules()
     vi.stubEnv('VITE_GOOGLE_CLIENT_ID', 'google-client-id')
     credentialCallback = undefined
+    resizeCallback = undefined
     initializeSpy = vi.fn((options: { callback: (response: GoogleCredentialResponse) => void }) => {
       credentialCallback = options.callback
     })
@@ -37,6 +55,10 @@ describe('GoogleSignInButton', () => {
       },
     }
     vi.stubGlobal('ResizeObserver', ResizeObserverMock)
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
   })
 
   it('initializes Google Identity once while allowing button re-renders', async () => {
@@ -70,5 +92,40 @@ describe('GoogleSignInButton', () => {
     credentialCallback?.({ credential: 'late-jwt-from-google' })
 
     expect(emittedBeforeUnmount).toEqual([['jwt-from-google']])
+  })
+
+  it('does not re-render when ResizeObserver fires with the same container width', async () => {
+    await mountButton()
+
+    expect(renderButtonSpy).toHaveBeenCalledTimes(1)
+
+    // Simulate child-size wobble: GSI iframe replacement nudges the observer
+    // but the container width has not actually changed.
+    await fireResize()
+    await fireResize()
+    await fireResize()
+
+    expect(renderButtonSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-renders when ResizeObserver fires after a real container width change', async () => {
+    const wrapper = await mountButton()
+
+    expect(renderButtonSpy).toHaveBeenCalledTimes(1)
+
+    setContainerWidth(wrapper, 480)
+    await fireResize()
+
+    expect(renderButtonSpy).toHaveBeenCalledTimes(2)
+
+    // A second resize at the new width is again a wobble — no re-render.
+    await fireResize()
+
+    expect(renderButtonSpy).toHaveBeenCalledTimes(2)
+
+    setContainerWidth(wrapper, 360)
+    await fireResize()
+
+    expect(renderButtonSpy).toHaveBeenCalledTimes(3)
   })
 })

--- a/src/domains/auth/components/GoogleSignInButton.vue
+++ b/src/domains/auth/components/GoogleSignInButton.vue
@@ -75,6 +75,11 @@ const handleCredential = (response: GoogleCredentialResponse) => {
 }
 
 let resizeObserver: ResizeObserver | null = null
+let lastRenderedWidth = -1
+
+function currentContainerWidth(): number {
+  return Math.floor(containerRef.value?.clientWidth ?? props.width ?? 320)
+}
 
 async function renderButton(): Promise<void> {
   if (!clientId || !buttonRef.value || props.disabled) {
@@ -95,6 +100,7 @@ async function renderButton(): Promise<void> {
   activeCredentialCallback = handleCredential
   initializeGoogleIdentity(clientId)
 
+  const width = currentContainerWidth()
   buttonRef.value.innerHTML = ''
   window.google.accounts.id.renderButton(buttonRef.value, {
     theme: 'outline',
@@ -102,8 +108,9 @@ async function renderButton(): Promise<void> {
     type: 'standard',
     text: props.text,
     shape: props.shape,
-    width: Math.floor(containerRef.value?.clientWidth ?? props.width ?? 320),
+    width,
   })
+  lastRenderedWidth = width
   ready.value = true
 }
 
@@ -114,6 +121,9 @@ onMounted(() => {
 
   if (containerRef.value) {
     resizeObserver = new ResizeObserver(() => {
+      if (currentContainerWidth() === lastRenderedWidth) {
+        return
+      }
       renderButton().catch(() => {
         ready.value = false
       })


### PR DESCRIPTION
## Summary
- Prevent the Google Sign-In button ResizeObserver from re-rendering when the container width has not actually changed
- Record the last rendered GSI button width so iframe child-size wobble does not retrigger `renderButton()` indefinitely
- Add component coverage for same-width ResizeObserver events, real width changes, and existing singleton initialization behavior

## Test Plan
- [x] `TZ=UTC npm run test -- src/domains/auth/components/GoogleSignInButton.spec.ts`
- [x] `npm run build`
- [x] `git diff --check`

## Dogfood
- Attempted local `/login` browser smoke through the worktree Vite dev server. The local worktree environment did not expose a Google client ID/button, so no meaningful GSI network-loop browser proof was possible there. Regression is covered by focused component tests that simulate the ResizeObserver loop directly.

Closes #162
