### PR TITLE
Promote staging to production — 2026-05-19 FE cut (sw-catalog-cache-scope)

### DIFF
--- a/src/pwa/workboxRuntimeCaching.spec.ts
+++ b/src/pwa/workboxRuntimeCaching.spec.ts
@@ -19,6 +19,8 @@ describe('PWA runtime caching', () => {
     expect(rules).toHaveLength(1)
     const [catalogRule] = rules
 
+    expect(catalogRule.urlPattern.toString()).not.toContain('isCatalogApiPath')
+
     expect(matches(catalogRule.urlPattern, '/api/icd10/search?q=flu')).toBe(true)
     expect(matches(catalogRule.urlPattern, '/api/system-medicines')).toBe(true)
     expect(matches(catalogRule.urlPattern, '/api/specialties')).toBe(true)

--- a/src/pwa/workboxRuntimeCaching.ts
+++ b/src/pwa/workboxRuntimeCaching.ts
@@ -18,19 +18,20 @@ type RuntimeCacheRule = {
   }
 }
 
-function isCatalogApiPath(pathname: string): boolean {
-  return (
-    pathname.startsWith('/api/icd10') ||
-    pathname.startsWith('/api/system-medicines') ||
-    pathname.startsWith('/api/specialties')
-  )
-}
-
 export const runtimeCaching: RuntimeCacheRule[] = [
   {
     // Read-only public catalogs only. Authenticated clinic/PHI API responses
     // must not be persisted in Workbox Cache Storage.
-    urlPattern: ({ url, request }) => request.method === 'GET' && isCatalogApiPath(url.pathname),
+    urlPattern: ({ url, request }) => {
+      const pathname = url.pathname
+
+      return (
+        request.method === 'GET' &&
+        (pathname.startsWith('/api/icd10') ||
+          pathname.startsWith('/api/system-medicines') ||
+          pathname.startsWith('/api/specialties'))
+      )
+    },
     handler: 'StaleWhileRevalidate',
     options: {
       cacheName: 'mediflow-catalogs',


### PR DESCRIPTION
## Summary
Promote FE staging to main. One non-merge commit included.

## Branches
- Base: \`main\` @ $(git rev-parse origin/main | cut -c1-7)
- Head: \`staging\` @ $(git rev-parse origin/staging | cut -c1-7)

## Included
- d8a535c fix pwa catalog cache matcher (PR #165 / fix/sw-catalog-cache-scope)

## Deployment
Cloudflare Pages auto-deploys to app.mediflow.ph on merge.