### PR TITLE
fix(appointments): auto-center current date in month rail on mount

### DIFF
--- a/src/domains/appointment/components/AppointmentBoard.vue
+++ b/src/domains/appointment/components/AppointmentBoard.vue
@@ -530,6 +530,7 @@ onMounted(() => {
   currentTimeTimer = setInterval(() => {
     currentTime.value = new Date()
   }, 1000)
+  scrollSelectedMonthDay()
   void fetchBoard()
 })
 


### PR DESCRIPTION
## Summary
When opening the Appointments page, the horizontal month rail landed on its leftmost position, so users had to scroll to find today's strip. The Schedule page centers today on mount; Appointments now does too.

## Why this fix vs the schedule pattern
Schedule centers via `watch(... { immediate: true })`. Doing the same on Appointments would double-fire `fetchBoard()` (already called in `onMounted`). Surgical fix: call `scrollSelectedMonthDay()` once inside the existing `onMounted` block, right before the initial fetch.

## Test plan
- [x] Manual: open `/appointments` — month rail is scrolled so today's strip is horizontally centered in the rail viewport
- [x] DOM verification via Playwright: `selectedCenter === railCenter` after mount
- [ ] No regression on Schedule page (untouched)