### PR TITLE
Fix PWA catalog cache matcher

### DIFF
--- a/src/pwa/workboxRuntimeCaching.spec.ts
+++ b/src/pwa/workboxRuntimeCaching.spec.ts
@@ -19,6 +19,8 @@ describe('PWA runtime caching', () => {
     expect(rules).toHaveLength(1)
     const [catalogRule] = rules
 
+    expect(catalogRule.urlPattern.toString()).not.toContain('isCatalogApiPath')
+
     expect(matches(catalogRule.urlPattern, '/api/icd10/search?q=flu')).toBe(true)
     expect(matches(catalogRule.urlPattern, '/api/system-medicines')).toBe(true)
     expect(matches(catalogRule.urlPattern, '/api/specialties')).toBe(true)

--- a/src/pwa/workboxRuntimeCaching.ts
+++ b/src/pwa/workboxRuntimeCaching.ts
@@ -18,19 +18,20 @@ type RuntimeCacheRule = {
   }
 }
 
-function isCatalogApiPath(pathname: string): boolean {
-  return (
-    pathname.startsWith('/api/icd10') ||
-    pathname.startsWith('/api/system-medicines') ||
-    pathname.startsWith('/api/specialties')
-  )
-}
-
 export const runtimeCaching: RuntimeCacheRule[] = [
   {
     // Read-only public catalogs only. Authenticated clinic/PHI API responses
     // must not be persisted in Workbox Cache Storage.
-    urlPattern: ({ url, request }) => request.method === 'GET' && isCatalogApiPath(url.pathname),
+    urlPattern: ({ url, request }) => {
+      const pathname = url.pathname
+
+      return (
+        request.method === 'GET' &&
+        (pathname.startsWith('/api/icd10') ||
+          pathname.startsWith('/api/system-medicines') ||
+          pathname.startsWith('/api/specialties'))
+      )
+    },
     handler: 'StaleWhileRevalidate',
     options: {
       cacheName: 'mediflow-catalogs',


### PR DESCRIPTION
## Summary

Fixes the generated service worker crash where the Workbox runtime cache matcher referenced `isCatalogApiPath` after Workbox serialized the matcher into `sw.js` without the helper function.

## Changes

- Inlines the safe catalog API path checks inside the `urlPattern` callback so the generated service worker is self-contained.
- Adds a focused regression assertion that the matcher no longer serializes a reference to `isCatalogApiPath`.

## Impact

The PWA service worker can match catalog API requests without throwing `ReferenceError`, while still avoiding runtime caching for authenticated clinic or PHI API endpoints.

## Validation

- `./node_modules/.bin/vitest run src/pwa/workboxRuntimeCaching.spec.ts`
- `./node_modules/.bin/vue-tsc -b`
- `./node_modules/.bin/vite build`
- Inspected generated `dist/sw.js`: zero `isCatalogApiPath` references, catalog cache route still present.