### PR TITLE
UI polish: lighter modal scrim + pricing card alignment

### DIFF
--- a/src/domains/subscription/components/PricingCard.vue
+++ b/src/domains/subscription/components/PricingCard.vue
@@ -33,7 +33,6 @@ const meta = computed(() => {
         'Everything in Pro',
         'Up to 6 practising doctors (owner + 5)',
         'Multi-doctor scheduling and queue routing',
-        'Per-doctor activity and revenue reports',
         'Priority email and chat support',
       ],
     }
@@ -64,9 +63,10 @@ const ctaLabel = computed(() => {
 
 <template>
   <Card
-    :class="featured
-      ? 'border-amber-200 dark:border-amber-800/50 shadow-md'
-      : ''"
+    :class="[
+      'h-full flex flex-col',
+      featured ? 'border-amber-200 dark:border-amber-800/50 shadow-md' : '',
+    ]"
   >
     <CardHeader class="text-center pb-2">
       <div
@@ -80,7 +80,7 @@ const ctaLabel = computed(() => {
       <CardTitle class="text-xl">{{ meta.title }}</CardTitle>
       <CardDescription>{{ meta.tagline }}</CardDescription>
     </CardHeader>
-    <CardContent class="space-y-6">
+    <CardContent class="flex-1 flex flex-col gap-6">
       <div class="text-center">
         <span class="text-4xl font-bold">{{ meta.price }}</span>
         <span class="text-muted-foreground">/month</span>
@@ -93,7 +93,7 @@ const ctaLabel = computed(() => {
         </div>
       </div>
 
-      <div class="text-center">
+      <div class="mt-auto text-center">
         <p
           v-if="authStore.isOnTrial && variant === 'pro'"
           class="mb-3 text-sm text-amber-600 dark:text-amber-400 font-medium"

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -345,8 +345,8 @@
 
   .surface-overlay {
     background: var(--surface-overlay);
-    backdrop-filter: blur(24px) saturate(1.1);
-    -webkit-backdrop-filter: blur(24px) saturate(1.1);
+    backdrop-filter: blur(4px);
+    -webkit-backdrop-filter: blur(4px);
   }
 
   .surface-interactive {


### PR DESCRIPTION
## Summary
- Revert `.surface-overlay` backdrop-filter to `blur(4px)` — the previous `blur(24px) saturate(1.1)` washed underlying UI to near-white in modal backgrounds. Matches the deployed staging look.
- Bottom-align Pro and Max CTAs in the pricing grid by stretching `PricingCard` to `h-full` and pushing the button block with `mt-auto`. Pro/Max no longer drift apart when feature counts differ.
- Drop "Per-doctor activity and revenue reports" from the Max feature list — not shipping in that tier yet.

`.surface-floating` (the modal panel itself) keeps its gradient/inset treatment — only the scrim behind the modal changed.

## Test plan
- [ ] `/subscription` as a Free owner: Pro and Max CTA buttons line up at the same Y on `lg:` and stacked layouts.
- [ ] Open Add Patient modal: backdrop is lightly blurred, underlying patient list is still legible.
- [ ] Open any AlertDialog / Sheet: scrim looks consistent.
- [ ] Dark mode: overlay still reads correctly (no near-white wash).