### PR TITLE
fix: patient form validation polish + restore modal backdrop blur

### DIFF
--- a/src/components/DateOfBirthPicker.vue
+++ b/src/components/DateOfBirthPicker.vue
@@ -16,6 +16,12 @@ import { Calendar } from '@/components/ui/calendar'
 
 const model = defineModel<string | undefined>()
 
+const props = withDefaults(defineProps<{
+  invalid?: boolean
+}>(), {
+  invalid: false,
+})
+
 const months = [
   { value: '1', label: 'Jan' },
   { value: '2', label: 'Feb' },
@@ -136,7 +142,7 @@ const minDate = new CalendarDate(1900, 1, 1)
   <div class="dob-picker flex flex-wrap items-center gap-2">
     <div class="flex items-center gap-1.5">
       <Select v-model="selectedMonth">
-        <SelectTrigger class="h-10 w-[84px] rounded-xl px-3" size="sm">
+        <SelectTrigger class="h-10 w-[84px] rounded-xl px-3" size="sm" :aria-invalid="props.invalid">
           <SelectValue placeholder="Mon" />
         </SelectTrigger>
         <SelectContent>
@@ -147,7 +153,7 @@ const minDate = new CalendarDate(1900, 1, 1)
       </Select>
 
       <Select v-model="selectedDay">
-        <SelectTrigger class="h-10 w-[74px] rounded-xl px-3" size="sm">
+        <SelectTrigger class="h-10 w-[74px] rounded-xl px-3" size="sm" :aria-invalid="props.invalid">
           <SelectValue placeholder="Day" />
         </SelectTrigger>
         <SelectContent>
@@ -158,7 +164,7 @@ const minDate = new CalendarDate(1900, 1, 1)
       </Select>
 
       <Select v-model="selectedYear">
-        <SelectTrigger class="h-10 w-[92px] rounded-xl px-3" size="sm">
+        <SelectTrigger class="h-10 w-[92px] rounded-xl px-3" size="sm" :aria-invalid="props.invalid">
           <SelectValue placeholder="Year" />
         </SelectTrigger>
         <SelectContent>

--- a/src/components/NameForm.vue
+++ b/src/components/NameForm.vue
@@ -14,8 +14,12 @@ import type { PatientName } from '@/domains/patient/types/patient.types'
 const props = withDefaults(defineProps<{
   modelValue: PatientName | null
   disabled?: boolean
+  firstNameError?: string
+  lastNameError?: string
 }>(), {
   disabled: false,
+  firstNameError: '',
+  lastNameError: '',
 })
 
 const emit = defineEmits<{
@@ -60,8 +64,10 @@ function emitValue() {
         type="text"
         placeholder="Juan"
         :disabled="disabled"
+        :aria-invalid="!!props.firstNameError"
         @input="emitValue"
       />
+      <p v-if="props.firstNameError" data-field-error="first_name" class="text-xs text-destructive">{{ props.firstNameError }}</p>
     </div>
 
     <div class="flex flex-col gap-2">
@@ -71,8 +77,10 @@ function emitValue() {
         type="text"
         placeholder="Dela Cruz"
         :disabled="disabled"
+        :aria-invalid="!!props.lastNameError"
         @input="emitValue"
       />
+      <p v-if="props.lastNameError" data-field-error="last_name" class="text-xs text-destructive">{{ props.lastNameError }}</p>
     </div>
 
     <div class="flex flex-col gap-2">

--- a/src/domains/auth/components/PhoneVerifyDialog.vue
+++ b/src/domains/auth/components/PhoneVerifyDialog.vue
@@ -9,7 +9,7 @@ import { Label } from '@/components/ui/label'
 import { OtpInput } from '@/components/ui/otp-input'
 import { LoaderCircle, Phone, ShieldCheck, MailWarning } from 'lucide-vue-next'
 import { HttpError } from '@/lib/http'
-import { phoneNumberPH } from '@/lib/validationRules'
+import { phoneNumberPH, formatPHMobile } from '@/lib/validationRules'
 import { useAuthStore } from '../stores/authStore'
 import { phoneVerificationApi, type ConfirmErrorCode } from '../api/phoneVerificationApi'
 import type { ValidationError } from '../types/auth.types'
@@ -50,6 +50,16 @@ const { handleSubmit: handlePhoneSubmit, setFieldError: setPhoneFieldError, rese
 })
 
 const { value: phoneValue, errorMessage: phoneError } = useField<string>('phone')
+
+const phoneModel = computed<string>({
+  get: () => phoneValue.value ?? '',
+  set: (val) => { phoneValue.value = formatPHMobile(String(val ?? '')) },
+})
+
+function onPhonePaste(e: ClipboardEvent): void {
+  e.preventDefault()
+  phoneValue.value = formatPHMobile(e.clipboardData?.getData('text') ?? '')
+}
 
 // Step 2 — code state
 const phoneMasked = ref<string>('')
@@ -293,13 +303,15 @@ const headerDescription = computed<string>(() => {
           </Label>
           <Input
             id="phone-verify-input"
-            v-model="phoneValue"
+            v-model="phoneModel"
             type="tel"
-            inputmode="tel"
+            inputmode="numeric"
             autocomplete="tel"
+            maxlength="11"
             placeholder="09XXXXXXXXX"
             :disabled="requestLoading"
             :aria-invalid="!!phoneError"
+            @paste="onPhonePaste"
           />
           <p v-if="phoneError" class="text-xs text-destructive">{{ phoneError }}</p>
           <p v-else class="text-xs text-muted-foreground">Philippine mobile (09XXXXXXXXX or +639XXXXXXXXX).</p>

--- a/src/domains/auth/components/ProfileForm.vue
+++ b/src/domains/auth/components/ProfileForm.vue
@@ -201,7 +201,7 @@ const onSubmit = handleSubmit(async (values) => {
               Date of birth
               <span class="ml-auto text-xs font-normal text-muted-foreground">Optional</span>
             </Label>
-            <DateOfBirthPicker v-model="dateOfBirth" />
+            <DateOfBirthPicker v-model="dateOfBirth" :invalid="!!dateOfBirthError" />
             <p v-if="dateOfBirthError" class="text-xs text-destructive">{{ dateOfBirthError }}</p>
           </div>
         </div>

--- a/src/domains/patient/components/CreatePatientDialog.vue
+++ b/src/domains/patient/components/CreatePatientDialog.vue
@@ -36,7 +36,7 @@ import AddressForm from '@/components/AddressForm.vue'
 import NameForm from '@/components/NameForm.vue'
 import { patientApi } from '../api/patientApi'
 import { HttpError } from '@/lib/http'
-import { createPatientSchema } from '@/lib/validationRules'
+import { createPatientSchema, formatPHMobile } from '@/lib/validationRules'
 import { useFormDraft } from '@/composables/useFormDraft'
 import { useAuthStore } from '@/domains/auth/stores/authStore'
 import type { ValidationError } from '@/domains/auth/types/auth.types'
@@ -114,23 +114,27 @@ watch(
 
 // Push NameForm + AddressForm output into vee-validate so schema validation
 // runs over them on submit. Composite fields tracked by reference identity,
-// so deep watch is required for address.
-watch(
-  name,
-  (val) => {
-    setFirstName(val?.first_name ?? '')
-    setLastName(val?.last_name ?? '')
-  },
-  { immediate: true },
-)
+// so deep watch is required for address. No `immediate: true` — otherwise
+// vee-validate validates empty strings on mount and shows required errors
+// before the user has typed anything.
+watch(name, (val) => {
+  setFirstName(val?.first_name ?? '')
+  setLastName(val?.last_name ?? '')
+})
 
-watch(
-  address,
-  (val) => {
-    setAddressFieldValue(val)
-  },
-  { immediate: true, deep: true },
-)
+watch(address, (val) => {
+  setAddressFieldValue(val)
+}, { deep: true })
+
+const contactNumberModel = computed<string>({
+  get: () => contactNumber.value ?? '',
+  set: (val) => { contactNumber.value = formatPHMobile(String(val ?? '')) },
+})
+
+function onContactNumberPaste(e: ClipboardEvent): void {
+  e.preventDefault()
+  contactNumber.value = formatPHMobile(e.clipboardData?.getData('text') ?? '')
+}
 
 /**
  * Find the first inline field error inside the form and bring it into view +
@@ -243,9 +247,12 @@ const onSubmit = handleSubmit(
             <User class="size-3.5 text-muted-foreground" />
             Patient Name
           </Label>
-          <NameForm v-model="name" :disabled="isLoading" />
-          <p v-if="firstNameError" data-field-error="first_name" class="mt-1.5 text-xs text-destructive">{{ firstNameError }}</p>
-          <p v-if="lastNameError" data-field-error="last_name" class="mt-1 text-xs text-destructive">{{ lastNameError }}</p>
+          <NameForm
+            v-model="name"
+            :disabled="isLoading"
+            :first-name-error="firstNameError"
+            :last-name-error="lastNameError"
+          />
         </div>
 
         <!-- DOB / Sex -->
@@ -255,7 +262,7 @@ const onSubmit = handleSubmit(
               <CalendarDays class="size-3.5 text-muted-foreground" />
               Date of birth
             </Label>
-            <DateOfBirthPicker v-model="dateOfBirth" />
+            <DateOfBirthPicker v-model="dateOfBirth" :invalid="!!dateOfBirthError" />
             <p v-if="dateOfBirthError" data-field-error="date_of_birth" class="text-xs text-destructive">{{ dateOfBirthError }}</p>
           </div>
 
@@ -305,11 +312,15 @@ const onSubmit = handleSubmit(
             </Label>
             <Input
               id="dlg_contact_number"
-              v-model="contactNumber"
+              v-model="contactNumberModel"
               type="tel"
+              inputmode="numeric"
+              autocomplete="tel"
+              maxlength="11"
               placeholder="09171234567"
               :disabled="isLoading"
               :aria-invalid="!!contactNumberError"
+              @paste="onContactNumberPaste"
             />
             <p v-if="contactNumberError" data-field-error="contact_number" class="text-xs text-destructive">{{ contactNumberError }}</p>
           </div>

--- a/src/domains/patient/components/EditPatientDialog.vue
+++ b/src/domains/patient/components/EditPatientDialog.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { useForm, useField } from 'vee-validate'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -36,7 +36,7 @@ import AddressForm from '@/components/AddressForm.vue'
 import NameForm from '@/components/NameForm.vue'
 import { patientApi } from '../api/patientApi'
 import { HttpError } from '@/lib/http'
-import { editPatientSchema, validateRuleSchema } from '@/lib/validationRules'
+import { editPatientSchema, validateRuleSchema, formatPHMobile } from '@/lib/validationRules'
 import type { PatientResponse, PatientAddress, PatientName } from '../types/patient.types'
 import type { ValidationError } from '@/domains/auth/types/auth.types'
 
@@ -103,6 +103,16 @@ watch(
   },
   { immediate: true },
 )
+
+const contactNumberModel = computed<string>({
+  get: () => contactNumber.value ?? '',
+  set: (val) => { contactNumber.value = formatPHMobile(String(val ?? '')) },
+})
+
+function onContactNumberPaste(e: ClipboardEvent): void {
+  e.preventDefault()
+  contactNumber.value = formatPHMobile(e.clipboardData?.getData('text') ?? '')
+}
 
 const onSubmit = handleSubmit(async (values) => {
   generalError.value = null
@@ -207,7 +217,7 @@ const onSubmit = handleSubmit(async (values) => {
               <CalendarDays class="size-3.5 text-muted-foreground" />
               Date of birth
             </Label>
-            <DateOfBirthPicker v-model="dateOfBirth" />
+            <DateOfBirthPicker v-model="dateOfBirth" :invalid="!!dateOfBirthError" />
             <p v-if="dateOfBirthError" class="text-xs text-destructive">{{ dateOfBirthError }}</p>
           </div>
 
@@ -257,11 +267,15 @@ const onSubmit = handleSubmit(async (values) => {
             </Label>
             <Input
               id="edit_contact_number"
-              v-model="contactNumber"
+              v-model="contactNumberModel"
               type="tel"
+              inputmode="numeric"
+              autocomplete="tel"
+              maxlength="11"
               placeholder="09171234567"
               :disabled="isLoading"
               :aria-invalid="!!contactNumberError"
+              @paste="onContactNumberPaste"
             />
             <p v-if="contactNumberError" class="text-xs text-destructive">{{ contactNumberError }}</p>
           </div>

--- a/src/lib/validationRules.ts
+++ b/src/lib/validationRules.ts
@@ -132,6 +132,19 @@ export function phoneNumberPH(label: string) {
 }
 
 /**
+ * Normalises arbitrary phone input to the canonical PH mobile format `09XXXXXXXXX`.
+ * Strips non-digits, converts `+639`/`639` prefix to `09`, prepends `0` if the user
+ * starts typing with `9`, then caps at 11 digits. Use on @input to prevent invalid
+ * characters and over-length input at the keystroke level.
+ */
+export function formatPHMobile(value: string): string {
+  let digits = (value ?? '').replace(/\D/g, '')
+  if (digits.startsWith('63')) digits = '0' + digits.slice(2)
+  else if (digits.startsWith('9')) digits = '0' + digits
+  return digits.slice(0, 11)
+}
+
+/**
  * Returns a rule that fails when the value is not in the allowed list.
  * @param label   - Human-readable field label used in the error message.
  * @param options - Allowed values.

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -274,7 +274,6 @@
     border-color: var(--surface-border);
     box-shadow: var(--surface-shadow);
     backdrop-filter: var(--surface-blur);
-    -webkit-backdrop-filter: var(--surface-blur);
   }
 
   .surface-card {
@@ -282,7 +281,6 @@
     border-color: var(--surface-border);
     box-shadow: var(--surface-shadow);
     backdrop-filter: var(--surface-blur);
-    -webkit-backdrop-filter: var(--surface-blur);
   }
 
   .surface-card-lite {
@@ -305,7 +303,6 @@
 
   :root[data-surface-mode='full'] .surface-card-lite {
     backdrop-filter: var(--surface-blur);
-    -webkit-backdrop-filter: var(--surface-blur);
   }
 
   .surface-floating {
@@ -315,7 +312,6 @@
     border-color: var(--surface-border-strong);
     box-shadow: var(--surface-shadow-strong), inset 0 1px 0 oklch(1 0 0 / 0.4);
     backdrop-filter: blur(30px) saturate(1.35);
-    -webkit-backdrop-filter: blur(30px) saturate(1.35);
   }
 
   .dark .surface-floating {
@@ -330,7 +326,6 @@
     border-color: var(--surface-border);
     box-shadow: var(--surface-shadow);
     backdrop-filter: var(--surface-blur);
-    -webkit-backdrop-filter: var(--surface-blur);
   }
 
   .surface-solid {
@@ -346,7 +341,6 @@
   .surface-overlay {
     background: var(--surface-overlay);
     backdrop-filter: blur(4px);
-    -webkit-backdrop-filter: blur(4px);
   }
 
   .surface-interactive {


### PR DESCRIPTION
## Summary
- **Patient form (Add / Edit):** errors no longer fire on mount, first/last name errors now render under their own inputs, and every invalid field gets a red border (Input, Select, DOB picker). Phone inputs auto-format to canonical `09XXXXXXXXX` and cap at 11 digits (paste of `+639XXXXXXXXX` is normalised).
- **Modal scrim:** restored unprefixed `backdrop-filter` in the prod CSS bundle. Lightning CSS was deduping the manual `backdrop-filter` / `-webkit-backdrop-filter` pair and keeping only the webkit line, which left modal bodies looking too transparent on staging while dev looked correct. Removing the manual prefix lets the autoprefixer emit both forms.

## Test plan
- [ ] Open Add Patient — no errors visible on mount; submit empty form shows required errors under the right inputs + red borders on First Name, Last Name, DOB selects, and Sex
- [ ] Phone field caps at 11 digits via keyboard; paste `+639171234567` → snaps to `09171234567`; type `9171234567` → becomes `09171234567`
- [ ] Edit Patient: same behaviour for DOB red border and phone formatter
- [ ] PhoneVerifyDialog (Profile → Add/Change phone): formatter + maxlength behave the same
- [ ] Open any modal on staging after deploy — modal body should look the same as local (no see-through panel)