### PR TITLE
feat(graphql): load patient detail via GraphQL aggregate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "app",
       "version": "0.0.0",
       "dependencies": {
+        "@apollo/client": "^3.14.1",
         "@fullcalendar/core": "^6.1.20",
         "@fullcalendar/daygrid": "^6.1.20",
         "@fullcalendar/interaction": "^6.1.20",
@@ -26,6 +27,7 @@
         "dexie": "^4.4.2",
         "dompurify": "3.4.2",
         "echarts": "^6.0.0",
+        "graphql": "^16.14.0",
         "lucide-vue-next": "^0.575.0",
         "pinia": "^3.0.4",
         "reka-ui": "^2.9.6",
@@ -86,6 +88,48 @@
       },
       "peerDependencies": {
         "ajv": ">=8"
+      }
+    },
+    "node_modules/@apollo/client": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.14.1.tgz",
+      "integrity": "sha512-SgGX6E23JsZhUdG2anxiyHvEvvN6CUaI4ZfMsndZFeuHPXL3H0IsaiNAhLITSISbeyeYd+CBd9oERXQDdjXWZw==",
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "@wry/caches": "^1.0.0",
+        "@wry/equality": "^0.5.6",
+        "@wry/trie": "^0.5.0",
+        "graphql-tag": "^2.12.6",
+        "hoist-non-react-statics": "^3.3.2",
+        "optimism": "^0.18.0",
+        "prop-types": "^15.7.2",
+        "rehackt": "^0.1.0",
+        "symbol-observable": "^4.0.0",
+        "ts-invariant": "^0.10.3",
+        "tslib": "^2.3.0",
+        "zen-observable-ts": "^1.2.5"
+      },
+      "peerDependencies": {
+        "graphql": "^15.0.0 || ^16.0.0",
+        "graphql-ws": "^5.5.5 || ^6.0.3",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc",
+        "subscriptions-transport-ws": "^0.9.0 || ^0.11.0"
+      },
+      "peerDependenciesMeta": {
+        "graphql-ws": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "subscriptions-transport-ws": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2332,6 +2376,15 @@
       "peerDependencies": {
         "@fullcalendar/core": "~6.1.20",
         "vue": "^3.0.11"
+      }
+    },
+    "node_modules/@graphql-typed-document-node/core": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
+      "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
@@ -4891,6 +4944,54 @@
         "vue": "^3.5.0"
       }
     },
+    "node_modules/@wry/caches": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@wry/caches/-/caches-1.0.1.tgz",
+      "integrity": "sha512-bXuaUNLVVkD20wcGBWRyo7j9N3TxePEWFZj2Y+r9OoUzfqmavM84+mFykRicNsBqatba5JLay1t48wxaXaWnlA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@wry/context": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.7.4.tgz",
+      "integrity": "sha512-jmT7Sb4ZQWI5iyu3lobQxICu2nC/vbUhP0vIdd6tHC9PTfenmRmuIFqktc6GH9cgi+ZHnsLWPvfSvc4DrYmKiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@wry/equality": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.7.tgz",
+      "integrity": "sha512-BRFORjsTuQv5gxcXsuDXx6oGRhuVsEGwZy6LOzRRfgu+eSfxbhUQ9L9YtSEIuIjY/o7g3iWFjrc5eSY1GXP2Dw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@wry/trie": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.5.0.tgz",
+      "integrity": "sha512-FNoYzHawTMk/6KMQoEG5O4PuioX19UbwdQKF44yw0nLfOypfQdjtfZzo/UIJWAJ23sNIFbD1Ug9lbaDGMwbqQA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/abbrev": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
@@ -7105,6 +7206,30 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
     },
+    "node_modules/graphql": {
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.0.tgz",
+      "integrity": "sha512-BBvQ/406p+4CZbTpCbVPSxfzrZrbnuWSP1ELYgyS6B+hNeKzgrdB4JczCa5VZUBQrDa9hUngm0KnexY6pJRN5Q==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
+    "node_modules/graphql-tag": {
+      "version": "2.12.6",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz",
+      "integrity": "sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
     "node_modules/happy-dom": {
       "version": "20.9.0",
       "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.9.0.tgz",
@@ -7214,6 +7339,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
       }
     },
     "node_modules/hookable": {
@@ -8300,6 +8434,18 @@
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
       "license": "Apache-2.0"
     },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/loupe": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
@@ -8547,6 +8693,15 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -8596,6 +8751,18 @@
       "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
       "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
       "license": "MIT"
+    },
+    "node_modules/optimism": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.18.1.tgz",
+      "integrity": "sha512-mLXNwWPa9dgFyDqkNi54sjDyNJ9/fTI6WGBLgnXku1vdKY/jovHfZT5r+aiVeFFLOz+foPNOm5YJ4mqgld2GBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@wry/caches": "^1.0.0",
+        "@wry/context": "^0.7.0",
+        "@wry/trie": "^0.5.0",
+        "tslib": "^2.3.0"
+      }
     },
     "node_modules/own-keys": {
       "version": "1.0.1",
@@ -8885,6 +9052,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
     "node_modules/proto-list": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
@@ -8954,6 +9132,12 @@
       "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
       "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==",
       "license": "ISC"
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/readdirp": {
       "version": "5.0.0",
@@ -9068,6 +9252,24 @@
       },
       "bin": {
         "regjsparser": "bin/parser"
+      }
+    },
+    "node_modules/rehackt": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/rehackt/-/rehackt-0.1.0.tgz",
+      "integrity": "sha512-7kRDOuLHB87D/JESKxQoRwv4DzbIdwkAGQ7p6QKGdVlY1IZheUnVhlk/4UZlNUVxdAXpyxikE3URsG067ybVzw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/reka-ui": {
@@ -9913,6 +10115,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-observable": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-4.0.0.tgz",
+      "integrity": "sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/tailwind-merge": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.5.0.tgz",
@@ -10180,6 +10391,18 @@
       "license": "MIT",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/ts-invariant": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.10.3.tgz",
+      "integrity": "sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/tslib": {
@@ -11551,6 +11774,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/zen-observable": {
+      "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
+      "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==",
+      "license": "MIT"
+    },
+    "node_modules/zen-observable-ts": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.2.5.tgz",
+      "integrity": "sha512-QZWQekv6iB72Naeake9hS1KxHlotfRpe+WGNbNx5/ta+R3DNjVO2bswf63gXlWDcs+EMd7XY8HfVQyP1X6T4Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "zen-observable": "0.8.15"
       }
     },
     "node_modules/zrender": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:e2e:headed": "playwright test --headed"
   },
   "dependencies": {
+    "@apollo/client": "^3.14.1",
     "@fullcalendar/core": "^6.1.20",
     "@fullcalendar/daygrid": "^6.1.20",
     "@fullcalendar/interaction": "^6.1.20",
@@ -34,6 +35,7 @@
     "dexie": "^4.4.2",
     "dompurify": "3.4.2",
     "echarts": "^6.0.0",
+    "graphql": "^16.14.0",
     "lucide-vue-next": "^0.575.0",
     "pinia": "^3.0.4",
     "reka-ui": "^2.9.6",

--- a/src/domains/dental/components/DentalPatientSections.vue
+++ b/src/domains/dental/components/DentalPatientSections.vue
@@ -21,7 +21,8 @@ const pdStore = usePatientDetailStore()
 const router = useRouter()
 
 onMounted(() => {
-  if (!pdStore.dentalProfile && !pdStore.isLoadingDental) {
+  // Fall back to the REST dental load only if the aggregate didn't already load it.
+  if (!pdStore.dentalLoaded && !pdStore.isLoadingDental) {
     pdStore.loadDental()
   }
 })

--- a/src/domains/obgyn/components/ObGynPatientSections.vue
+++ b/src/domains/obgyn/components/ObGynPatientSections.vue
@@ -416,7 +416,8 @@ const { clinicalSummary: gynNarrativeSummary } = useClinicalSummary(gynProfile, 
 // ── Load ──────────────────────────────────────────────────────────────────
 onMounted(async () => {
   if (!patientId.value) return
-  if (!pdStore.gynProfile) await pdStore.loadObgyn()
+  // Fall back to the REST OB-GYN load only if the aggregate didn't already load it.
+  if (!pdStore.obgynLoaded && !pdStore.isLoadingObgyn) await pdStore.loadObgyn()
 })
 </script>
 

--- a/src/domains/patient/components/specialties/family-medicine/FMPatientSections.vue
+++ b/src/domains/patient/components/specialties/family-medicine/FMPatientSections.vue
@@ -624,7 +624,9 @@ const showPreventiveModal = ref<boolean>(false)
 // ── Load ──────────────────────────────────────────────────────────────────
 onMounted(async () => {
   if (!pdStore.patientId) return
-  if (!pdStore.lifestyle && !pdStore.isLoadingFM) {
+  // Only fall back to the REST FM fan-out if FM data wasn't already loaded
+  // (the GraphQL aggregate sets fmLoaded even when individual records are null).
+  if (!pdStore.fmLoaded && !pdStore.isLoadingFM) {
     await pdStore.loadFM()
   }
 })

--- a/src/domains/patient/components/specialties/pediatrics/GrowthChartDialog.vue
+++ b/src/domains/patient/components/specialties/pediatrics/GrowthChartDialog.vue
@@ -36,7 +36,7 @@ watch(
     // Lazy-load peds data on first open — skip if the patient-detail page
     // already hydrated it, otherwise the button on a fresh Assessment tab
     // would show an empty chart.
-    if (pdStore.growthHistory.length === 0 && !pdStore.isLoadingPeds) {
+    if (!pdStore.pedsLoaded && !pdStore.isLoadingPeds) {
       pdStore.loadPediatrics()
     }
   },

--- a/src/domains/patient/components/specialties/pediatrics/PediatricsPatientSections.vue
+++ b/src/domains/patient/components/specialties/pediatrics/PediatricsPatientSections.vue
@@ -517,7 +517,8 @@ async function deleteMilestoneAssessment(assessmentUuid: string) {
 // ─────────────────────────────────────────────────────────────────────────────
 
 onMounted(async () => {
-  if (!pdStore.birthHistory && !pdStore.isLoadingPeds) {
+  // Fall back to the REST peds fan-out only if the aggregate didn't already load it.
+  if (!pdStore.pedsLoaded && !pdStore.isLoadingPeds) {
     await pdStore.loadPediatrics()
   }
 })

--- a/src/domains/patient/graphql/patientDetail.ts
+++ b/src/domains/patient/graphql/patientDetail.ts
@@ -1,0 +1,151 @@
+import { gql } from '@apollo/client/core'
+import type { DocumentNode } from '@apollo/client/core'
+import { apollo } from '@/lib/apollo'
+import type {
+  FamilyHistoryEntry,
+  Medication,
+  PreventiveCareItem,
+  StructuredAllergy,
+} from '@/domains/patient/api/patientApi'
+import type {
+  BirthHistoryResponse,
+  GrowthMeasurement,
+  ImmunizationTieredResponse,
+  MilestoneScheduleResponse,
+} from '@/domains/patient/api/pediatricsApi'
+import type { PatientAddress, Problem } from '@/domains/patient/types/patient.types'
+import type { LifestyleData } from '@/domains/consultation/types/consultation.types'
+import type { GynProfile, Pregnancy } from '@/domains/obgyn/types/obgyn.types'
+import type { DentalProfile, DentalTreatmentPlan, DentalVisitDetail } from '@/domains/dental/types/dental.types'
+
+/**
+ * Single read-aggregation query: replaces the patient core + FM-section REST
+ * fan-out with one round-trip. Specialty sections (e.g. pediatrics) are appended
+ * only for that specialty, so their computed resolvers never run otherwise.
+ * Writes stay on REST.
+ */
+const PATIENT_FIELDS = `
+  uuid first_name middle_name last_name suffix full_name formal_name
+  date_of_birth sex blood_type contact_number email note status avatar_url formatted_address
+  created_at updated_at
+  address {
+    region_code region_name province_code province_name
+    city_code city_name barangay_code barangay_name street
+  }
+  medicalRecord {
+    problem_list { uuid description icd_code status onset_date created_at updated_at }
+    medication_list { uuid drug_name dose frequency route indication started_date status discontinue_reason notes updated_at }
+    structured_allergies { uuid allergen type severity reaction identified_date notes }
+    family_history {
+      uuid relative alive current_age age_at_death cause_of_death notes
+      conditions { name icd_code age_of_onset }
+    }
+    lifestyle { smoking pack_years alcohol exercise diet medication_adherence }
+    preventive_care { key name category interval_years status last_done_date next_due_date result notes recorded_uuid }
+    social_history
+  }
+`
+
+const PEDIATRICS_FIELDS = `
+  pediatrics { birth_history immunizations growth_history developmental_milestones }
+`
+
+const OBGYN_FIELDS = `
+  obgyn { gyn_profile pregnancies }
+`
+
+const DENTAL_FIELDS = `
+  dental { profile treatment_plans visits }
+`
+
+/** Specialty keys whose sections are fetched within the same aggregate query. */
+export type AggregateSpecialty = 'pediatrics' | 'obgyn' | 'dental'
+
+const queryCache = new Map<string, DocumentNode>()
+
+function buildQuery(specialty: AggregateSpecialty | null): DocumentNode {
+  const cacheKey = specialty ?? 'base'
+  const cached = queryCache.get(cacheKey)
+  if (cached) return cached
+
+  const extra = specialty === 'pediatrics'
+    ? PEDIATRICS_FIELDS
+    : specialty === 'obgyn'
+      ? OBGYN_FIELDS
+      : specialty === 'dental'
+        ? DENTAL_FIELDS
+        : ''
+  const doc = gql(`query PatientDetail($uuid: ID!) { patient(uuid: $uuid) { ${PATIENT_FIELDS}${extra} } }`)
+  queryCache.set(cacheKey, doc)
+  return doc
+}
+
+export interface PatientDetailMedicalRecord {
+  problem_list: Problem[]
+  medication_list: Medication[]
+  structured_allergies: StructuredAllergy[]
+  family_history: FamilyHistoryEntry[]
+  lifestyle: LifestyleData | null
+  preventive_care: PreventiveCareItem[]
+  social_history: Record<string, unknown> | null
+}
+
+/** Pediatric sections — pass-through computed structures (match the REST shapes). */
+export interface PatientDetailPediatrics {
+  birth_history: BirthHistoryResponse['data'] | null
+  immunizations: ImmunizationTieredResponse | null
+  growth_history: GrowthMeasurement[]
+  developmental_milestones: MilestoneScheduleResponse | null
+}
+
+/** OB-GYN sections — Resource-shaped pass-through (match the REST shapes). */
+export interface PatientDetailObgyn {
+  gyn_profile: GynProfile | null
+  pregnancies: Pregnancy[]
+}
+
+/** Dental sections — Resource-shaped pass-through (match the REST shapes). */
+export interface PatientDetailDental {
+  profile: DentalProfile | null
+  treatment_plans: DentalTreatmentPlan[]
+  visits: DentalVisitDetail[]
+}
+
+/** GraphQL projection of a patient — a subset of the REST PatientResponse plus sections. */
+export interface PatientDetailGraphQL {
+  uuid: string
+  first_name: string
+  middle_name: string | null
+  last_name: string
+  suffix: string | null
+  full_name: string
+  formal_name: string
+  date_of_birth: string | null
+  sex: string
+  blood_type: string | null
+  contact_number: string | null
+  email: string | null
+  note: string | null
+  status: string
+  avatar_url: string | null
+  formatted_address: string
+  created_at: string
+  updated_at: string
+  address: PatientAddress | null
+  medicalRecord: PatientDetailMedicalRecord | null
+  pediatrics?: PatientDetailPediatrics | null
+  obgyn?: PatientDetailObgyn | null
+  dental?: PatientDetailDental | null
+}
+
+export async function fetchPatientDetail(
+  uuid: string,
+  specialty: AggregateSpecialty | null = null,
+): Promise<PatientDetailGraphQL | null> {
+  const { data } = await apollo.query<{ patient: PatientDetailGraphQL | null }>({
+    query: buildQuery(specialty),
+    variables: { uuid },
+  })
+  // errorPolicy 'all' can resolve with undefined data on a GraphQL-level error.
+  return data?.patient ?? null
+}

--- a/src/domains/patient/views/PatientDetailView.vue
+++ b/src/domains/patient/views/PatientDetailView.vue
@@ -193,14 +193,16 @@ async function fetchPatient() {
 
   try {
     const id = route.params.id as string
-    await pdStore.loadPatient(id)
+    const key = specialtyStore.config?.key
+    // Patient core + FM medical record (+ pediatrics when applicable) in one
+    // GraphQL query. Encounters stay on their own REST call.
     await Promise.all([
+      pdStore.loadAggregate(id, key),
       encounterStore.loadForPatient(id),
-      pdStore.loadCore(),
     ])
-    // Load specialty-specific data
-    if (specialtyStore.config?.key) {
-      pdStore.loadSpecialty(specialtyStore.config.key)
+    // These specialties are already covered by the aggregate; only load the rest.
+    if (key && !['family_medicine', 'internal_medicine', 'pediatrics', 'obgyn', 'dental'].includes(key)) {
+      pdStore.loadSpecialty(key)
     }
   } catch {
     error.value = 'Failed to load patient details. Please try again.'

--- a/src/lib/apollo.ts
+++ b/src/lib/apollo.ts
@@ -1,0 +1,58 @@
+import { ApolloClient, InMemoryCache, createHttpLink, from, fromPromise } from '@apollo/client/core'
+import { setContext } from '@apollo/client/link/context'
+import { onError } from '@apollo/client/link/error'
+import { getAuthToken, refreshAccessToken, SESSION_ID } from '@/lib/http'
+
+const BASE_URL = import.meta.env.VITE_API_URL as string
+
+// GraphQL lives under the same /api umbrella as REST (shared proxy/CORS/auth).
+const httpLink = createHttpLink({
+  uri: `${BASE_URL}/graphql`,
+  credentials: 'include',
+})
+
+// Mirror the REST auth: the in-memory access token (kept fresh by the REST
+// 401-refresh flow in http.ts) + the per-tab session id.
+const authLink = setContext((_, { headers }) => {
+  const token = getAuthToken()
+  return {
+    headers: {
+      ...headers,
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      'X-Session-Id': SESSION_ID,
+    },
+  }
+})
+
+// Share REST's 401 recovery: on an expired token, refresh once (single-flight,
+// dedup'd with the REST flow) and retry. If refresh fails (e.g. logged-out-all),
+// the error propagates and the REST layer drives the user to /login.
+const errorLink = onError(({ networkError, operation, forward }) => {
+  const status = (networkError as { statusCode?: number } | null)?.statusCode
+  if (status !== 401 || operation.getContext().authRetried) {
+    return
+  }
+
+  operation.setContext({ authRetried: true })
+
+  return fromPromise(
+    refreshAccessToken().then((refreshed) => {
+      if (!refreshed) {
+        throw networkError ?? new Error('Unauthorized')
+      }
+    }),
+  ).flatMap(() => forward(operation))
+})
+
+/**
+ * Read-only GraphQL client. Writes stay on REST, so we deliberately bypass the
+ * normalized cache (network-only) — the win here is request aggregation, and
+ * network-only avoids stale reads after a REST mutation without manual eviction.
+ */
+export const apollo = new ApolloClient({
+  link: from([errorLink, authLink, httpLink]),
+  cache: new InMemoryCache(),
+  defaultOptions: {
+    query: { fetchPolicy: 'network-only', errorPolicy: 'all' },
+  },
+})

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -75,6 +75,15 @@ async function handleUnauthorized(): Promise<boolean> {
   return refreshPromise
 }
 
+/**
+ * Single-flight access-token refresh, shared with the Apollo error link so
+ * GraphQL recovers from an expired token exactly like REST does. Returns true
+ * if a fresh token is now available.
+ */
+export function refreshAccessToken(): Promise<boolean> {
+  return handleUnauthorized()
+}
+
 // Multi-tab sync
 const authChannel = new BroadcastChannel('auth_token_sync')
 authChannel.addEventListener('message', (event) => {

--- a/src/stores/patientDetailStore.ts
+++ b/src/stores/patientDetailStore.ts
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
 import { toast } from 'vue-sonner'
 import { patientApi } from '@/domains/patient/api/patientApi'
+import { fetchPatientDetail } from '@/domains/patient/graphql/patientDetail'
 import type {
   PatientResponse,
   Problem,
@@ -85,6 +86,16 @@ export const usePatientDetailStore = defineStore('patientDetail', () => {
   const isLoading = ref(false)
   const isLoadingCore = ref(false)
   const isLoadingFM = ref(false)
+  // True once the FM sections are loaded (via the GraphQL aggregate OR loadFM),
+  // independent of whether any individual record (e.g. lifestyle) exists — so
+  // child sections don't re-trigger the REST fan-out for a null-record patient.
+  const fmLoaded = ref(false)
+  // Same idea for the pediatric sections (loaded via the aggregate OR loadPediatrics).
+  const pedsLoaded = ref(false)
+  // ...and the OB-GYN sections (loaded via the aggregate OR loadObgyn).
+  const obgynLoaded = ref(false)
+  // ...and the Dental sections (loaded via the aggregate OR loadDental).
+  const dentalLoaded = ref(false)
   const isLoadingPeds = ref(false)
   const isLoadingObgyn = ref(false)
   const isSavingObgyn = ref(false)
@@ -150,6 +161,109 @@ export const usePatientDetailStore = defineStore('patientDetail', () => {
       throw new Error('Failed to load patient')
     } finally {
       isLoading.value = false
+    }
+  }
+
+  /**
+   * Single GraphQL query for patient core + FM medical-record sections,
+   * replacing the loadPatient + loadCore + loadFM REST fan-out. pastDiagnoses
+   * and chronicTrends are computed/separate and stay on REST.
+   */
+  async function loadAggregate(id: string, specialtyKey?: string): Promise<void> {
+    const aggregateSpecialty = specialtyKey === 'pediatrics' || specialtyKey === 'obgyn' || specialtyKey === 'dental'
+      ? specialtyKey
+      : null
+    isLoading.value = true
+    isLoadingCore.value = true
+    isLoadingFM.value = true
+    fmLoaded.value = false
+    if (aggregateSpecialty === 'pediatrics') {
+      isLoadingPeds.value = true
+      pedsLoaded.value = false
+    }
+    if (aggregateSpecialty === 'obgyn') {
+      isLoadingObgyn.value = true
+      obgynLoaded.value = false
+    }
+    if (aggregateSpecialty === 'dental') {
+      isLoadingDental.value = true
+      dentalLoaded.value = false
+    }
+    patientId.value = id
+    try {
+      const [detail, diagnosesRes, trendsRes] = await Promise.all([
+        fetchPatientDetail(id, aggregateSpecialty),
+        patientApi.getPastDiagnoses(id).catch(() => ({ data: [] })),
+        patientApi.getChronicTrends(id).catch(() => ({ data: null })),
+      ])
+
+      if (!detail) {
+        patient.value = null
+        throw new Error('Failed to load patient')
+      }
+
+      patient.value = {
+        id: detail.uuid,
+        first_name: detail.first_name,
+        middle_name: detail.middle_name,
+        last_name: detail.last_name,
+        suffix: detail.suffix,
+        formal_name: detail.formal_name,
+        full_name: detail.full_name,
+        address: detail.address,
+        formatted_address: detail.formatted_address,
+        date_of_birth: detail.date_of_birth ?? '',
+        sex: detail.sex,
+        blood_type: detail.blood_type,
+        contact_number: detail.contact_number,
+        email: detail.email,
+        note: detail.note,
+        avatar_url: detail.avatar_url,
+        status: (detail.status ?? 'new') as PatientResponse['status'], // mirror PatientResource default
+        created_at: detail.created_at,
+        updated_at: detail.updated_at,
+      }
+
+      const mr = detail.medicalRecord
+      problems.value = mr?.problem_list ?? []
+      allergies.value = mr?.structured_allergies ?? []
+      medications.value = mr?.medication_list ?? []
+      familyHistory.value = mr?.family_history ?? []
+      lifestyle.value = mr?.lifestyle ?? null
+      preventiveCare.value = mr?.preventive_care ?? []
+      fmLoaded.value = true
+
+      if (aggregateSpecialty === 'pediatrics') {
+        const peds = detail.pediatrics
+        birthHistory.value = peds?.birth_history ?? null
+        immunizations.value = peds?.immunizations ?? null
+        growthHistory.value = peds?.growth_history ?? []
+        milestones.value = peds?.developmental_milestones ?? null
+        pedsLoaded.value = true
+      }
+
+      if (aggregateSpecialty === 'obgyn') {
+        gynProfile.value = detail.obgyn?.gyn_profile ?? null
+        pregnancies.value = detail.obgyn?.pregnancies ?? []
+        obgynLoaded.value = true
+      }
+
+      if (aggregateSpecialty === 'dental') {
+        dentalProfile.value = detail.dental?.profile ?? null
+        dentalTreatmentPlans.value = detail.dental?.treatment_plans ?? []
+        dentalVisits.value = detail.dental?.visits ?? []
+        dentalLoaded.value = true
+      }
+
+      pastDiagnoses.value = diagnosesRes.data
+      chronicTrends.value = trendsRes.data as ChronicTrendsData | null
+    } finally {
+      isLoading.value = false
+      isLoadingCore.value = false
+      isLoadingFM.value = false
+      if (aggregateSpecialty === 'pediatrics') isLoadingPeds.value = false
+      if (aggregateSpecialty === 'obgyn') isLoadingObgyn.value = false
+      if (aggregateSpecialty === 'dental') isLoadingDental.value = false
     }
   }
 
@@ -271,6 +385,7 @@ export const usePatientDetailStore = defineStore('patientDetail', () => {
       medications.value = medsRes.data as Medication[]
       preventiveCare.value = preventiveRes.data as PreventiveCareItem[]
       chronicTrends.value = trendsRes.data as ChronicTrendsData | null
+      fmLoaded.value = true
     } finally {
       isLoadingFM.value = false
     }
@@ -379,6 +494,7 @@ export const usePatientDetailStore = defineStore('patientDetail', () => {
       dentalProfile.value = profileRes.data
       dentalTreatmentPlans.value = plansRes.data
       dentalVisits.value = visitsRes.data
+      dentalLoaded.value = true
     } finally {
       isLoadingDental.value = false
     }
@@ -458,6 +574,7 @@ export const usePatientDetailStore = defineStore('patientDetail', () => {
       ])
       gynProfile.value = gynRes.data as GynProfile | null
       pregnancies.value = pregRes.data as Pregnancy[]
+      obgynLoaded.value = true
     } finally {
       isLoadingObgyn.value = false
     }
@@ -588,6 +705,7 @@ export const usePatientDetailStore = defineStore('patientDetail', () => {
       immunizations.value = immuneRes.data as ImmunizationTieredResponse | null
       growthHistory.value = (growthRes.data ?? []) as GrowthMeasurement[]
       milestones.value = milestoneRes.data as MilestoneScheduleResponse | null
+      pedsLoaded.value = true
     } finally {
       isLoadingPeds.value = false
     }
@@ -666,6 +784,10 @@ export const usePatientDetailStore = defineStore('patientDetail', () => {
     isLoading.value = false
     isLoadingCore.value = false
     isLoadingFM.value = false
+    fmLoaded.value = false
+    pedsLoaded.value = false
+    obgynLoaded.value = false
+    dentalLoaded.value = false
     isLoadingPeds.value = false
     isLoadingObgyn.value = false
     isSavingObgyn.value = false
@@ -690,6 +812,7 @@ export const usePatientDetailStore = defineStore('patientDetail', () => {
 
     // Actions — core
     loadPatient,
+    loadAggregate,
     loadCore,
     loadSpecialty,
     uploadAvatar,
@@ -713,6 +836,10 @@ export const usePatientDetailStore = defineStore('patientDetail', () => {
     preventiveCare,
     chronicTrends,
     isLoadingFM,
+    fmLoaded,
+    pedsLoaded,
+    obgynLoaded,
+    dentalLoaded,
 
     // State — OB-GYN
     gynProfile,


### PR DESCRIPTION
## Summary

Loads the patient-detail view through a single **read-only** GraphQL aggregate query (Apollo Client) instead of several REST round-trips. One request returns the core profile plus, per patient type, the FM medical record and the **pediatrics / OB-GYN / dental** specialty slices.

Pairs with the backend API in clinic-be (`feat/graphql-patient-read`). REST writes/upserts are unchanged.

## What's in it

- **`src/lib/apollo.ts`** — Apollo client pointed at `${VITE_API_URL}/graphql`; attaches `Bearer` + `X-Session-Id`; on a 401 it reuses http.ts's **single-flight** refresh, then replays the operation; `network-only` (no stale cache for clinical data).
- **`src/domains/patient/graphql/patientDetail.ts`** — specialty-aware query builder that appends the requested specialty fragment (pediatrics/obgyn/dental) per patient type, with a per-key DocumentNode cache.
- **`patientDetailStore.loadAggregate()`** — maps the aggregate response into the store; the **store remains the sole API interface** (components never call the API directly). Per-section `*Loaded` flags drive rendering instead of raw-data presence.
- **`PatientDetailView`** — routes the known specialties through the aggregate and skips the legacy per-section REST fetches.

## Testing

- `npm run build` green (vue-tsc type-check + production bundle).
- Live-verified against the worktree instance sharing the dev database.

> The dev-only `vite.config.ts` allowed-host entry and the local compose file are intentionally **not** part of this PR.